### PR TITLE
fix(kernel,engine): directive precedence + universal step identity (#61, #62)

### DIFF
--- a/jarviscore/core/mesh.py
+++ b/jarviscore/core/mesh.py
@@ -467,7 +467,9 @@ class Mesh:
                 - params: Additional parameters (optional)
 
         Returns:
-            List of step results in execution order
+            List of step results in ORIGINAL STEP ORDER (index i corresponds
+            to steps[i], regardless of execution/completion order). Every
+            result dict carries a ``step_id`` key identifying its step.
 
         Raises:
             RuntimeError: If mesh not started or not in autonomous mode

--- a/jarviscore/kernel/subagent.py
+++ b/jarviscore/kernel/subagent.py
@@ -1077,9 +1077,38 @@ class BaseSubAgent(ABC):
         thought_match = _THOUGHT_PATTERN.search(content)
         thought = thought_match.group(1).strip() if thought_match else ""
 
-        # Check for DONE first
         done_match = _DONE_PATTERN.search(content)
         result_match = _RESULT_PATTERN.search(content)
+        tool_match = _TOOL_PATTERN.search(content)
+
+        # RESULT alone (no DONE, no TOOL) only completes when it carries a
+        # structured JSON object. "RESULT: pending" prose mid-thought must not
+        # end the dispatch with a fabricated completion (issue #61).
+        if result_match and not done_match and not tool_match:
+            if _extract_json_object(result_match.group(1).strip()) is None:
+                result_match = None
+
+        # Directive precedence: models quote protocol keywords in their
+        # reasoning constantly — the system prompt itself teaches the magic
+        # strings. When one response carries BOTH an actionable TOOL and a
+        # DONE/RESULT completion, the LAST directive wins (models emit their
+        # decision at the end). A false completion destroys the dispatch;
+        # a false tool call costs one turn (issue #61).
+        if tool_match and (done_match or result_match):
+            completion_pos = max(
+                done_match.start() if done_match else -1,
+                result_match.start() if result_match else -1,
+            )
+            logger.info(
+                "Protocol ambiguity: TOOL@%d and DONE/RESULT@%d in one response — "
+                "taking the later directive",
+                tool_match.start(), completion_pos,
+            )
+            if tool_match.start() > completion_pos:
+                done_match = None
+                result_match = None
+
+        # Check for DONE
         if done_match or result_match:
             summary = done_match.group(1).strip() if done_match else "Completed via RESULT block"
             result = None
@@ -1090,8 +1119,7 @@ class BaseSubAgent(ABC):
                     result = result_match.group(1).strip()
             return {"type": "done", "thought": thought, "summary": summary, "result": result}
 
-        # Check for TOOL
-        tool_match = _TOOL_PATTERN.search(content)
+        # Check for TOOL (matched above, before precedence resolution)
         if tool_match:
             tool_name = tool_match.group(1).strip()
             params = {}

--- a/jarviscore/orchestration/engine.py
+++ b/jarviscore/orchestration/engine.py
@@ -335,11 +335,19 @@ class WorkflowEngine:
             f"{len(state.waiting_steps)} waiting"
         )
 
-        # Return in original step order
-        return [
-            results.get(s["id"], {"status": "skipped", "step_id": s["id"]})
-            for s in steps
-        ]
+        # Return in ORIGINAL STEP ORDER, every result carrying its identity.
+        # The engine only wrote step_id on failure/skip paths; a successful
+        # result was the agent's raw envelope, so consumers keying on
+        # step_id worked in every failure test and silently lost every
+        # success in production (issue #62). Stamp identity here, once,
+        # for all paths — results that already carry a step_id keep it.
+        ordered: List[Dict[str, Any]] = []
+        for s in steps:
+            result = results.get(s["id"], {"status": "skipped", "step_id": s["id"]})
+            if isinstance(result, dict) and "step_id" not in result:
+                result["step_id"] = s["id"]
+            ordered.append(result)
+        return ordered
 
     # ------------------------------------------------------------------
     # Crash Recovery

