### PR TITLE
fix(context): GOAL STATE block — plan memory crosses steps structured (#72)

### DIFF
--- a/jarviscore/context/context_manager.py
+++ b/jarviscore/context/context_manager.py
@@ -104,6 +104,9 @@ class BudgetConfig:
     ltm_window: int = 20
     # How many LTM entries the context block renders (was a silent [-5:]).
     ltm_render_limit: int = 5
+    # Token budget for the GOAL STATE block (issue #72) — the accumulated
+    # facts and step history of a goal execution, rendered structured.
+    goal_state_budget: int = 4000
 
     @property
     def usable_tokens(self) -> int:
@@ -185,6 +188,55 @@ class ContextManager:
     # ------------------------------------------------------------------
     # Honest rendering helpers (issues #55, #56)
     # ------------------------------------------------------------------
+
+    def _build_goal_state_block(self, context: Dict[str, Any]) -> str:
+        """Render a goal execution's accumulated state — structured (issue #72).
+
+        Consumes the keys `context_for_next_step()` injects (`_goal`,
+        `_goal_facts`, `_goal_facts_high_confidence`, `_completed_steps`,
+        `_plan_revision`). Returns "" when the agent is not running under a
+        goal — non-goal dispatches see zero change.
+        """
+        goal = context.get("_goal")
+        facts = context.get("_goal_facts")
+        completed = context.get("_completed_steps")
+        if not goal and not facts and not completed:
+            return ""
+
+        lines = ["## GOAL STATE"]
+        if goal:
+            revision = context.get("_plan_revision", 0)
+            rev_note = f" (plan revision {revision})" if revision else ""
+            lines.append(f"**Goal:** {self._clip(goal, 300)}{rev_note}")
+
+        if isinstance(facts, dict) and facts:
+            high_conf = context.get("_goal_facts_high_confidence") or {}
+            lines.append(f"**Established facts ({len(facts)}):**")
+            # High-confidence facts first — they are the plan's load-bearing truth
+            ordered = sorted(facts.items(), key=lambda kv: kv[0] not in high_conf)
+            visible, overflow = self._visible_items(dict(ordered), self.config.state_keys_limit * 2)
+            for key, value in visible:
+                marker = " ✓" if key in high_conf else ""
+                lines.append(f"- `{key}`{marker}: {self._clip(value, self.config.belief_value_limit)}")
+            if overflow:
+                lines.append(overflow.rstrip())
+
+        if isinstance(completed, list) and completed:
+            lines.append(f"**Completed steps ({len(completed)}):**")
+            for cs in completed[-8:]:
+                if isinstance(cs, dict):
+                    sid = cs.get("step_id", "?")
+                    verdict = cs.get("verdict", cs.get("status", "?"))
+                    summary = self._clip(cs.get("summary") or cs.get("task", ""), 160)
+                    lines.append(f"- [{verdict}] `{sid}`: {summary}")
+                else:
+                    lines.append(f"- {self._clip(cs, 160)}")
+            hidden = len(completed) - 8
+            if hidden > 0:
+                lines.append(f"…and {hidden} earlier steps not shown")
+
+        return "\n".join(lines)
+
 
     @staticmethod
     def _clip(value: Any, limit: int) -> str:
@@ -279,6 +331,15 @@ class ContextManager:
             mission += f"**CRITICAL ERROR TO FIX:** {state.last_error}\n"
         _add_block(mission)
 
+        # ═══ BLOCK 1b: GOAL STATE (High Priority — issue #72) ═══
+        # A goal execution's accumulated truth used to reach each step as ONE
+        # generic `_goal_facts: {...}` line clipped at the value limit — the
+        # plan's entire memory in 800 chars. Goal state is mission-level
+        # context: structured, one fact per line, honest overflow.
+        goal_block = self._build_goal_state_block(state.context or {})
+        if goal_block:
+            _add_block(goal_block, max_tokens=self.config.goal_state_budget)
+
         # ═══ BLOCK 2: FAILURE MEMORY (High Priority) ═══
         if state.failure_ledger:
             lines = ["## FAILURE MEMORY (Do Not Repeat)"]
@@ -326,10 +387,14 @@ class ContextManager:
                     output_str = self._clip(output, self.config.prior_step_value_limit)
                     input_block += f"**[Prior Step: {step_id}]**\n{output_str}\n\n"
 
-            # Other context fields (skip internal keys)
+            # Other context fields (skip internal keys; goal keys are
+            # PROMOTED to the GOAL STATE block, not dropped)
             skip_keys = {"previous_step_results", "workflow_id", "step_id",
                           "system_prompt", "_jarvis_context", "_auth_credentials",
-                          "_agent_default_kernel_role"}
+                          "_agent_default_kernel_role",
+                          "_goal", "_goal_id", "_goal_facts",
+                          "_goal_facts_high_confidence", "_completed_steps",
+                          "_plan_revision"}
             other = {k: v for k, v in state.context.items() if k not in skip_keys}
             if other:
                 cleaned = self._scrub_dict(other)

