### PR TITLE
fix(context): summarization is compression, never destruction (#59)

### DIFF
--- a/jarviscore/context/context_manager.py
+++ b/jarviscore/context/context_manager.py
@@ -91,6 +91,12 @@ class BudgetConfig:
     internal_var_limit: int = 200
     history_value_limit: int = 600
     state_keys_limit: int = 10
+    # Chars of each turn's output shown to the summarizer LLM. 100 chars was
+    # not a summarizable evidence base — the "summary" was confabulation by
+    # construction (issue #59).
+    summary_evidence_limit: int = 800
+    # How many compressed-away turns stay retrievable in the archive.
+    archive_window: int = 50
 
     @property
     def usable_tokens(self) -> int:
@@ -565,7 +571,14 @@ class ContextManager:
         return True
 
     async def _summarize_state(self, state: "KernelState", llm) -> bool:
-        """Compress oldest tool history entries into long-term memory."""
+        """Compress oldest tool history entries into long-term memory.
+
+        Compression, not destruction (issue #59): the summary is built from a
+        real evidence window per turn, the ORIGINALS are archived before the
+        history is trimmed, the stored summary is labeled lossy, and a failed
+        summarizer keeps the entries for the next cycle instead of replacing
+        evidence with a tool-name list.
+        """
         if len(state.tool_history) < 8:
             return False  # Not enough to compress
 
@@ -586,35 +599,58 @@ class ContextManager:
         old_entries = state.tool_history[:slice_idx]
         remaining = state.tool_history[slice_idx:]
 
-        # Build summary (LLM or fallback)
+        # Build summary from a real evidence base — an LLM asked to summarize
+        # "WHAT was discovered" needs to actually see the discoveries.
         try:
             summary_prompt = (
                 "Summarize these agent actions into 2-3 bullet points. "
                 "Focus on WHAT was discovered and WHAT was attempted:\n"
             )
             for tr in old_entries:
-                summary_prompt += f"- {tr.tool_name}: {str(tr.tool_output)[:100]}\n"
+                evidence = self._clip(tr.tool_output, self.config.summary_evidence_limit)
+                summary_prompt += f"- {tr.tool_name}: {evidence}\n"
 
             if hasattr(llm, "generate"):
                 result = await llm.generate(
                     messages=[{"role": "user", "content": summary_prompt}]
                 )
-                summary_text = result.get("content", "")[:500]
+                summary_text = self._clip(result.get("content", ""), 1000)
             else:
-                # Fallback: mechanical summary
+                # No LLM attached: mechanical summary, but the originals are
+                # archived below — nothing is destroyed.
                 tool_names = set(tr.tool_name for tr in old_entries)
                 summary_text = f"Executed {len(old_entries)} actions: {', '.join(tool_names)}"
         except Exception as e:
-            logger.warning(f"Summarization LLM call failed: {e}")
-            tool_names = set(tr.tool_name for tr in old_entries)
-            summary_text = f"Executed {len(old_entries)} actions: {', '.join(tool_names)}"
+            # A failed summarizer must not cost evidence: keep the entries
+            # and let the next cycle retry. The old fallback replaced the
+            # oldest 30% of the agent's history with a tool-name list.
+            logger.warning(
+                f"Summarization LLM call failed ({e}) — keeping tool history "
+                f"intact for retry on the next cycle"
+            )
+            return False
 
-        # Store in long-term memory
+        # Archive the originals BEFORE trimming — a summary is a view,
+        # never the only copy. JSON-safe (checkpoints call model_dump_json).
+        archive = state.internal_variables.setdefault("_archived_turns", [])
+        for tr in old_entries:
+            archive.append({
+                "tool_name": tr.tool_name,
+                "tool_input": json.loads(json.dumps(tr.tool_input, default=str)),
+                "tool_output": str(tr.tool_output),
+                "status": getattr(tr, "status", None),
+                "error": getattr(tr, "error", None),
+            })
+        if len(archive) > self.config.archive_window:
+            del archive[:-self.config.archive_window]
+
+        # Store in long-term memory — labeled for what it is
         if "long_term_memory" not in state.internal_variables:
             state.internal_variables["long_term_memory"] = []
         state.internal_variables["long_term_memory"].append({
-            "summary": summary_text,
+            "summary": f"[lossy summary of {len(old_entries)} turns — originals archived] {summary_text}",
             "turns_compressed": len(old_entries),
+            "archived": True,
             "timestamp": time.time(),
         })
 

--- a/tests/test_context_manager.py
+++ b/tests/test_context_manager.py
@@ -305,3 +305,110 @@ class TestToolHistoryMarkers:
         state.add_tool_result("read_file", {"path": "/x"}, "D" * 1500)
         rendered = big_cm.build_context(state)
         assert "…[truncated: showing 600 of" in rendered
+
+
+# ======================================================================
+# Issue #59: summarization is compression, never destruction
+# ======================================================================
+
+def _state_ready_to_compress(n_turns=10, output_len=400):
+    state = _kernel_state()
+    for i in range(n_turns):
+        state.add_tool_result(
+            "web_search", {"query": f"q{i}"},
+            {"status": "success", "content": f"finding-{i}-" + "x" * output_len},
+        )
+    return state
+
+
+def _compressing_cm():
+    # Tiny history_limit so the 80% threshold trips immediately
+    return ContextManager(BudgetConfig(history_limit=10))
+
+
+class TestZeroLossSummarization:
+
+    @pytest.mark.asyncio
+    async def test_originals_archived_before_trim(self):
+        cm = _compressing_cm()
+        state = _state_ready_to_compress()
+        llm = MagicMock()
+        llm.generate = AsyncMock(return_value={"content": "- discovered things"})
+
+        assert await cm._summarize_state(state, llm) is True
+
+        archive = state.internal_variables["_archived_turns"]
+        assert len(archive) == 3  # oldest 30% of 10
+        assert archive[0]["tool_name"] == "web_search"
+        # Full output preserved — not the 100-char stub of old
+        assert "finding-0-" in archive[0]["tool_output"]
+        assert len(archive[0]["tool_output"]) > 300
+        # And history was trimmed as before
+        assert len(state.tool_history) == 7
+
+    @pytest.mark.asyncio
+    async def test_summary_is_labeled_lossy(self):
+        cm = _compressing_cm()
+        state = _state_ready_to_compress()
+        llm = MagicMock()
+        llm.generate = AsyncMock(return_value={"content": "- found stuff"})
+
+        await cm._summarize_state(state, llm)
+
+        ltm = state.internal_variables["long_term_memory"]
+        assert ltm[0]["summary"].startswith("[lossy summary of 3 turns — originals archived]")
+        assert ltm[0]["archived"] is True
+
+    @pytest.mark.asyncio
+    async def test_summarizer_sees_a_real_evidence_window(self):
+        cm = _compressing_cm()
+        state = _state_ready_to_compress(output_len=700)
+        llm = MagicMock()
+        llm.generate = AsyncMock(return_value={"content": "- ok"})
+
+        await cm._summarize_state(state, llm)
+
+        prompt = llm.generate.call_args.kwargs["messages"][0]["content"]
+        # Old code fed 100 chars/turn; the evidence window is now config-sized
+        assert "finding-0-" + "x" * 300 in prompt
+
+    @pytest.mark.asyncio
+    async def test_failed_summarizer_keeps_history_intact(self):
+        cm = _compressing_cm()
+        state = _state_ready_to_compress()
+        llm = MagicMock()
+        llm.generate = AsyncMock(side_effect=RuntimeError("provider down"))
+
+        assert await cm._summarize_state(state, llm) is False
+        assert len(state.tool_history) == 10          # nothing trimmed
+        assert "_archived_turns" not in state.internal_variables
+        assert "long_term_memory" not in state.internal_variables
+
+    @pytest.mark.asyncio
+    async def test_archive_is_bounded(self):
+        cm = ContextManager(BudgetConfig(history_limit=10, archive_window=4))
+        state = _state_ready_to_compress()
+        state.internal_variables["_archived_turns"] = [
+            {"tool_name": f"old_{i}"} for i in range(4)
+        ]
+        llm = MagicMock()
+        llm.generate = AsyncMock(return_value={"content": "- ok"})
+
+        await cm._summarize_state(state, llm)
+
+        archive = state.internal_variables["_archived_turns"]
+        assert len(archive) == 4
+        # Newest entries survive; the pre-existing oldest were evicted
+        assert archive[-1]["tool_name"] == "web_search"
+
+    @pytest.mark.asyncio
+    async def test_archive_is_json_safe_for_checkpoints(self):
+        import json as _json
+        cm = _compressing_cm()
+        state = _state_ready_to_compress()
+        llm = MagicMock()
+        llm.generate = AsyncMock(return_value={"content": "- ok"})
+
+        await cm._summarize_state(state, llm)
+        # save_checkpoint calls model_dump_json — must not raise
+        _json.loads(state.model_dump_json())


### PR DESCRIPTION
Fixes #59. Stacked on #65 (same file) — merge #65 first; GitHub will retarget this to main automatically.

## The principle

> Truncation is not context compression — it is lossiness.

Compression means four things, and `_summarize_state()` now does all four:

1. **Summarize from real evidence.** The summarizer LLM saw 100 chars per turn — 1–3% of the content it was asked to summarize, making the "summary" confabulation by construction. It now sees `summary_evidence_limit` chars per turn (default 800, in `BudgetConfig`).
2. **Archive before trim.** Compressed-away turns are written to `internal_variables["_archived_turns"]` (JSON-safe for checkpoints, bounded by `archive_window=50`) *before* `tool_history` is trimmed. A summary is a view — never the only copy.
3. **Label the loss.** Stored summaries read `[lossy summary of 3 turns — originals archived] …` and carry `archived: true`, so downstream reasoning can weight them.
4. **Never trade evidence for confetti.** A failed summarizer call previously *replaced the oldest 30% of the agent's history with a tool-name list*. It now returns `False` and keeps the entries intact for retry on the next cycle.

## Non-breaking

- Trigger conditions, slice size, and trim behavior on the success path are unchanged.
- New `BudgetConfig` fields are additive with safe defaults.
- The only behavior change on the failure path is *keeping* data that was previously destroyed.
- 6 new tests (incl. checkpoint JSON-safety of the archive); 85 adjacent tests pass unchanged.

Follow-up (noted, not in this PR): once #64's `read_turn_result` merges, a sibling `read_archived_turn` tool can make the archive directly agent-readable — completing the retrieval path from LTM summary back to original evidence.