--- a/tests/test_parse_precedence_and_step_identity.py
+++ b/tests/test_parse_precedence_and_step_identity.py
@@ -1,0 +1,175 @@
+"""
+Tests for issues #61 and #62.
+
+#61 — _parse_response directive precedence:
+- A quoted "DONE:" line before a real TOOL call must not falsely complete
+- A quoted TOOL example before a real DONE must still complete
+- RESULT alone only completes when it carries structured JSON
+- Single-directive responses parse exactly as before (non-breaking)
+
+#62 — WorkflowEngine result identity:
+- Every result in the returned list carries step_id — success included
+- Results that already carry a step_id keep it
+"""
+
+from typing import Any, Dict
+
+import pytest
+
+from jarviscore.kernel.subagent import BaseSubAgent
+
+
+parse = BaseSubAgent._parse_response
+
+
+# ======================================================================
+# #61 — directive precedence
+# ======================================================================
+
+class TestDirectivePrecedence:
+
+    def test_quoted_done_before_real_tool_executes_the_tool(self):
+        content = (
+            "THOUGHT: I still need the schema. Once I have it I will emit\n"
+            "DONE: <summary> as instructed.\n"
+            "TOOL: fetch_schema\n"
+            'PARAMS: {"url": "https://api.example.com/spec"}'
+        )
+        parsed = parse(content)
+        assert parsed["type"] == "tool"
+        assert parsed["tool"] == "fetch_schema"
+        assert parsed["params"] == {"url": "https://api.example.com/spec"}
+
+    def test_quoted_tool_example_before_real_done_completes(self):
+        content = (
+            "THOUGHT: earlier I ran\n"
+            "TOOL: web_search\n"
+            "which gave me everything I need, so I am finishing.\n"
+            "DONE: research complete\n"
+            'RESULT: {"finding": "x"}'
+        )
+        parsed = parse(content)
+        assert parsed["type"] == "done"
+        assert parsed["summary"] == "research complete"
+        assert parsed["result"] == {"finding": "x"}
+
+    def test_plain_tool_response_unchanged(self):
+        content = (
+            "THOUGHT: need data\n"
+            "TOOL: web_search\n"
+            'PARAMS: {"query": "AML trends"}'
+        )
+        parsed = parse(content)
+        assert parsed["type"] == "tool"
+        assert parsed["tool"] == "web_search"
+
+    def test_plain_done_response_unchanged(self):
+        content = (
+            "THOUGHT: finished\n"
+            "DONE: all wrapped up\n"
+            'RESULT: {"answer": 42}'
+        )
+        parsed = parse(content)
+        assert parsed["type"] == "done"
+        assert parsed["result"] == {"answer": 42}
+
+    def test_done_without_result_still_completes(self):
+        parsed = parse("THOUGHT: ok\nDONE: summary only")
+        assert parsed["type"] == "done"
+        assert parsed["summary"] == "summary only"
+
+
+class TestResultAloneRequiresJson:
+
+    def test_result_alone_with_json_completes(self):
+        parsed = parse('RESULT: {"answer": 42}')
+        assert parsed["type"] == "done"
+        assert parsed["result"] == {"answer": 42}
+
+    def test_result_alone_prose_is_not_a_completion(self):
+        parsed = parse("THOUGHT: the final\nRESULT: pending — need one more read")
+        assert parsed["type"] == "raw"
+
+    def test_done_with_prose_result_keeps_historical_behavior(self):
+        parsed = parse("DONE: finished\nRESULT: plain text answer")
+        assert parsed["type"] == "done"
+        assert parsed["result"] == "plain text answer"
+
+
+# ======================================================================
+# #62 — every engine result carries step_id
+# ======================================================================
+
+from jarviscore import Mesh, MeshMode  # noqa: E402
+from jarviscore.core.agent import Agent  # noqa: E402
+
+
+class EchoAgent(Agent):
+    role = "echo"
+    capabilities = ["echo"]
+
+    async def execute_task(self, task: Dict[str, Any]) -> Dict[str, Any]:
+        return {"status": "success", "output": task.get("task", "")}
+
+
+class FailingAgent(Agent):
+    role = "boom"
+    capabilities = ["boom"]
+
+    async def execute_task(self, task: Dict[str, Any]) -> Dict[str, Any]:
+        return {"status": "failure", "error": "kaput"}
+
+
+class SelfIdentifyingAgent(Agent):
+    role = "selfid"
+    capabilities = ["selfid"]
+
+    async def execute_task(self, task: Dict[str, Any]) -> Dict[str, Any]:
+        return {"status": "success", "output": "x", "step_id": "my-own-identity"}
+
+
+@pytest.mark.asyncio
+class TestResultIdentity:
+
+    async def test_success_results_carry_step_id(self):
+        mesh = Mesh(mode=MeshMode.AUTONOMOUS)
+        mesh.add(EchoAgent)
+        await mesh.start()
+        try:
+            results = await mesh.workflow("wf-id-success", [
+                {"id": "alpha", "agent": "echo", "task": "one"},
+                {"id": "beta", "agent": "echo", "task": "two"},
+            ])
+        finally:
+            await mesh.stop()
+
+        assert [r["step_id"] for r in results] == ["alpha", "beta"]
+        assert all(r["status"] == "success" for r in results)
+
+    async def test_mixed_success_and_failure_all_carry_step_id(self):
+        mesh = Mesh(mode=MeshMode.AUTONOMOUS)
+        mesh.add(EchoAgent)
+        mesh.add(FailingAgent)
+        await mesh.start()
+        try:
+            results = await mesh.workflow("wf-id-mixed", [
+                {"id": "ok", "agent": "echo", "task": "fine"},
+                {"id": "bad", "agent": "boom", "task": "explode"},
+            ])
+        finally:
+            await mesh.stop()
+
+        assert [r["step_id"] for r in results] == ["ok", "bad"]
+
+    async def test_agent_supplied_step_id_is_respected(self):
+        mesh = Mesh(mode=MeshMode.AUTONOMOUS)
+        mesh.add(SelfIdentifyingAgent)
+        await mesh.start()
+        try:
+            results = await mesh.workflow("wf-id-own", [
+                {"id": "engine-id", "agent": "selfid", "task": "t"},
+            ])
+        finally:
+            await mesh.stop()
+
+        assert results[0]["step_id"] == "my-own-identity"