--- a/tests/test_context_manager.py
+++ b/tests/test_context_manager.py
@@ -543,3 +543,73 @@ class TestLtmRenderOverflow:
         state.internal_variables["long_term_memory"] = [_ltm_entry(i) for i in range(5)]
         rendered = big_cm.build_context(state)
         assert "older memories not shown" not in rendered
+
+
+# ======================================================================
+# Issue #72: GOAL STATE block — plan memory crosses steps structured
+# ======================================================================
+
+def _goal_context(n_facts=3, n_steps=2):
+    return {
+        "_goal": "Run the weekly market analysis",
+        "_goal_id": "goal-abc",
+        "_plan_revision": 1,
+        "_goal_facts": {f"fact_{i}": f"value {i}" for i in range(n_facts)},
+        "_goal_facts_high_confidence": {"fact_0": "value 0"},
+        "_completed_steps": [
+            {
+                "step_id": f"step_{i:02d}",
+                "task": f"do thing {i}",
+                "verdict": "pass",
+                "summary": f"did thing {i}",
+            }
+            for i in range(n_steps)
+        ],
+    }
+
+
+class TestGoalStateBlock:
+
+    def test_goal_state_renders_structured(self, big_cm):
+        rendered = big_cm.build_context(_kernel_state(context=_goal_context()))
+        assert "## GOAL STATE" in rendered
+        assert "**Goal:** Run the weekly market analysis (plan revision 1)" in rendered
+        assert "**Established facts (3):**" in rendered
+        assert "- `fact_1`: value 1" in rendered
+        assert "- [pass] `step_01`: did thing 1" in rendered
+
+    def test_high_confidence_facts_render_first_and_marked(self, big_cm):
+        rendered = big_cm.build_context(_kernel_state(context=_goal_context()))
+        assert "- `fact_0` ✓: value 0" in rendered
+        facts_section = rendered.split("**Established facts")[1]
+        assert facts_section.index("fact_0") < facts_section.index("fact_1")
+
+    def test_goal_keys_do_not_leak_into_input_context(self, big_cm):
+        ctx = _goal_context()
+        ctx["normal_key"] = "normal value"
+        rendered = big_cm.build_context(_kernel_state(context=ctx))
+        # Promoted, not duplicated: no generic clipped line for goal keys
+        assert "- `_goal_facts`:" not in rendered
+        assert "- `_completed_steps`:" not in rendered
+        # Ordinary context still renders generically
+        assert "- `normal_key`: normal value" in rendered
+
+    def test_non_goal_dispatch_sees_no_block(self, big_cm):
+        rendered = big_cm.build_context(_kernel_state(context={"plain": "ctx"}))
+        assert "## GOAL STATE" not in rendered
+
+    def test_fact_overflow_is_announced_by_name(self, big_cm):
+        ctx = _goal_context(n_facts=25)
+        rendered = big_cm.build_context(_kernel_state(context=ctx))
+        assert "earlier key(s) not shown" in rendered
+
+    def test_step_overflow_is_announced(self, big_cm):
+        ctx = _goal_context(n_steps=12)
+        rendered = big_cm.build_context(_kernel_state(context=ctx))
+        assert "…and 4 earlier steps not shown" in rendered
+
+    def test_long_fact_values_carry_markers(self, big_cm):
+        ctx = _goal_context()
+        ctx["_goal_facts"]["huge"] = "H" * 900
+        rendered = big_cm.build_context(_kernel_state(context=ctx))
+        assert "…[truncated: showing 200 of 900 chars]" in rendered


### PR DESCRIPTION
Fixes #72. Stacked on #70 (merge chain: #65 → #67 → #70 → this).

The plan-mode context chain was one clipped 800-char line — see the issue for the audit. Now goal executions get a dedicated block: goal + revision headline, facts one per line (high-confidence first, marked ✓), completed steps as [verdict] step_id: summary, honest markers and named overflow throughout, own token budget. Goal keys are promoted out of the generic context loop, and non-goal dispatches render byte-identically to before (tested). 7 new tests.