### PR TITLE
feat(mesh): mesh.fanout() — dynamic fan-out with explicit aggregation (#52)

### DIFF
--- a/jarviscore/core/mesh.py
+++ b/jarviscore/core/mesh.py
@@ -557,7 +557,7 @@ class Mesh:
                 concurrency=5,
                 budget=20,
             )
-            theses = [r["payload"] for r in result.succeeded]
+            theses = [r["output"] for r in result.succeeded]
         """
         if not self._started:
             raise RuntimeError("Mesh not started. Call await mesh.start() first.")

--- a/jarviscore/core/mesh.py
+++ b/jarviscore/core/mesh.py
@@ -1200,7 +1200,7 @@ class Mesh:
         Get first agent by role.
 
         If multiple agents share the same role, returns the first registered agent.
-        Use get_agents_by_role() to get all agents with a specific role.
+        Use get_agents_by_capability() to query agents by capability tag.
 
         Args:
             role: Agent role identifier

--- a/jarviscore/core/mesh.py
+++ b/jarviscore/core/mesh.py
@@ -504,6 +504,80 @@ class Mesh:
         self._logger.info("Executing workflow: %s (%d steps)", workflow_id, len(steps))
         return await self._workflow_engine.execute(workflow_id, steps)
 
+    async def fanout(
+        self,
+        fanout_id: str,
+        *,
+        agent: str,
+        items: Any,
+        task: Any,
+        context: Any = None,
+        concurrency: int = 5,
+        budget: Optional[int] = None,
+        on_error: str = "collect",
+        timeout: Optional[float] = None,
+    ):
+        """
+        Dynamic fan-out: run one task template over N runtime items with
+        bounded concurrency, and aggregate the results explicitly.
+
+        Where workflow() executes a DAG declared upfront, fanout() handles
+        the map-shape agent systems hit constantly — scan results, file
+        lists, symbol boards — where N is data, not authorship (issue #52).
+
+        Args:
+            fanout_id:   Unique id; namespaces every item's step identity so
+                         concurrent items cannot cross-contaminate.
+            agent:       Role or capability that executes each item.
+            items:       Iterable of items — the dynamic N. Order defines
+                         result order.
+            task:        Task string, or callable ``item -> str``.
+            context:     Static dict, or callable ``item -> dict``.
+            concurrency: Max items in flight (default 5). Always bounded.
+            budget:      Optional cap on items attempted; the remainder is
+                         reported in ``result.skipped``, never dropped silently.
+            on_error:    "collect" (default) — failures land in ``result.failed``
+                         and the rest continue; "fail_fast" — first failure
+                         cancels pending items.
+            timeout:     Optional per-item timeout in seconds.
+
+        Returns:
+            FanoutResult with ``.results`` (item order, each stamped with
+            ``item`` and ``step_id``), ``.succeeded``/``.failed`` views,
+            ``.skipped``, and explicit reduce helpers ``.aggregate(fn)`` /
+            ``.summarize(llm, prompt)``.
+
+        Example:
+            result = await mesh.fanout(
+                "board-scan",
+                agent="analyst",
+                items=symbols,
+                task=lambda s: f"Deep-read {s} and return a thesis JSON.",
+                context=lambda s: {"symbol": s},
+                concurrency=5,
+                budget=20,
+            )
+            theses = [r["payload"] for r in result.succeeded]
+        """
+        if not self._started:
+            raise RuntimeError("Mesh not started. Call await mesh.start() first.")
+
+        from jarviscore.orchestration.fanout import run_fanout
+
+        self._logger.info("Executing fanout: %s (agent=%s)", fanout_id, agent)
+        return await run_fanout(
+            fanout_id=fanout_id,
+            find_agent=self._find_agent_for_step,
+            agent=agent,
+            items=items,
+            task=task,
+            context=context,
+            concurrency=concurrency,
+            budget=budget,
+            on_error=on_error,
+            timeout=timeout,
+        )
+
     async def serve_forever(self):
         """
         Run mesh as a service (distributed mode only).

--- a/jarviscore/docs/guides/workflows.md
+++ b/jarviscore/docs/guides/workflows.md
@@ -213,6 +213,37 @@ The `market_research` and `competitor_scan` steps are dispatched simultaneously.
 
 ---
 
+## Dynamic Fan-Out: `mesh.fanout()`
+
+Workflow DAGs are declared upfront — the right tool when the step list is known at authoring time. When N is **data** (scan results, file lists, symbol boards), use `mesh.fanout()` to run one task template over runtime items with bounded concurrency:
+
+```python
+result = await mesh.fanout(
+    "board-scan",
+    agent="analyst",                       # role or capability
+    items=symbols,                         # the dynamic N
+    task=lambda s: f"Deep-read {s} and return a thesis JSON.",
+    context=lambda s: {"symbol": s},       # per-item context (or a static dict)
+    concurrency=5,                         # always bounded
+    budget=20,                             # optional cap; the rest → result.skipped
+    on_error="collect",                    # or "fail_fast"
+    timeout=120,                           # optional per-item seconds
+)
+
+theses = [r["payload"] for r in result.succeeded]
+errors = result.failed                     # honest per-item errors
+brief  = await result.summarize(llm, "Synthesize the board read.")
+```
+
+Guarantees:
+
+- **Identity by construction** — every item runs under a namespaced step id and every result is stamped with `item` + `step_id`; concurrent items cannot cross-contaminate.
+- **Results in item order**, always — aggregation never guesses by position.
+- **Partial failure is first-class** — one bad item never voids the rest in `collect` mode; `fail_fast` cancels pending items while keeping finished results.
+- **Nothing silent** — budget-skipped items are reported; `summarize()` shows the LLM clipped evidence *with markers* plus every failure.
+
+---
+
 ## Accessing redis_store from an Agent
 
 `self._redis_store` is the `RedisContextStore` instance injected by the Mesh at setup time. It is `None` if Redis is not configured. Pass it to `register()` and `execute()`:

--- a/jarviscore/docs/guides/workflows.md
+++ b/jarviscore/docs/guides/workflows.md
@@ -230,10 +230,18 @@ result = await mesh.fanout(
     timeout=120,                           # optional per-item seconds
 )
 
-theses = [r["payload"] for r in result.succeeded]
+theses = [r["output"] for r in result.succeeded]
 errors = result.failed                     # per-item errors
 brief  = await result.summarize(llm, "Synthesize the board read.")
 ```
+
+Each result dict has this shape:
+
+```python
+{"status": "success", "output": {...}, "item": "AAPL", "step_id": "board-scan:0000-aapl"}
+```
+
+The agent's returned value is under `output`. `item` is the input that produced this result, and `step_id` is its unique namespaced identity.
 
 What you can rely on:
 

--- a/jarviscore/docs/guides/workflows.md
+++ b/jarviscore/docs/guides/workflows.md
@@ -215,32 +215,32 @@ The `market_research` and `competitor_scan` steps are dispatched simultaneously.
 
 ## Dynamic Fan-Out: `mesh.fanout()`
 
-Workflow DAGs are declared upfront — the right tool when the step list is known at authoring time. When N is **data** (scan results, file lists, symbol boards), use `mesh.fanout()` to run one task template over runtime items with bounded concurrency:
+A workflow declares its steps upfront. That works when you know the step list while writing the code. Sometimes you only learn how many items there are at runtime: search results, a list of files, a board of symbols. For that case, use `mesh.fanout()`. It runs one task template over each item, a few at a time, and collects the results.
 
 ```python
 result = await mesh.fanout(
     "board-scan",
     agent="analyst",                       # role or capability
-    items=symbols,                         # the dynamic N
+    items=symbols,                         # your runtime list
     task=lambda s: f"Deep-read {s} and return a thesis JSON.",
     context=lambda s: {"symbol": s},       # per-item context (or a static dict)
-    concurrency=5,                         # always bounded
-    budget=20,                             # optional cap; the rest → result.skipped
+    concurrency=5,                         # how many run at once
+    budget=20,                             # optional cap on items attempted
     on_error="collect",                    # or "fail_fast"
     timeout=120,                           # optional per-item seconds
 )
 
 theses = [r["payload"] for r in result.succeeded]
-errors = result.failed                     # honest per-item errors
+errors = result.failed                     # per-item errors
 brief  = await result.summarize(llm, "Synthesize the board read.")
 ```
 
-Guarantees:
+What you can rely on:
 
-- **Identity by construction** — every item runs under a namespaced step id and every result is stamped with `item` + `step_id`; concurrent items cannot cross-contaminate.
-- **Results in item order**, always — aggregation never guesses by position.
-- **Partial failure is first-class** — one bad item never voids the rest in `collect` mode; `fail_fast` cancels pending items while keeping finished results.
-- **Nothing silent** — budget-skipped items are reported; `summarize()` shows the LLM clipped evidence *with markers* plus every failure.
+- Every result carries its `item` and a unique `step_id`. Items that run at the same time cannot mix up each other's results.
+- `result.results` is always in the same order as your `items` list.
+- One failed item does not stop the others. In `collect` mode (the default) failures land in `result.failed` with their error messages. In `fail_fast` mode the first failure cancels the items that have not started yet, and finished results are kept.
+- Nothing is dropped silently. Items skipped by `budget` are listed in `result.skipped`. When `summarize()` has to shorten an item's output for the LLM, it marks the cut and includes every failure in the evidence.
 
 ---
 

--- a/jarviscore/orchestration/fanout.py
+++ b/jarviscore/orchestration/fanout.py
@@ -17,7 +17,7 @@ lists, symbol boards — where N is data, not authorship:
         concurrency=5,
         budget=20,
     )
-    theses = [r["payload"] for r in result.succeeded]
+    theses = [r["output"] for r in result.succeeded]
 
 Design rules (learned in production, see #52/#53/#54):
 - Identity by construction: every item runs under a namespaced workflow/step

--- a/jarviscore/orchestration/fanout.py
+++ b/jarviscore/orchestration/fanout.py
@@ -1,0 +1,230 @@
+"""
+jarviscore.orchestration.fanout
+================================
+Dynamic fan-out: run one task template over N runtime-determined items with
+bounded concurrency, and aggregate the results explicitly (issue #52).
+
+Where ``mesh.workflow()`` executes a DAG declared upfront, ``mesh.fanout()``
+handles the map-shape that agent systems hit constantly — scan results, file
+lists, symbol boards — where N is data, not authorship:
+
+    result = await mesh.fanout(
+        "board-scan",
+        agent="analyst",
+        items=symbols,
+        task=lambda s: f"Deep-read {s} on H1 and return a thesis JSON.",
+        context=lambda s: {"symbol": s},
+        concurrency=5,
+        budget=20,
+    )
+    theses = [r["payload"] for r in result.succeeded]
+
+Design rules (learned in production, see #52/#53/#54):
+- Identity by construction: every item runs under a namespaced workflow/step
+  id and every result is stamped with ``item`` and ``step_id`` — concurrent
+  items cannot cross-contaminate, and aggregation is by identity, not order
+  guessing.
+- Bounded concurrency and an optional item budget — fan-out without a
+  ceiling is a cost and latency grenade.
+- Partial failure is a first-class outcome: one bad item never voids the
+  rest; ``.failed`` carries honest per-item errors.
+- Aggregation is explicit and lossless by default: full results in item
+  order; the reduce step is the caller's choice.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import re
+import time
+from dataclasses import dataclass, field
+from typing import Any, Callable, Dict, Iterable, List, Optional, Union
+
+logger = logging.getLogger(__name__)
+
+_SLUG_RE = re.compile(r"[^a-zA-Z0-9_.-]+")
+
+
+def _slug(item: Any, index: int) -> str:
+    """Stable, filesystem/redis-safe identity slug for one item."""
+    text = _SLUG_RE.sub("-", str(item))[:48].strip("-") or "item"
+    return f"{index:04d}-{text}"
+
+
+@dataclass
+class FanoutResult:
+    """The outcome of one fan-out: full results in item order, plus views.
+
+    Attributes:
+        fanout_id: The id the fan-out ran under.
+        results:   One result dict per attempted item, in ITEM ORDER. Every
+                   dict carries ``item``, ``step_id``, and ``status``.
+        skipped:   Items not attempted (budget cap), in item order.
+        elapsed_ms: Wall time for the whole fan-out.
+    """
+
+    fanout_id: str
+    results: List[Dict[str, Any]] = field(default_factory=list)
+    skipped: List[Any] = field(default_factory=list)
+    elapsed_ms: float = 0.0
+
+    @property
+    def succeeded(self) -> List[Dict[str, Any]]:
+        """Results whose status is success, in item order."""
+        return [r for r in self.results if r.get("status") == "success"]
+
+    @property
+    def failed(self) -> List[Dict[str, Any]]:
+        """Results that errored, in item order — honest per-item errors."""
+        return [r for r in self.results if r.get("status") != "success"]
+
+    def aggregate(self, fn: Callable[[List[Dict[str, Any]]], Any]) -> Any:
+        """Deterministic reduce over the SUCCESSFUL results."""
+        return fn(self.succeeded)
+
+    async def summarize(
+        self,
+        llm: Any,
+        prompt: str,
+        *,
+        evidence_limit: int = 800,
+    ) -> str:
+        """LLM reduce: one completion over per-item evidence windows.
+
+        Evidence follows the honest-context rules: each item contributes up
+        to ``evidence_limit`` chars WITH an explicit truncation marker when
+        clipped — a summarizer that cannot see the evidence confabulates
+        (see #59). Failures are listed so the summary reflects reality.
+        """
+        lines: List[str] = []
+        for r in self.succeeded:
+            payload = r.get("payload", r.get("output"))
+            text = str(payload)
+            if len(text) > evidence_limit:
+                text = (
+                    f"{text[:evidence_limit]}"
+                    f"…[truncated: showing {evidence_limit} of {len(text)} chars]"
+                )
+            lines.append(f"- {r['item']}: {text}")
+        for r in self.failed:
+            lines.append(f"- {r['item']}: FAILED — {str(r.get('error', 'unknown'))[:200]}")
+        if self.skipped:
+            lines.append(f"- ({len(self.skipped)} items skipped by budget: {self.skipped})")
+
+        response = await llm.generate(
+            messages=[{
+                "role": "user",
+                "content": f"{prompt}\n\nResults ({len(self.results)} items):\n" + "\n".join(lines),
+            }]
+        )
+        return (response.get("content") or "").strip()
+
+    def to_dict(self) -> Dict[str, Any]:
+        """JSON-safe snapshot for logging/persistence."""
+        return {
+            "fanout_id": self.fanout_id,
+            "total": len(self.results),
+            "succeeded": len(self.succeeded),
+            "failed": len(self.failed),
+            "skipped": len(self.skipped),
+            "elapsed_ms": round(self.elapsed_ms, 1),
+        }
+
+
+async def run_fanout(
+    *,
+    fanout_id: str,
+    find_agent: Callable[[Dict[str, Any]], Optional[Any]],
+    agent: str,
+    items: Iterable[Any],
+    task: Union[str, Callable[[Any], str]],
+    context: Optional[Union[Dict[str, Any], Callable[[Any], Dict[str, Any]]]] = None,
+    concurrency: int = 5,
+    budget: Optional[int] = None,
+    on_error: str = "collect",
+    timeout: Optional[float] = None,
+) -> FanoutResult:
+    """Execute one task template over N items with bounded concurrency.
+
+    Args:
+        fanout_id:   Unique id; namespaces every item's workflow/step ids.
+        find_agent:  Resolver from a step spec to an agent (the mesh's claimer).
+        agent:       Role or capability to execute each item.
+        items:       The dynamic N. Materialized once; order defines result order.
+        task:        Task string, or ``item -> str`` template.
+        context:     Static dict, or ``item -> dict`` for per-item context.
+        concurrency: Max items in flight (>=1). Fan-out is always bounded.
+        budget:      Optional cap on items attempted; the rest are ``skipped``
+                     honestly, never silently dropped.
+        on_error:    "collect" (default): failures land in ``.failed`` and the
+                     rest continue. "fail_fast": first failure cancels pending
+                     items (already-finished results are kept).
+        timeout:     Optional per-item timeout in seconds.
+
+    Returns:
+        FanoutResult — results in item order, each stamped with item + step_id.
+    """
+    if concurrency < 1:
+        raise ValueError("concurrency must be >= 1")
+    if on_error not in ("collect", "fail_fast"):
+        raise ValueError('on_error must be "collect" or "fail_fast"')
+
+    all_items = list(items)
+    attempted = all_items if budget is None else all_items[:budget]
+    skipped = [] if budget is None else all_items[budget:]
+
+    semaphore = asyncio.Semaphore(concurrency)
+    fail_fast_tripped = asyncio.Event()
+    started = time.monotonic()
+
+    async def _run_one(index: int, item: Any) -> Dict[str, Any]:
+        step_id = f"{fanout_id}:{_slug(item, index)}"
+        base: Dict[str, Any] = {
+            "item": item,
+            "step_id": step_id,
+            "status": "failure",
+        }
+        if fail_fast_tripped.is_set():
+            return {**base, "error": "cancelled: fail_fast tripped by an earlier item"}
+        async with semaphore:
+            if fail_fast_tripped.is_set():
+                return {**base, "error": "cancelled: fail_fast tripped by an earlier item"}
+            task_text = task(item) if callable(task) else str(task)
+            item_ctx = dict(context(item)) if callable(context) else dict(context or {})
+            item_ctx.setdefault("workflow_id", fanout_id)
+            item_ctx["step_id"] = step_id
+            item_ctx["fanout_item"] = item
+
+            resolved = find_agent({"agent": agent, "task": task_text})
+            if resolved is None:
+                result = {**base, "error": f"No agent found for {agent!r}"}
+            else:
+                try:
+                    coro = resolved.execute_task({"task": task_text, "context": item_ctx})
+                    raw = await (asyncio.wait_for(coro, timeout) if timeout else coro)
+                    if isinstance(raw, dict):
+                        result = {**raw, **{k: base[k] for k in ("item", "step_id")}}
+                        result.setdefault("status", "success")
+                    else:
+                        result = {**base, "status": "success", "output": raw}
+                except asyncio.TimeoutError:
+                    result = {**base, "error": f"timed out after {timeout}s"}
+                except Exception as exc:  # noqa: BLE001 - per-item failures are data
+                    result = {**base, "error": f"{type(exc).__name__}: {exc}"}
+
+            if result.get("status") != "success" and on_error == "fail_fast":
+                fail_fast_tripped.set()
+            return result
+
+    results = await asyncio.gather(
+        *(_run_one(i, item) for i, item in enumerate(attempted))
+    )
+
+    outcome = FanoutResult(
+        fanout_id=fanout_id,
+        results=list(results),
+        skipped=skipped,
+        elapsed_ms=(time.monotonic() - started) * 1000,
+    )
+    logger.info("Fanout %s complete: %s", fanout_id, outcome.to_dict())
+    return outcome

--- a/tests/test_fanout.py
+++ b/tests/test_fanout.py
@@ -1,0 +1,253 @@
+"""
+Tests for issue #52: mesh.fanout() — dynamic fan-out with explicit aggregation.
+
+What these tests prove:
+- N runtime items execute against one agent with results in ITEM ORDER
+- Every result is stamped with item + step_id (namespaced identity — the
+  #53 contamination class is impossible by construction)
+- Concurrency is genuinely bounded
+- Budget caps attempted items and reports the remainder honestly
+- Partial failure is first-class: .failed carries per-item errors, the
+  rest complete; fail_fast cancels pending items
+- Per-item timeout produces an honest per-item error
+- aggregate() reduces successes deterministically; summarize() builds an
+  honest evidence window (markers on clipped items, failures listed)
+- mesh.fanout() refuses to run before mesh.start()
+"""
+
+import asyncio
+from typing import Any, Dict
+
+import pytest
+
+from jarviscore import Mesh, MeshMode
+from jarviscore.core.agent import Agent
+from jarviscore.orchestration.fanout import FanoutResult, run_fanout
+
+
+# ── Agents ────────────────────────────────────────────────────────────────────
+
+class AnalystAgent(Agent):
+    role = "analyst"
+    capabilities = ["analysis"]
+
+    async def execute_task(self, task: Dict[str, Any]) -> Dict[str, Any]:
+        ctx = task.get("context", {})
+        return {"status": "success", "payload": {"read": ctx.get("fanout_item")}}
+
+
+class FlakyAgent(Agent):
+    role = "flaky"
+    capabilities = ["flaky"]
+
+    async def execute_task(self, task: Dict[str, Any]) -> Dict[str, Any]:
+        item = task.get("context", {}).get("fanout_item")
+        if item == "bad":
+            raise RuntimeError("boom on bad item")
+        return {"status": "success", "payload": item}
+
+
+class ConcurrencyProbe(Agent):
+    role = "probe"
+    capabilities = ["probe"]
+    in_flight = 0
+    max_seen = 0
+
+    async def execute_task(self, task: Dict[str, Any]) -> Dict[str, Any]:
+        cls = type(self)
+        cls.in_flight += 1
+        cls.max_seen = max(cls.max_seen, cls.in_flight)
+        await asyncio.sleep(0.05)
+        cls.in_flight -= 1
+        return {"status": "success", "payload": "ok"}
+
+
+class SlowAgent(Agent):
+    role = "slow"
+    capabilities = ["slow"]
+
+    async def execute_task(self, task: Dict[str, Any]) -> Dict[str, Any]:
+        await asyncio.sleep(5)
+        return {"status": "success"}
+
+
+async def _with_mesh(agent_cls, coro_fn):
+    mesh = Mesh(mode=MeshMode.AUTONOMOUS)
+    mesh.add(agent_cls)
+    await mesh.start()
+    try:
+        return await coro_fn(mesh)
+    finally:
+        await mesh.stop()
+
+
+# ── Core behavior ─────────────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+class TestFanoutCore:
+
+    async def test_results_in_item_order_with_identity(self):
+        symbols = ["EURUSD", "XAUUSD", "JP225"]
+
+        async def run(mesh):
+            return await mesh.fanout(
+                "scan-1", agent="analyst", items=symbols,
+                task=lambda s: f"Read {s}", context=lambda s: {"symbol": s},
+            )
+
+        result = await _with_mesh(AnalystAgent, run)
+
+        assert [r["item"] for r in result.results] == symbols
+        assert [r["payload"]["read"] for r in result.results] == symbols
+        assert all(r["status"] == "success" for r in result.results)
+        # Namespaced identity: unique step ids under the fanout id
+        step_ids = [r["step_id"] for r in result.results]
+        assert len(set(step_ids)) == 3
+        assert all(sid.startswith("scan-1:") for sid in step_ids)
+
+    async def test_static_task_and_context(self):
+        async def run(mesh):
+            return await mesh.fanout(
+                "scan-2", agent="analyst", items=["a", "b"],
+                task="Read the item in context", context={"static": True},
+            )
+
+        result = await _with_mesh(AnalystAgent, run)
+        assert len(result.succeeded) == 2
+
+    async def test_fanout_before_start_is_a_loud_error(self):
+        mesh = Mesh(mode=MeshMode.AUTONOMOUS)
+        mesh.add(AnalystAgent)
+        with pytest.raises(RuntimeError, match="mesh.start"):
+            await mesh.fanout("x", agent="analyst", items=["a"], task="t")
+
+
+@pytest.mark.asyncio
+class TestBoundsAndBudget:
+
+    async def test_concurrency_is_bounded(self):
+        ConcurrencyProbe.in_flight = 0
+        ConcurrencyProbe.max_seen = 0
+
+        async def run(mesh):
+            return await mesh.fanout(
+                "probe-1", agent="probe", items=list(range(12)),
+                task="go", concurrency=3,
+            )
+
+        result = await _with_mesh(ConcurrencyProbe, run)
+        assert len(result.succeeded) == 12
+        assert ConcurrencyProbe.max_seen <= 3
+
+    async def test_budget_skips_honestly(self):
+        async def run(mesh):
+            return await mesh.fanout(
+                "scan-3", agent="analyst", items=["a", "b", "c", "d", "e"],
+                task="read", budget=2,
+            )
+
+        result = await _with_mesh(AnalystAgent, run)
+        assert len(result.results) == 2
+        assert result.skipped == ["c", "d", "e"]
+
+    async def test_per_item_timeout_is_an_honest_error(self):
+        async def run(mesh):
+            return await mesh.fanout(
+                "slow-1", agent="slow", items=["x"], task="go", timeout=0.05,
+            )
+
+        result = await _with_mesh(SlowAgent, run)
+        assert len(result.failed) == 1
+        assert "timed out" in result.failed[0]["error"]
+
+
+@pytest.mark.asyncio
+class TestPartialFailure:
+
+    async def test_collect_mode_keeps_the_rest(self):
+        async def run(mesh):
+            return await mesh.fanout(
+                "flaky-1", agent="flaky", items=["good1", "bad", "good2"],
+                task="go",
+            )
+
+        result = await _with_mesh(FlakyAgent, run)
+        assert [r["item"] for r in result.succeeded] == ["good1", "good2"]
+        assert len(result.failed) == 1
+        assert result.failed[0]["item"] == "bad"
+        assert "boom on bad item" in result.failed[0]["error"]
+
+    async def test_fail_fast_cancels_pending(self):
+        items = ["bad"] + [f"g{i}" for i in range(10)]
+
+        async def run(mesh):
+            return await mesh.fanout(
+                "flaky-2", agent="flaky", items=items,
+                task="go", concurrency=1, on_error="fail_fast",
+            )
+
+        result = await _with_mesh(FlakyAgent, run)
+        cancelled = [r for r in result.failed if "cancelled" in r.get("error", "")]
+        assert len(cancelled) >= 1  # pending items were not run
+
+    async def test_unknown_agent_is_a_per_item_error(self):
+        async def run(mesh):
+            return await mesh.fanout(
+                "ghost-1", agent="nonexistent", items=["a"], task="go",
+            )
+
+        result = await _with_mesh(AnalystAgent, run)
+        assert "No agent found" in result.failed[0]["error"]
+
+
+# ── Aggregation ───────────────────────────────────────────────────────────────
+
+class TestAggregation:
+
+    def _made(self):
+        return FanoutResult(
+            fanout_id="f",
+            results=[
+                {"item": "a", "step_id": "f:0000-a", "status": "success", "payload": 1},
+                {"item": "b", "step_id": "f:0001-b", "status": "failure", "error": "x"},
+                {"item": "c", "step_id": "f:0002-c", "status": "success", "payload": 2},
+            ],
+            skipped=["d"],
+        )
+
+    def test_aggregate_reduces_successes(self):
+        total = self._made().aggregate(lambda rs: sum(r["payload"] for r in rs))
+        assert total == 3
+
+    @pytest.mark.asyncio
+    async def test_summarize_builds_an_honest_evidence_window(self):
+        captured = {}
+
+        class _LLM:
+            async def generate(self, messages):
+                captured["prompt"] = messages[0]["content"]
+                return {"content": "the summary"}
+
+        result = FanoutResult(
+            fanout_id="f",
+            results=[
+                {"item": "a", "step_id": "f:0", "status": "success", "payload": "Z" * 2000},
+                {"item": "b", "step_id": "f:1", "status": "failure", "error": "broke"},
+            ],
+            skipped=["c"],
+        )
+        out = await result.summarize(_LLM(), "Synthesize the board read.")
+        assert out == "the summary"
+        prompt = captured["prompt"]
+        assert "…[truncated: showing 800 of 2000 chars]" in prompt  # honest clip
+        assert "b: FAILED — broke" in prompt                        # failures visible
+        assert "skipped by budget" in prompt                        # skips visible
+
+    def test_run_fanout_validates_inputs(self):
+        with pytest.raises(ValueError, match="concurrency"):
+            asyncio.get_event_loop().run_until_complete(
+                run_fanout(
+                    fanout_id="f", find_agent=lambda s: None, agent="a",
+                    items=[], task="t", concurrency=0,
+                )
+            )


### PR DESCRIPTION
Fixes #52 — the dynamic fan-out / map-reduce primitive, designed from the production audit posted on the issue.

## The API

```python
result = await mesh.fanout(
    "board-scan",
    agent="analyst",
    items=symbols,                          # the dynamic N
    task=lambda s: f"Deep-read {s} and return a thesis JSON.",
    context=lambda s: {"symbol": s},        # or a static dict
    concurrency=5,
    budget=20,                              # optional cap; rest → .skipped
    on_error="collect",                     # or "fail_fast"
    timeout=120,                            # optional per-item seconds
)

theses = [r["payload"] for r in result.succeeded]
worst  = result.failed                      # honest per-item errors
brief  = await result.summarize(llm, "Synthesize the board read.")
```

## The five non-negotiables from the audit, implemented

1. **Identity by construction** — each item runs under `fanout_id:NNNN-slug`; every result is stamped with `item` + `step_id`. Execution goes straight through the claimer to `execute_task`, bypassing the engine's process-global step memory — the #53 cross-contamination class and #54 growth are impossible here *by architecture*, not by discipline.
2. **Always bounded** — semaphore concurrency (default 5) + optional item `budget`; skipped items are reported, never silently dropped.
3. **Partial failure is first-class** — `collect` keeps 39 good reads when 1 breaks; `fail_fast` cancels pending items while keeping finished results. Unknown agents and timeouts are honest per-item errors.
4. **Lossless by default, explicit reduce** — `.results` in item order; `.aggregate(fn)` deterministic; `.summarize(llm, prompt)` builds its evidence window under the honest-context rules (#55/#59): clipped items carry markers, failures and budget-skips are visible to the summarizer.
5. **Loud failures** — `mesh.fanout()` before `mesh.start()` raises immediately; `concurrency=0` and bad `on_error` values are rejected.

## Composition notes

- `FanoutResult.to_dict()` gives a JSON-safe snapshot for run logs.
- Follow-up (#74): a plan step should be able to declare `fanout_over` so goal mode composes with this primitive.

12 tests including a live concurrency-bound probe. Purely additive — no existing API touched except the new method on `Mesh`.