### PR DESCRIPTION
Fixes #61, fixes #62 — the two silent-misparse traps.

## #61 — the last directive wins

`_parse_response` checked DONE/RESULT before TOOL over the whole response with line-anchored MULTILINE patterns. A response like:

```
THOUGHT: Once I have the schema I will emit
DONE: <summary> as instructed.
TOOL: fetch_schema
PARAMS: {"url": "..."}
```

previously parsed as **done** — the tool call dropped, the dispatch completed with a fragment of the agent's plan as its "summary". Now:

- **Both directives present → the later one wins.** Models emit their decision at the end; a false completion is unrecoverable while a false tool call costs one turn.
- **RESULT alone requires JSON.** `RESULT: pending — need one more read` no longer completes; `DONE:` + prose RESULT keeps historical behavior (a legitimate completion attempt).
- A `protocol_ambiguity` log line measures how often models actually do this.

## #62 — identity on every result

The engine stamped `step_id` only on failure/skip/deadlock/cancel paths; a successful result was the agent's raw envelope. Consumers keying on `step_id` pass every failure-path test and silently lose every success — this exact failure shipped in production downstream (Billy: every successful 8-step evaluation dropped for 34 minutes).

Now the final assembly stamps `step_id` on every result that lacks one; agent-supplied identities are respected. The `mesh.workflow` docstring is corrected too — results are in **original step order**, not "execution order".

## Non-breaking guarantees

- Single-directive responses parse byte-identically (tested).
- `step_id` is an added key where none previously existed; results already carrying one keep it (tested).
- 11 new tests incl. end-to-end mesh workflows; 175 adjacent tests pass unchanged.

With #64 and #65, this completes the "honest envelopes" half of the audit: identity flows with every result, no directive is inferred from quoted prose, and no clipped byte is unreachable.
