### PR TITLE
fix(kernel): observation channel integrity + convergence false stalls (#57, #58)

### DIFF
--- a/jarviscore/kernel/cognition.py
+++ b/jarviscore/kernel/cognition.py
@@ -50,6 +50,8 @@ THINKING_TOOLS = frozenset({
     "inspect_error",
     "scan_peers",
     "read_mailbox",
+    # Re-reading a retained tool result is recall, not action (issue #57).
+    "read_turn_result",
 })
 
 ACTION_TOOLS = frozenset({
@@ -111,6 +113,7 @@ class ConvergenceGovernor:
         # Mutable governor state
         self._same_tool_streak: int = 0
         self._last_tool: Optional[str] = None
+        self._last_tool_key: Optional[str] = None
         self._equiv_streak: int = 0
         self._last_outcome_sig: Optional[str] = None
         self._stagnant_turns: int = 0
@@ -145,32 +148,55 @@ class ConvergenceGovernor:
         return score
 
     @staticmethod
+    def _is_error_output(tool_output: Any) -> bool:
+        """True when the output is an explicit error/empty result."""
+        if tool_output is None:
+            return True
+        if isinstance(tool_output, str):
+            return not tool_output.strip()
+        if isinstance(tool_output, dict):
+            status = str(tool_output.get("status", "")).lower()
+            return status in {"error", "failed", "blocked"} or bool(tool_output.get("error"))
+        return False
+
+    @staticmethod
     def _outcome_signature(tool_name: str, tool_output: Any) -> str:
         """
         Canonical signature of a (tool, result) pair for detecting
-        semantically equivalent repeated outcomes.
+        genuinely identical repeated outcomes.
+
+        Hashes the FULL canonicalized output — "equivalent" must mean
+        identical. Earlier drafts compared content length / a 120-char
+        prefix, which flagged different results of the same size as
+        "equivalent" and stalled healthy agents (e.g. paginated reads
+        returning uniform page sizes). See issue #58.
         """
-        if not isinstance(tool_output, dict):
-            return f"{tool_name}:{str(tool_output)[:120]}"
-        stable: Dict[str, Any] = {"tool": tool_name}
-        for key in ("status", "success", "error"):
-            if key in tool_output:
-                stable[key] = tool_output[key]
-        results = tool_output.get("results")
-        if isinstance(results, list):
-            stable["results_count"] = len(results)
-        content = tool_output.get("content") or tool_output.get("output")
-        if isinstance(content, str):
-            stable["content_len"] = len(content)
-        return json.dumps(stable, sort_keys=True, default=str)[:300]
+        try:
+            canonical = json.dumps(
+                tool_output, sort_keys=True, default=str, separators=(",", ":")
+            )
+        except (TypeError, ValueError):
+            canonical = repr(tool_output)
+        digest = hashlib.sha256(canonical.encode("utf-8", "replace")).hexdigest()
+        return f"{tool_name}:{digest}"
 
     def evaluate(
         self,
         tool_name: str,
         tool_output: Any,
+        params: Optional[Dict[str, Any]] = None,
     ) -> Optional[Dict[str, Any]]:
         """
         Evaluate one tool call and return a stall verdict dict if stall is detected.
+
+        Args:
+            tool_name: Name of the tool invoked.
+            tool_output: The tool's result.
+            params: Optional tool parameters. When provided, the same-tool
+                streak becomes param-aware — calling one tool repeatedly with
+                DIFFERENT params (reading ten files, ten distinct searches) is
+                legitimate iteration, not spinning. When omitted, behavior is
+                the historical name-only streak.
 
         Returns:
             None if no stall.
@@ -178,16 +204,22 @@ class ConvergenceGovernor:
         """
         self._turn += 1
 
-        # 1. Same-tool streak
-        if self._last_tool == tool_name:
+        # 1. Same-tool streak (param-aware when params are supplied)
+        if params is None:
+            streak_key = tool_name
+        else:
+            streak_key = f"{tool_name}:{FailureLedger.fingerprint(tool_name, params)[:16]}"
+        if self._last_tool_key == streak_key:
             self._same_tool_streak += 1
         else:
             self._same_tool_streak = 1
         self._last_tool = tool_name
+        self._last_tool_key = streak_key
 
-        # 2. Equivalent-outcome streak
+        # 2. Equivalent-outcome streak (identical means identical — full-content hash)
         sig = self._outcome_signature(tool_name, tool_output)
-        if self._last_outcome_sig == sig:
+        novel = self._last_outcome_sig != sig
+        if not novel:
             self._equiv_streak += 1
         else:
             self._equiv_streak = 1
@@ -195,6 +227,11 @@ class ConvergenceGovernor:
 
         # 3. Stagnant turns
         score = self._progress_score(tool_output)
+        if score < self.min_progress_score and novel and not self._is_error_output(tool_output):
+            # Unknown result schema, but the output CHANGED and is not an
+            # error — novelty is progress for shapes _progress_score does not
+            # recognize (domain dicts without status/content/results keys).
+            score = self.min_progress_score
         if score >= self.min_progress_score:
             self._stagnant_turns = 0
         else:
@@ -232,6 +269,20 @@ class ConvergenceGovernor:
         without re-running evaluate() and double-counting streaks.
         """
         return self._last_verdict
+
+    def reset_streaks(self, reason: str = "") -> None:
+        """Clear all stall streaks and the cached verdict.
+
+        The supported way for pivot/recovery paths to grant the agent a
+        fresh convergence window — callers must not poke the private
+        counters directly.
+        """
+        self._same_tool_streak = 0
+        self._equiv_streak = 0
+        self._stagnant_turns = 0
+        self._last_verdict = None
+        if reason:
+            logger.info("[ConvergenceGovernor] Streaks reset: %s", reason)
 
     def get_intervention(self) -> Optional[str]:
         """Return a coaching message if the agent's trajectory suggests it
@@ -507,6 +558,7 @@ class AgentCognitionManager:
         tool_name: str,
         tokens: int = 0,
         tool_output: Any = None,
+        params: Optional[Dict[str, Any]] = None,
     ) -> None:
         """
         Record a tool invocation and charge tokens to the appropriate budget.
@@ -515,6 +567,9 @@ class AgentCognitionManager:
             tool_name: Name of the tool invoked
             tokens: Tokens consumed by this invocation
             tool_output: Result from the tool (used by ConvergenceGovernor)
+            params: Tool parameters — forwarded to the ConvergenceGovernor so
+                the same-tool streak can distinguish iteration (same tool,
+                different params) from spinning (same tool, same params).
         """
         phase = self.classify_tool(tool_name)
         if tokens > 0:
@@ -536,7 +591,7 @@ class AgentCognitionManager:
 
         # Feed the Convergence Governor
         if tool_name != "done":
-            self.convergence.evaluate(tool_name, tool_output)
+            self.convergence.evaluate(tool_name, tool_output, params=params)
 
         # Update phase
         self._update_phase(tool_name)

--- a/jarviscore/kernel/subagent.py
+++ b/jarviscore/kernel/subagent.py
@@ -89,6 +89,32 @@ _DONE_PATTERN = re.compile(r"^DONE:\s*(.*)$", re.MULTILINE)
 _RESULT_PATTERN = re.compile(r"^RESULT:\s*(.+)$", re.MULTILINE | re.DOTALL)
 _THOUGHT_PATTERN = re.compile(r"^THOUGHT:\s*(.+?)(?=\n(?:TOOL|DONE|RESULT|THOUGHT):|\Z)", re.MULTILINE | re.DOTALL)
 
+# ── Observation channel integrity (issue #57) ─────────────────────────────
+# How much of a tool result the agent sees inline per turn. Anything beyond
+# the cap is clipped WITH an explicit marker and remains retrievable via the
+# built-in read_turn_result tool for the lifetime of the dispatch.
+_OBSERVATION_LIMIT = int(os.getenv("SUBAGENT_OBSERVATION_LIMIT", "800"))
+# Full-result retention per turn (chars) and how many turns are kept.
+_TURN_RESULT_RETENTION = int(os.getenv("SUBAGENT_TURN_RESULT_RETENTION", "16000"))
+_TURN_RESULT_WINDOW = int(os.getenv("SUBAGENT_TURN_RESULT_WINDOW", "10"))
+
+
+def _clip_observation(text: str, turn: int, limit: int = 0) -> str:
+    """Clip a tool result for the observation channel — honestly.
+
+    A model that KNOWS data is missing asks for the rest; a model that
+    doesn't confabulates. Every clip therefore carries an explicit marker
+    with the exact retrieval call for the remainder.
+    """
+    limit = limit or _OBSERVATION_LIMIT
+    if len(text) <= limit:
+        return text
+    return (
+        f"{text[:limit]}\n"
+        f"…[showing {limit} of {len(text)} chars — call TOOL: read_turn_result "
+        f'PARAMS: {{"turn": {turn}, "offset": {limit}}} for the rest]'
+    )
+
 def _extract_json_object(text: str) -> Optional[Dict[str, Any]]:
     """Extract the first complete JSON object from *text* using brace-counting.
 
@@ -252,6 +278,10 @@ class BaseSubAgent(ABC):
         # Cognition infrastructure — reset per run() call
         self._cognition: Optional[AgentCognitionManager] = None
 
+        # Live KernelState for the current dispatch — set at the top of run()
+        # so built-in tools (read_turn_result) can reach the retention ring.
+        self._current_state: Optional[KernelState] = None
+
         # Let subclass register its tools explicitly
         self.setup_tools()
 
@@ -263,6 +293,42 @@ class BaseSubAgent(ABC):
     ) -> None:
         """Register a tool available to this subagent."""
         self._tools[name] = ToolDefinition(name, func, description, phase)
+
+    def _tool_read_turn_result(self, turn: int, offset: int = 0, length: int = 0) -> Dict[str, Any]:
+        """Read the FULL output of a previous tool call when the inline view was clipped (params: turn, optional offset/length).
+
+        The observation channel shows at most a fixed window of each tool
+        result; the untruncated output of the last few turns is retained and
+        readable here in chunks. This is the honest counterpart to the
+        …[showing X of Y chars] marker.
+        """
+        state = self._current_state
+        ring = (state.internal_variables.get("_turn_results") or {}) if state is not None else {}
+        full = ring.get(str(turn))
+        if full is None:
+            available = sorted(ring, key=int) if ring else []
+            return {
+                "status": "error",
+                "error": (
+                    f"No retained result for turn {turn}. "
+                    f"Retained turns: {available or 'none'} "
+                    f"(the last {_TURN_RESULT_WINDOW} tool turns are kept)."
+                ),
+            }
+        offset = max(0, int(offset))
+        length = int(length) or _OBSERVATION_LIMIT * 4
+        chunk = full[offset:offset + length]
+        remaining = max(0, len(full) - (offset + len(chunk)))
+        return {
+            "status": "success",
+            "turn": turn,
+            "offset": offset,
+            "total_chars": len(full),
+            "remaining_chars": remaining,
+            "output": chunk,
+            **({"note": f'call again with {{"turn": {turn}, "offset": {offset + len(chunk)}}} for the rest'}
+               if remaining else {}),
+        }
 
     @property
     def tool_names(self) -> List[str]:
@@ -445,6 +511,9 @@ class BaseSubAgent(ABC):
 
         # Restore cross-task memory (no-op unless memory_enabled=True)
         await self._restore_memory(state)
+
+        # Expose state to built-in tools (read_turn_result) for this dispatch.
+        self._current_state = state
 
         # Pre-run hook — subclasses can do deterministic pre-flight work
         await self._pre_run_hook(state)
@@ -713,6 +782,15 @@ class BaseSubAgent(ABC):
                 tool_result = await self._execute_tool(tool_name, tool_params)
                 turn_log["result"] = str(tool_result)[:500]
 
+                # ── Retain the full result for honest retrieval (issue #57) ──
+                # The observation channel clips below; the bytes it clips stay
+                # reachable via read_turn_result for the last N turns.
+                if tool_name != "read_turn_result":
+                    ring = state.internal_variables.setdefault("_turn_results", {})
+                    ring[str(turn)] = str(tool_result)[:_TURN_RESULT_RETENTION]
+                    for stale in sorted(ring, key=int)[:-_TURN_RESULT_WINDOW]:
+                        del ring[stale]
+
                 # Record in state
                 error_str = tool_result.get("error") if isinstance(tool_result, dict) else None
                 state.add_tool_result(tool_name, tool_params, tool_result, error=error_str)
@@ -728,6 +806,7 @@ class BaseSubAgent(ABC):
                 # ── Track usage + convergence ──
                 self._cognition.track_usage(
                     tool_name, tokens=llm_tokens_this_turn, tool_output=tool_result,
+                    params=tool_params,
                 )
 
                 # ── Record failure if tool errored ──
@@ -774,10 +853,10 @@ class BaseSubAgent(ABC):
                             "different strategy this turn. Consider: different tool, "
                             "different parameters, or call DONE with partial results."
                         )
-                        # Reset governor streaks to allow one more turn
-                        self._cognition.convergence._same_tool_streak = 0
-                        self._cognition.convergence._equiv_streak = 0
-                        self._cognition.convergence._last_verdict = None
+                        # Grant a fresh convergence window for the pivot turn.
+                        self._cognition.convergence.reset_streaks(
+                            reason=f"strategic pivot granted to {self.role}"
+                        )
                         logger.info(
                             f"[{self.role}] Strategic pivot granted — "
                             f"resetting convergence for one more turn"
@@ -786,7 +865,7 @@ class BaseSubAgent(ABC):
                         # Record conversation for continuity through the pivot
                         observation = (
                             f"Tool '{tool_name}' returned: "
-                            f"{str(tool_result)[:800]}"
+                            f"{_clip_observation(str(tool_result), turn)}"
                         )
                         conversation_history.append({
                             "assistant": content,
@@ -817,7 +896,7 @@ class BaseSubAgent(ABC):
                 # Record conversation history for multi-turn LLM continuity
                 # Structured turn digest instead of raw output — helps the LLM
                 # retain what was learned and reason about strategy changes.
-                result_str = str(tool_result)[:800]
+                result_str = _clip_observation(str(tool_result), turn)
                 observation = (
                     f"[Turn {turn}] Tool '{tool_name}' returned ({turn_log['status']}):\n"
                     f"{result_str}\n\n"

--- a/tests/test_convergence_fixes.py
+++ b/tests/test_convergence_fixes.py
@@ -192,3 +192,127 @@ class TestStrategicPivot:
         verdict = gov.check_stall_verdict()
         assert verdict is not None
         assert "stagnant_turns" in verdict["reason"]
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Issue #58: content-true equivalence, param-aware streaks, novelty-as-progress
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestContentTrueEquivalence:
+    """'Equivalent' must mean identical — never same-length or same-prefix."""
+
+    def test_same_length_different_content_is_not_equivalent(self):
+        """Paginated reads returning uniform page sizes are progress, not a stall."""
+        gov = ConvergenceGovernor()
+        for page in range(6):
+            out = {"status": "success", "content": f"page-{page:04d}-" + "x" * 100}
+            gov.evaluate("fetch_page", out, params={"page": page})
+        assert gov._equiv_streak == 1
+        assert gov.check_stall_verdict() is None
+
+    def test_identical_outputs_are_equivalent_and_trip(self):
+        gov = ConvergenceGovernor()
+        out = {"status": "success", "content": "identical"}
+        verdict = None
+        for i in range(4):
+            verdict = gov.evaluate("fetch_page", out, params={"page": i})
+        assert verdict is not None
+        assert "equivalent_outcome_streak" in verdict["reason"]
+
+    def test_same_prefix_different_tail_is_not_equivalent(self):
+        """Long strings sharing a 120+ char prefix are distinct outcomes."""
+        gov = ConvergenceGovernor()
+        prefix = "A" * 200
+        for i in range(6):
+            gov.evaluate("read", prefix + f"tail-{i}", params={"i": i})
+        assert gov._equiv_streak == 1
+
+
+class TestParamAwareStreak:
+    """Same tool + different params is iteration; same tool + same params is spinning."""
+
+    def test_same_tool_different_params_does_not_trip(self):
+        gov = ConvergenceGovernor()
+        verdict = None
+        for i in range(8):
+            verdict = gov.evaluate(
+                "read_file",
+                {"status": "success", "content": f"file {i} contents"},
+                params={"path": f"/src/mod_{i}.py"},
+            )
+        assert verdict is None
+        assert gov._same_tool_streak == 1
+
+    def test_same_tool_same_params_still_trips(self):
+        gov = ConvergenceGovernor()
+        verdict = None
+        for _ in range(5):
+            verdict = gov.evaluate(
+                "read_file",
+                {"status": "success", "content": "same"},
+                params={"path": "/src/one.py"},
+            )
+        assert verdict is not None
+        assert "same_tool_streak" in verdict["reason"]
+
+    def test_no_params_preserves_historical_name_only_streak(self):
+        """Callers that don't pass params get exactly the old behavior."""
+        gov = ConvergenceGovernor()
+        verdict = None
+        for i in range(5):
+            verdict = gov.evaluate("web_search", {"status": "success", "content": f"r{i}"})
+        assert verdict is not None
+        assert "same_tool_streak" in verdict["reason"]
+
+
+class TestNoveltyAsProgress:
+    """Changing, non-error outputs count as progress even for unknown schemas."""
+
+    def test_unknown_schema_changing_dicts_do_not_stagnate(self):
+        """Domain dicts without status/content/results keys used to score 0.0."""
+        gov = ConvergenceGovernor()
+        verdict = None
+        for i in range(8):
+            verdict = gov.evaluate(
+                "get_price", {"price": 100.0 + i, "zone": [99, 101]},
+                params={"symbol": f"SYM{i}"},
+            )
+        assert verdict is None
+        assert gov._stagnant_turns == 0
+
+    def test_repeated_identical_unknown_dict_still_stalls(self):
+        """No novelty, no recognized schema — that IS stagnation (and equivalence)."""
+        gov = ConvergenceGovernor()
+        verdict = None
+        for i in range(6):
+            verdict = gov.evaluate(
+                "get_price", {"price": 100.0},
+                params={"call": i},  # different params: isolate the outcome signals
+            )
+        assert verdict is not None
+
+    def test_error_outputs_never_count_as_progress(self):
+        gov = ConvergenceGovernor()
+        for i in range(6):
+            gov.evaluate(
+                "flaky", {"status": "error", "error": f"boom {i}"},
+                params={"attempt": i},
+            )
+        assert gov._stagnant_turns == 6
+
+
+class TestResetStreaks:
+    """Public reset replaces external pokes at private counters."""
+
+    def test_reset_clears_streaks_and_verdict(self):
+        gov = ConvergenceGovernor()
+        out = {"status": "success", "content": "same"}
+        for _ in range(5):
+            gov.evaluate("tool_a", out)
+        assert gov.check_stall_verdict() is not None
+
+        gov.reset_streaks(reason="test pivot")
+        assert gov._same_tool_streak == 0
+        assert gov._equiv_streak == 0
+        assert gov._stagnant_turns == 0
+        assert gov.check_stall_verdict() is None

--- a/tests/test_observation_channel.py
+++ b/tests/test_observation_channel.py
@@ -1,0 +1,114 @@
+"""
+Tests for issue #57: observation channel integrity.
+
+What these tests prove:
+- Clipped observations carry an explicit marker with the retrieval call
+- Unclipped observations are byte-identical to before (non-breaking)
+- The full result of recent turns is retrievable via read_turn_result,
+  in chunks, with honest offset/remaining accounting
+- read_turn_result is auto-registered on every subagent and classified
+  as a thinking tool (recall, not action)
+"""
+
+import pytest
+
+from jarviscore.kernel.cognition import THINKING_TOOLS
+from jarviscore.kernel.state import KernelState
+from jarviscore.kernel.subagent import (
+    BaseSubAgent,
+    _OBSERVATION_LIMIT,
+    _TURN_RESULT_WINDOW,
+    _clip_observation,
+)
+
+
+class _MinimalSubAgent(BaseSubAgent):
+    """Smallest concrete subagent — just enough to exercise the base class."""
+
+    def get_system_prompt(self) -> str:
+        return "You are a test agent."
+
+    def setup_tools(self) -> None:
+        pass
+
+
+@pytest.fixture
+def agent():
+    return _MinimalSubAgent(agent_id="test-agent", role="tester", llm_client=None)
+
+
+@pytest.fixture
+def state_with_ring(agent):
+    state = KernelState(
+        workflow_id="wf", step_id="s1", agent_id="test-agent", task="t",
+    )
+    state.internal_variables["_turn_results"] = {
+        "3": "R" * 5000,
+        "4": "short result",
+    }
+    agent._current_state = state
+    return state
+
+
+class TestClipObservation:
+
+    def test_short_results_pass_through_unchanged(self):
+        assert _clip_observation("small", turn=2) == "small"
+
+    def test_exactly_at_limit_passes_through(self):
+        text = "x" * _OBSERVATION_LIMIT
+        assert _clip_observation(text, turn=2) == text
+
+    def test_clipped_result_carries_marker_with_retrieval_call(self):
+        text = "y" * (_OBSERVATION_LIMIT + 500)
+        out = _clip_observation(text, turn=7)
+        assert out.startswith("y" * _OBSERVATION_LIMIT)
+        assert f"showing {_OBSERVATION_LIMIT} of {len(text)} chars" in out
+        assert "read_turn_result" in out
+        assert '"turn": 7' in out
+        assert f'"offset": {_OBSERVATION_LIMIT}' in out
+
+
+class TestReadTurnResult:
+
+    def test_reads_retained_result_in_chunks(self, agent, state_with_ring):
+        first = agent._tool_read_turn_result(turn=3, offset=0, length=2000)
+        assert first["status"] == "success"
+        assert first["output"] == "R" * 2000
+        assert first["total_chars"] == 5000
+        assert first["remaining_chars"] == 3000
+        assert '"offset": 2000' in first["note"]
+
+        rest = agent._tool_read_turn_result(turn=3, offset=2000, length=3000)
+        assert rest["output"] == "R" * 3000
+        assert rest["remaining_chars"] == 0
+        assert "note" not in rest
+
+    def test_full_read_of_short_result(self, agent, state_with_ring):
+        out = agent._tool_read_turn_result(turn=4)
+        assert out["status"] == "success"
+        assert out["output"] == "short result"
+        assert out["remaining_chars"] == 0
+
+    def test_unknown_turn_is_an_honest_error(self, agent, state_with_ring):
+        out = agent._tool_read_turn_result(turn=99)
+        assert out["status"] == "error"
+        assert "No retained result for turn 99" in out["error"]
+        assert "'3'" in out["error"] and "'4'" in out["error"]
+
+    def test_no_state_is_an_honest_error(self, agent):
+        agent._current_state = None
+        out = agent._tool_read_turn_result(turn=1)
+        assert out["status"] == "error"
+
+    def test_window_constant_is_positive(self):
+        assert _TURN_RESULT_WINDOW >= 1
+
+
+class TestToolRegistration:
+
+    def test_read_turn_result_is_auto_registered(self, agent):
+        assert "read_turn_result" in agent.tool_names
+
+    def test_read_turn_result_is_a_thinking_tool(self):
+        assert "read_turn_result" in THINKING_TOOLS


### PR DESCRIPTION
Fixes #57, fixes #58 — the two coupled world-state killers in the subagent OODA loop.

## Why together

The observation channel's silent 800-char cap and the governor's lossy stall heuristics form one feedback loop: an agent re-calls a tool to see the bytes it silently lost, the retry returns the same clipped view, the governor calls the same-length outputs "equivalent," and a healthy dispatch dies with `YIELD_CONVERGENCE_STALL`. The truncation manufactures the spinning the governor punishes.

## #57 — observation channel integrity

- **Markers**: every clipped observation now ends with `…[showing 800 of 12,440 chars — call TOOL: read_turn_result PARAMS: {"turn": N, "offset": 800} for the rest]`. Models handle known-missing data well and unknown-missing data terribly.
- **Retrieval path**: full results of the last 10 tool turns are retained in `state.internal_variables["_turn_results"]` (bounded ring, JSON-safe strings) and readable in chunks via the new built-in `read_turn_result` tool — auto-registered on every subagent via the existing `_tool_*` discovery, classified as a *thinking* tool (recall, not action).
- **Knobs** (all default to today's values): `SUBAGENT_OBSERVATION_LIMIT=800`, `SUBAGENT_TURN_RESULT_RETENTION=16000`, `SUBAGENT_TURN_RESULT_WINDOW=10`.

## #58 — convergence governor false stalls

- `_outcome_signature` hashes the **full canonical output** (sha256 of sorted-key JSON). "Equivalent" now means *identical* — never same-length (`content_len`) or same-120-char-prefix.
- **Param-aware same-tool streak**: `evaluate(..., params=)` — reading ten different files or making ten distinct searches is iteration, not spinning. Callers that pass no params get exactly the historical name-only behavior (verified by test).
- **Novelty-as-progress**: a changed, non-error output counts as progress even when `_progress_score` doesn't recognize the schema — domain dicts (`{"price": ...}`) no longer accumulate `stagnant_turns` while visibly progressing.
- **`reset_streaks()`**: public API for the pivot path; `subagent.py` no longer reaches into `_same_tool_streak`/`_equiv_streak` privates.

## Non-breaking guarantees

- Unclipped observations are byte-identical to before; clipping threshold unchanged.
- `evaluate()`/`track_usage()` gain optional kwargs only; the no-params path preserves historical streak behavior exactly.
- All env knobs default to current values.
- 30 new regression tests; existing suites pass unchanged (748 passed — the one `test_llm_fallback::test_provider_detection` failure pre-exists on main and is env-dependent).

Note for reviewers: the same-length-equivalence and param-blind-streak failure modes were observed in production downstream (Billy) before being traced here.
