### PR TITLE
feat(context): generational compaction — bounded LTM without context collapse (#69)

### DIFF
--- a/jarviscore/context/context_manager.py
+++ b/jarviscore/context/context_manager.py
@@ -97,6 +97,13 @@ class BudgetConfig:
     summary_evidence_limit: int = 800
     # How many compressed-away turns stay retrievable in the archive.
     archive_window: int = 50
+    # Long-term memory bound (issue #69). On overflow the OLDEST half is
+    # merged into one labeled epoch summary; the newest entries keep full
+    # fidelity. Incremental accumulation, never monolithic rewrite — the
+    # context-collapse failure mode identified by ACE (arXiv:2510.04618).
+    ltm_window: int = 20
+    # How many LTM entries the context block renders (was a silent [-5:]).
+    ltm_render_limit: int = 5
 
     @property
     def usable_tokens(self) -> int:
@@ -363,11 +370,15 @@ class ContextManager:
         ltm = state.internal_variables.get("long_term_memory", [])
         if ltm:
             ltm_block = "## LONG-TERM MEMORY (Compressed History)\n"
-            for item in ltm[-5:]:
+            render_limit = self.config.ltm_render_limit
+            for item in ltm[-render_limit:]:
                 if isinstance(item, dict):
                     ltm_block += f"- {self._clip(item.get('summary', str(item)), self.config.memory_item_limit)}\n"
                 else:
                     ltm_block += f"- {self._clip(item, self.config.memory_item_limit)}\n"
+            hidden = len(ltm) - render_limit
+            if hidden > 0:
+                ltm_block += f"…and {hidden} older memories not shown\n"
             _add_block(ltm_block, max_tokens=2000)
 
         # ═══ BLOCK 8: TOOL HISTORY (Sliding Window) ═══
@@ -650,6 +661,7 @@ class ContextManager:
         state.internal_variables["long_term_memory"].append({
             "summary": f"[lossy summary of {len(old_entries)} turns — originals archived] {summary_text}",
             "turns_compressed": len(old_entries),
+            "generation": 1,
             "archived": True,
             "timestamp": time.time(),
         })
@@ -657,6 +669,94 @@ class ContextManager:
         # Trim history
         state.tool_history = remaining
         logger.info(f"Compressed {len(old_entries)} turns into long-term memory")
+
+        # Bound LTM itself — generational compaction (issue #69)
+        await self._compact_ltm(state, llm)
+
+        # Compression telemetry: entropy management must be visible, not
+        # suspected. Rides in internal variables → rendered in INTERNAL STATE.
+        stats = state.internal_variables.setdefault(
+            "compression_stats",
+            {"cycles": 0, "turns_compressed": 0, "epochs": 0, "max_generation": 1},
+        )
+        stats["cycles"] += 1
+        stats["turns_compressed"] += len(old_entries)
+        return True
+
+    async def _compact_ltm(self, state: "KernelState", llm) -> bool:
+        """Bound long_term_memory via generational epoch merges (issue #69).
+
+        The failure mode this avoids is context collapse (ACE,
+        arXiv:2510.04618): iteratively re-summarizing EVERYTHING erodes
+        detail until memory is mush. Instead, on overflow only the OLDEST
+        half is merged into one epoch summary — newest entries are never
+        touched, so fidelity decays monotonically with age and recent
+        memory stays verbatim. Generations are labeled so downstream
+        reasoning can weight fidelity, and merged-away entries are archived
+        first — compression, never destruction.
+        """
+        ltm = state.internal_variables.get("long_term_memory") or []
+        if len(ltm) <= self.config.ltm_window:
+            return False
+
+        merge_count = max(2, self.config.ltm_window // 2)
+        oldest = ltm[:merge_count]
+        newest = ltm[merge_count:]
+
+        def _text(item: Any) -> str:
+            return item.get("summary", str(item)) if isinstance(item, dict) else str(item)
+
+        def _gen(item: Any) -> int:
+            return int(item.get("generation", 1)) if isinstance(item, dict) else 1
+
+        generation = max(_gen(i) for i in oldest) + 1
+        try:
+            merge_prompt = (
+                "Merge these agent memory entries into one dense record. "
+                "Recall first: preserve every decision, discovery, error, and "
+                "open question — drop only redundancy and filler:\n"
+                + "\n".join(f"- {_text(i)}" for i in oldest)
+            )
+            if not hasattr(llm, "generate"):
+                return False  # no LLM: keep entries; retry when one is attached
+            result = await llm.generate(
+                messages=[{"role": "user", "content": merge_prompt}]
+            )
+            epoch_text = self._clip(result.get("content", ""), 2000)
+        except Exception as e:
+            # A failed merge must not cost memory — keep entries, retry later.
+            logger.warning(f"LTM epoch merge failed ({e}) — keeping entries for retry")
+            return False
+
+        # Archive the merged-away originals before replacing them.
+        ltm_archive = state.internal_variables.setdefault("_archived_ltm", [])
+        ltm_archive.extend(
+            i if isinstance(i, dict) else {"summary": str(i)} for i in oldest
+        )
+        if len(ltm_archive) > self.config.archive_window:
+            del ltm_archive[:-self.config.archive_window]
+
+        epoch = {
+            "summary": (
+                f"[gen-{generation} epoch summary of {len(oldest)} older memories "
+                f"— originals archived] {epoch_text}"
+            ),
+            "generation": generation,
+            "merged_entries": len(oldest),
+            "archived": True,
+            "timestamp": time.time(),
+        }
+        state.internal_variables["long_term_memory"] = [epoch] + newest
+
+        stats = state.internal_variables.setdefault(
+            "compression_stats",
+            {"cycles": 0, "turns_compressed": 0, "epochs": 0, "max_generation": 1},
+        )
+        stats["epochs"] += 1
+        stats["max_generation"] = max(stats.get("max_generation", 1), generation)
+        logger.info(
+            f"LTM compacted: {len(oldest)} entries merged into gen-{generation} epoch"
+        )
         return True
 
     # ------------------------------------------------------------------

--- a/tests/test_context_manager.py
+++ b/tests/test_context_manager.py
@@ -412,3 +412,134 @@ class TestZeroLossSummarization:
         await cm._summarize_state(state, llm)
         # save_checkpoint calls model_dump_json — must not raise
         _json.loads(state.model_dump_json())
+
+
+# ======================================================================
+# Issue #69: generational compaction — LTM is bounded, collapse is not
+# ======================================================================
+
+def _ltm_entry(i, generation=1):
+    return {
+        "summary": f"[lossy summary of 3 turns — originals archived] discovered fact {i}",
+        "generation": generation,
+        "turns_compressed": 3,
+        "archived": True,
+        "timestamp": 1000.0 + i,
+    }
+
+
+class TestGenerationalCompaction:
+
+    @pytest.mark.asyncio
+    async def test_ltm_under_window_is_untouched(self):
+        cm = ContextManager(BudgetConfig(ltm_window=20))
+        state = _kernel_state()
+        state.internal_variables["long_term_memory"] = [_ltm_entry(i) for i in range(20)]
+        llm = MagicMock()
+        llm.generate = AsyncMock(return_value={"content": "merged"})
+
+        assert await cm._compact_ltm(state, llm) is False
+        assert len(state.internal_variables["long_term_memory"]) == 20
+        llm.generate.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_overflow_merges_only_the_oldest_half(self):
+        cm = ContextManager(BudgetConfig(ltm_window=20))
+        state = _kernel_state()
+        state.internal_variables["long_term_memory"] = [_ltm_entry(i) for i in range(21)]
+        llm = MagicMock()
+        llm.generate = AsyncMock(return_value={"content": "dense epoch record"})
+
+        assert await cm._compact_ltm(state, llm) is True
+
+        ltm = state.internal_variables["long_term_memory"]
+        # 21 entries → oldest 10 merged into 1 epoch + 11 untouched
+        assert len(ltm) == 12
+        epoch = ltm[0]
+        assert epoch["generation"] == 2
+        assert epoch["merged_entries"] == 10
+        assert epoch["summary"].startswith("[gen-2 epoch summary of 10 older memories")
+        # Newest entries are verbatim — never rewritten (anti context-collapse)
+        assert ltm[1] == _ltm_entry(10)
+        assert ltm[-1] == _ltm_entry(20)
+
+    @pytest.mark.asyncio
+    async def test_merging_epochs_increments_the_generation(self):
+        cm = ContextManager(BudgetConfig(ltm_window=4))
+        state = _kernel_state()
+        state.internal_variables["long_term_memory"] = (
+            [_ltm_entry(0, generation=2)] + [_ltm_entry(i) for i in range(1, 5)]
+        )
+        llm = MagicMock()
+        llm.generate = AsyncMock(return_value={"content": "gen3 record"})
+
+        await cm._compact_ltm(state, llm)
+        assert state.internal_variables["long_term_memory"][0]["generation"] == 3
+
+    @pytest.mark.asyncio
+    async def test_merged_entries_are_archived_first(self):
+        cm = ContextManager(BudgetConfig(ltm_window=4))
+        state = _kernel_state()
+        state.internal_variables["long_term_memory"] = [_ltm_entry(i) for i in range(5)]
+        llm = MagicMock()
+        llm.generate = AsyncMock(return_value={"content": "epoch"})
+
+        await cm._compact_ltm(state, llm)
+        archived = state.internal_variables["_archived_ltm"]
+        assert [a["summary"] for a in archived] == [
+            _ltm_entry(0)["summary"], _ltm_entry(1)["summary"]
+        ]
+
+    @pytest.mark.asyncio
+    async def test_failed_merge_keeps_memory_intact(self):
+        cm = ContextManager(BudgetConfig(ltm_window=4))
+        state = _kernel_state()
+        entries = [_ltm_entry(i) for i in range(6)]
+        state.internal_variables["long_term_memory"] = list(entries)
+        llm = MagicMock()
+        llm.generate = AsyncMock(side_effect=RuntimeError("provider down"))
+
+        assert await cm._compact_ltm(state, llm) is False
+        assert state.internal_variables["long_term_memory"] == entries
+        assert "_archived_ltm" not in state.internal_variables
+
+    @pytest.mark.asyncio
+    async def test_merge_prompt_is_recall_first(self):
+        cm = ContextManager(BudgetConfig(ltm_window=4))
+        state = _kernel_state()
+        state.internal_variables["long_term_memory"] = [_ltm_entry(i) for i in range(5)]
+        llm = MagicMock()
+        llm.generate = AsyncMock(return_value={"content": "epoch"})
+
+        await cm._compact_ltm(state, llm)
+        prompt = llm.generate.call_args.kwargs["messages"][0]["content"]
+        assert "preserve every decision, discovery, error" in prompt
+        assert "discovered fact 0" in prompt
+
+    @pytest.mark.asyncio
+    async def test_full_cycle_updates_compression_stats(self):
+        cm = _compressing_cm()
+        state = _state_ready_to_compress()
+        llm = MagicMock()
+        llm.generate = AsyncMock(return_value={"content": "- ok"})
+
+        await cm._summarize_state(state, llm)
+        stats = state.internal_variables["compression_stats"]
+        assert stats["cycles"] == 1
+        assert stats["turns_compressed"] == 3
+        assert stats["max_generation"] >= 1
+
+
+class TestLtmRenderOverflow:
+
+    def test_hidden_ltm_entries_are_announced(self, big_cm):
+        state = _kernel_state()
+        state.internal_variables["long_term_memory"] = [_ltm_entry(i) for i in range(9)]
+        rendered = big_cm.build_context(state)
+        assert "…and 4 older memories not shown" in rendered
+
+    def test_no_notice_at_or_under_render_limit(self, big_cm):
+        state = _kernel_state()
+        state.internal_variables["long_term_memory"] = [_ltm_entry(i) for i in range(5)]
+        rendered = big_cm.build_context(state)
+        assert "older memories not shown" not in rendered


### PR DESCRIPTION
Fixes #69. Stacked on #67 (which stacks on #65) — merge order: #65 → #67 → this.

## The research this taps

- **ACE — Agentic Context Engineering (ICLR 2026, arXiv:2510.04618):** iterative context rewriting suffers *context collapse* (detail erodes over repeated summarization) and *brevity bias* (concision drops domain insight). Remedy: incremental, structured accumulation — never monolithic rewrite.
- **Anthropic, "Effective context engineering for AI agents":** context is a finite attention budget subject to *context rot*; compaction prompts should be tuned **recall-first**; the safest compression keeps references retrievable rather than destroying raw material.

## What this implements

**Generational compaction** for `long_term_memory`, which previously grew without bound (every compaction cycle appends forever) while silently rendering only the last 5:

1. **Bounded**: at `ltm_window` (20), the oldest half merges into ONE epoch summary. The newest entries are **never rewritten** — fidelity decays monotonically with age; recent memory stays verbatim. Merging epochs into epochs increments an explicit `generation` counter, so second-order compression is visible, not accidental.
2. **Recall-first merge prompt** per Anthropic's guidance: "preserve every decision, discovery, error, and open question — drop only redundancy."
3. **Archive before merge** (extends #67's principle): merged-away entries land in bounded `_archived_ltm`; a failed merge keeps memory intact and retries later.
4. **Named render overflow** (parity with #56): "…and N older memories not shown" replaces the silent `[-5:]`.
5. **`compression_stats` telemetry** (cycles / turns compressed / epochs / max generation) — users watching for "unbounded context bloat" can now *see* entropy being managed.

## Growth math

Before: LTM entries = O(compaction cycles) — unbounded.
After: LTM ≤ `ltm_window` entries always; information decays as summaries-of-summaries only for the oldest generation band, with originals archived and the whole chain labeled. Checkpoint size becomes O(1) in dispatch length for the memory block.

## Non-breaking

- All new `BudgetConfig` fields have safe defaults; behavior below `ltm_window` is unchanged.
- Entries gain a `generation` field; existing readers of `summary`/`timestamp` are unaffected.
- 9 new tests; 85 adjacent tests pass unchanged.
