### PR TITLE
fix(cognition): FailureLedger integrity — structured-first classification, aligned guard keys (#60)

### DIFF
--- a/jarviscore/kernel/cognition.py
+++ b/jarviscore/kernel/cognition.py
@@ -23,6 +23,7 @@ import hashlib
 import json
 import logging
 import os
+import re
 import time
 from collections import deque
 from enum import Enum
@@ -75,6 +76,19 @@ _CONV_STALL_ACTION = os.getenv("CONVERGENCE_STALL_ACTION", "yield").strip().lowe
 
 # Failure guard TTL (in-process guard; Redis uses its own TTL)
 _FAILURE_GUARD_HORIZON_SECONDS = int(os.getenv("FAILURE_GUARD_HORIZON_SECONDS", "1800"))
+# Whether unclassifiable failures block retries. "guard" (default, historical)
+# treats UNKNOWN as permanent; "skip" treats it as weak evidence and allows
+# retries — an error we could not classify is thin grounds for a 30-min block.
+_FAILURE_GUARD_UNKNOWN = os.getenv("FAILURE_GUARD_UNKNOWN", "guard").strip().lower()
+
+# HTTP-ish status codes → failure class, for structured classification.
+_STATUS_CODE_CLASSES = {
+    401: "AUTH_UNAUTHORIZED",
+    403: "AUTH_FORBIDDEN",
+    404: "NOT_FOUND",
+    408: "TIMEOUT",
+    429: "RATE_LIMIT",
+}
 
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -321,14 +335,46 @@ class FailureLedger:
         return hashlib.sha256(f"{tool_name}:{payload}".encode("utf-8")).hexdigest()
 
     @staticmethod
-    def _classify_error(error_text: str) -> str:
-        """Classify failure mode from error string."""
+    def _classify_error(error_text: str, output: Any = None) -> str:
+        """Classify a failure — structured signals first, prose last.
+
+        Classification decides retryability (TIMEOUT/NETWORK are never
+        guarded), so it must prefer machine-readable evidence over substring
+        sniffing (issue #60):
+
+        1. output["error_type"] — an explicit class from the tool wins outright
+        2. output["status_code"] / output["code"] — numeric HTTP-ish codes
+        3. Prose heuristics — word-boundary matched numeric codes, so
+           "1404 rows" never reads as a 404
+        """
+        # 1. Explicit class from the tool
+        if isinstance(output, dict):
+            explicit = output.get("error_type")
+            if isinstance(explicit, str) and explicit.strip():
+                return explicit.strip().upper()
+            # 2. Numeric status code
+            for key in ("status_code", "code"):
+                code = output.get(key)
+                try:
+                    code = int(code)
+                except (TypeError, ValueError):
+                    continue
+                if code in _STATUS_CODE_CLASSES:
+                    return _STATUS_CODE_CLASSES[code]
+                if code >= 500:
+                    return "NETWORK"
+
+        # 3. Prose heuristics (fallback only)
         text = str(error_text).lower()
-        if "401" in text or "unauthorized" in text:
+
+        def _code(n: str) -> bool:
+            return bool(re.search(rf"\b{n}\b", text))
+
+        if _code("401") or "unauthorized" in text:
             return "AUTH_UNAUTHORIZED"
-        if "403" in text or "forbidden" in text:
+        if _code("403") or "forbidden" in text:
             return "AUTH_FORBIDDEN"
-        if "429" in text or "rate limit" in text:
+        if _code("429") or "rate limit" in text:
             return "RATE_LIMIT"
         if "timeout" in text or "timed out" in text:
             return "TIMEOUT"
@@ -336,7 +382,7 @@ class FailureLedger:
             return "NETWORK"
         if "schema" in text or "validation" in text:
             return "SCHEMA_VALIDATION"
-        if "not found" in text or "404" in text:
+        if "not found" in text or _code("404"):
             return "NOT_FOUND"
         return "UNKNOWN"
 
@@ -355,7 +401,7 @@ class FailureLedger:
         If redis_store is attached, the failure is also indexed there.
         """
         fp = self.fingerprint(tool_name, params)
-        error_type = self._classify_error(error or str(output or ""))
+        error_type = self._classify_error(error or str(output or ""), output=output)
         entry: Dict[str, Any] = {
             "ts": time.time(),
             "tool": tool_name,
@@ -391,12 +437,20 @@ class FailureLedger:
         Return True if this fingerprint has failed recently and should not be retried.
 
         Checks Redis cross-session guard first (if attached), then in-process ledger.
-        Transient failures (TIMEOUT, NETWORK) are NOT guarded — they may succeed on retry.
+        Transient failures (TIMEOUT, NETWORK) are NOT guarded — they may succeed
+        on retry. UNKNOWN failures follow FAILURE_GUARD_UNKNOWN ("guard", the
+        historical default, or "skip" — an error we could not classify is weak
+        evidence for a 30-minute block).
         """
-        # Redis cross-session check
+        # Redis cross-session check — keyed exactly as record() writes it
+        # (issue #60: this used to query workflow_id="unknown" while record()
+        # indexed under the real workflow id, so the cross-session guard
+        # could never match what was written).
         if self.redis_store and hasattr(self.redis_store, "has_failure_guard"):
             try:
-                if self.redis_store.has_failure_guard("global", "unknown", fp):
+                if self.redis_store.has_failure_guard(
+                    "global", str(self.workflow_id), fp
+                ):
                     return True
             except Exception as exc:
                 logger.warning(
@@ -406,6 +460,9 @@ class FailureLedger:
 
         # In-process ledger check
         now = time.time()
+        skip_types = {"TIMEOUT", "NETWORK"}
+        if _FAILURE_GUARD_UNKNOWN == "skip":
+            skip_types = skip_types | {"UNKNOWN"}
         for entry in reversed(self._ledger[-20:]):
             if entry.get("fingerprint") != fp:
                 continue
@@ -415,7 +472,7 @@ class FailureLedger:
             if (now - float(ts)) > self.horizon_seconds:
                 continue
             # Don't guard transient failures — they might succeed next time
-            if entry.get("error_type") in {"TIMEOUT", "NETWORK"}:
+            if entry.get("error_type") in skip_types:
                 continue
             return True
         return False

--- a/tests/test_failure_ledger.py
+++ b/tests/test_failure_ledger.py
@@ -1,0 +1,106 @@
+"""
+Tests for issue #60: FailureLedger integrity.
+
+What these tests prove:
+- Structured signals (error_type field, status_code) outrank prose sniffing
+- Numeric codes in prose match on word boundaries — "1404 rows" is not a 404
+- record() feeds the structured output into classification
+- is_guarded() queries Redis with the SAME workflow id record() writes
+- UNKNOWN guarding is configurable (guard = historical default, skip = lenient)
+"""
+
+from unittest.mock import MagicMock
+
+import jarviscore.kernel.cognition as cognition
+from jarviscore.kernel.cognition import FailureLedger
+
+
+classify = FailureLedger._classify_error
+
+
+class TestStructuredFirstClassification:
+
+    def test_explicit_error_type_field_wins(self):
+        out = {"status": "error", "error_type": "quota_exceeded", "error": "404 not found"}
+        assert classify("404 not found", output=out) == "QUOTA_EXCEEDED"
+
+    def test_status_code_outranks_prose(self):
+        out = {"status": "error", "status_code": 429, "error": "the request failed"}
+        assert classify("the request failed", output=out) == "RATE_LIMIT"
+
+    def test_code_key_also_recognized(self):
+        assert classify("boom", output={"code": 403}) == "AUTH_FORBIDDEN"
+
+    def test_5xx_classifies_as_network(self):
+        assert classify("server error", output={"status_code": 503}) == "NETWORK"
+
+    def test_non_numeric_code_falls_through_to_prose(self):
+        assert classify("connection reset", output={"code": "ERR_RESET"}) == "NETWORK"
+
+
+class TestWordBoundaryProse:
+
+    def test_1404_rows_is_not_a_404(self):
+        assert classify("processed 1404 rows before failing") == "UNKNOWN"
+
+    def test_plain_404_still_matches(self):
+        assert classify("upstream returned 404") == "NOT_FOUND"
+
+    def test_race_condition_401_boundary(self):
+        assert classify("id 84012 missing") == "UNKNOWN"
+        assert classify("HTTP 401 from gateway") == "AUTH_UNAUTHORIZED"
+
+    def test_historical_text_classes_unchanged(self):
+        assert classify("request timed out after 30s") == "TIMEOUT"
+        assert classify("rate limit exceeded") == "RATE_LIMIT"
+        assert classify("schema validation failed") == "SCHEMA_VALIDATION"
+        assert classify("connection refused") == "NETWORK"
+
+
+class TestRecordUsesStructuredOutput:
+
+    def test_record_classifies_from_output_dict(self):
+        ledger = FailureLedger(agent_id="a", workflow_id="wf-1")
+        ledger.record(
+            "call_api", {"x": 1},
+            error="request failed",
+            output={"status": "error", "status_code": 429},
+        )
+        assert ledger.recent_failures[-1]["error_type"] == "RATE_LIMIT"
+
+
+class TestGuardKeyAlignment:
+
+    def test_is_guarded_queries_the_workflow_id_record_writes(self):
+        redis = MagicMock()
+        redis.has_failure_guard = MagicMock(return_value=False)
+        redis.index_failure_event = MagicMock()
+
+        ledger = FailureLedger(agent_id="agent-9", workflow_id="wf-real-42", redis_store=redis)
+        fp = ledger.record("web_search", {"q": "x"}, error="403 forbidden")
+        ledger.is_guarded(fp)
+
+        written_wf = redis.index_failure_event.call_args.kwargs["workflow_id"]
+        read_wf = redis.has_failure_guard.call_args.args[1]
+        assert written_wf == read_wf == "wf-real-42"
+
+
+class TestUnknownGuardPolicy:
+
+    def _guarded_after_unknown_failure(self):
+        ledger = FailureLedger(agent_id="a", workflow_id="wf")
+        fp = ledger.record("tool", {"p": 1}, error="something inexplicable")
+        assert ledger.recent_failures[-1]["error_type"] == "UNKNOWN"
+        return ledger.is_guarded(fp)
+
+    def test_default_guards_unknown(self):
+        assert self._guarded_after_unknown_failure() is True
+
+    def test_skip_mode_does_not_guard_unknown(self, monkeypatch):
+        monkeypatch.setattr(cognition, "_FAILURE_GUARD_UNKNOWN", "skip")
+        assert self._guarded_after_unknown_failure() is False
+
+    def test_transient_failures_never_guarded_either_way(self):
+        ledger = FailureLedger(agent_id="a", workflow_id="wf")
+        fp = ledger.record("tool", {"p": 1}, error="connection timed out")
+        assert ledger.is_guarded(fp) is False


### PR DESCRIPTION
Fixes #60 — the FailureLedger's two integrity gaps.

## Problem 1 — substring classification decided retry policy

`_classify_error` pattern-matched prose, and `is_guarded()` exempts transient classes from guarding — so a misclassification silently flipped retry policy. Now classification prefers machine-readable evidence, in order:

1. `output["error_type"]` — an explicit class from the tool wins outright
2. `output["status_code"]` / `output["code"]` — 401/403/404/408/429 map directly, 5xx → NETWORK
3. Prose heuristics — unchanged, except numeric codes now match on **word boundaries**: `processed 1404 rows` is no longer a NOT_FOUND; `HTTP 401 from gateway` still is

`record()` already received `output` — it just never consulted it.

## Problem 2 — the Redis guard read/write key mismatch

`record()` indexed failures under `workflow_id=str(self.workflow_id)`; `is_guarded()` queried `has_failure_guard("global", "unknown", fp)`. Write and read used different keys, so depending on the store schema the cross-session guard either never fired (dead feature) or leaked across workflows. `is_guarded()` now queries exactly what `record()` writes.

## Bonus knob

`FAILURE_GUARD_UNKNOWN=guard|skip` (default `guard`, today's behavior): an error we couldn't classify is arguably weak evidence for a 30-minute retry block — `skip` treats UNKNOWN like the transient classes.

## Non-breaking

- Prose-only inputs classify identically except the boundary-corrected numerics (which were the bug).
- Structured keys were never consulted before — pure addition.
- Env knob defaults to historical behavior.
- 14 new tests (structured precedence, word boundaries, guard-key round-trip via mock Redis capture, UNKNOWN policy both ways); adjacent suites pass unchanged.

This closes out the audit's cognition-layer items: with #64 (governor + observation), all stall/guard machinery now operates on identity and structured evidence instead of string sniffing.
