### PR TITLE
feat(planning): goal persistence + resume (#73)

### DIFF
--- a/jarviscore/planning/goal_context.py
+++ b/jarviscore/planning/goal_context.py
@@ -76,6 +76,29 @@ class PlannedStep:
             extras["_agent_default_kernel_role"] = self.subagent_hint
         return extras
 
+    def to_dict(self) -> Dict[str, Any]:
+        """JSON-safe serialization for goal persistence (issue #73)."""
+        return {
+            "step_id": self.step_id,
+            "task": self.task,
+            "success_criterion": self.success_criterion,
+            "expected_findings": list(self.expected_findings),
+            "depends_on": list(self.depends_on),
+            "subagent_hint": self.subagent_hint,
+        }
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "PlannedStep":
+        """Rehydrate a step from a persisted snapshot (issue #73)."""
+        return cls(
+            step_id=str(data["step_id"]),
+            task=str(data["task"]),
+            success_criterion=str(data.get("success_criterion", "")),
+            expected_findings=list(data.get("expected_findings") or []),
+            depends_on=list(data.get("depends_on") or []),
+            subagent_hint=data.get("subagent_hint"),
+        )
+
 
 # ── Step evaluation ───────────────────────────────────────────────────────────
 
@@ -132,6 +155,57 @@ class CompletedStep:
             "verdict": self.evaluation.verdict,
             "summary": getattr(self.output, "summary", "")[:300],
         }
+
+
+@dataclass
+class _ResumedStep:
+    """A completed step rehydrated from a persisted snapshot (issue #73).
+
+    Duck-types the parts of CompletedStep that downstream code reads after
+    the fact — ``.step``, ``.evaluation``, ``.elapsed_ms``, ``to_summary()``.
+    The live AgentOutput is gone; its summary survives.
+    """
+    step: PlannedStep
+    verdict: str
+    evaluator_note: str
+    summary: str
+    elapsed_ms: float = 0.0
+
+    @property
+    def evaluation(self) -> Any:
+        from types import SimpleNamespace
+        return SimpleNamespace(
+            verdict=self.verdict,
+            evaluator_note=self.evaluator_note,
+            confidence=0.0,
+        )
+
+    @property
+    def output(self) -> Any:
+        from types import SimpleNamespace
+        return SimpleNamespace(summary=self.summary, metadata={})
+
+    def to_summary(self) -> Dict[str, Any]:
+        return {
+            "step_id": self.step.step_id,
+            "task": self.step.task[:200],
+            "verdict": self.verdict,
+            "summary": self.summary[:300],
+        }
+
+    @classmethod
+    def from_snapshot_entry(cls, entry: Dict[str, Any]) -> "_ResumedStep":
+        return cls(
+            step=PlannedStep(
+                step_id=str(entry.get("step_id", "?")),
+                task=str(entry.get("task", "")),
+                success_criterion="",
+            ),
+            verdict=str(entry.get("verdict", "pass")),
+            evaluator_note=str(entry.get("evaluator_note", "")),
+            summary=str(entry.get("summary", "")),
+            elapsed_ms=float(entry.get("elapsed_ms", 0.0) or 0.0),
+        )
 
 
 # ── Goal execution state ──────────────────────────────────────────────────────
@@ -332,15 +406,52 @@ class GoalExecution:
         """Full serialisable representation for blob persistence / debugging."""
         return {
             **self.to_summary_dict(),
+            "agent_id": self.agent_id,
             "facts": self.truth.to_flat_dict(),
+            "plan": [s.to_dict() for s in self.plan],
+            "truth_facts_full": {
+                k: f.model_dump() for k, f in self.truth.facts.items()
+            },
             "completed_steps": [
                 {
                     "step_id": cs.step.step_id,
                     "task": cs.step.task,
                     "verdict": cs.evaluation.verdict,
                     "evaluator_note": cs.evaluation.evaluator_note,
+                    "summary": str(getattr(cs.output, "summary", "") or "")[:300],
                     "elapsed_ms": round(cs.elapsed_ms, 1),
                 }
                 for cs in self.completed
             ],
         }
+
+    @classmethod
+    def from_snapshot(cls, data: Dict[str, Any]) -> "GoalExecution":
+        """Rehydrate a persisted execution for resume (issue #73).
+
+        Restores the goal, the full plan, the truth facts (with confidence
+        and evidence), and the completed-step history as lightweight records
+        that satisfy everything downstream reads (``.step``, ``.evaluation``,
+        ``.to_summary()``). Live ``AgentOutput`` objects are not — and need
+        not be — reconstructed.
+        """
+        from jarviscore.context.truth import TruthFact
+
+        execution = cls(
+            goal=str(data.get("goal", "")),
+            agent_id=str(data.get("agent_id", "unknown")),
+            goal_id=str(data.get("goal_id") or f"goal-{uuid.uuid4().hex[:10]}"),
+        )
+        execution.plan = [PlannedStep.from_dict(s) for s in data.get("plan") or []]
+        execution.plan_revision = int(data.get("plan_revision", 0))
+        execution.status = str(data.get("status", "planning"))
+
+        for key, fact in (data.get("truth_facts_full") or {}).items():
+            try:
+                execution.truth.facts[key] = TruthFact(**fact)
+            except Exception:  # noqa: BLE001 - a bad fact must not void the rest
+                logger.warning("Skipping unrehydratable fact %r on resume", key)
+
+        for cs in data.get("completed_steps") or []:
+            execution.completed.append(_ResumedStep.from_snapshot_entry(cs))
+        return execution

--- a/jarviscore/profiles/autoagent.py
+++ b/jarviscore/profiles/autoagent.py
@@ -642,6 +642,7 @@ class AutoAgent(Profile):
         context: Optional[Dict[str, Any]] = None,
         max_steps: int = 30,
         max_replan_attempts: Optional[int] = None,
+        resume_goal_id: Optional[str] = None,
     ) -> "GoalExecution":
         """
         Internal method — driven by execute_task() when goal_oriented = True.
@@ -715,33 +716,63 @@ class AutoAgent(Profile):
         planner = Planner(self.llm, system_prompt_excerpt=str(self.system_prompt or "")[:400])
         evaluator = StepEvaluator(self.llm)
 
+        # ── Resume path (issue #73) ──────────────────────────────────────────────
+        # A persisted goal rehydrates: plan, truth facts, completed history.
+        # Execution continues from the first step without a passing verdict.
+        resumed = None
+        if resume_goal_id:
+            resumed = await self._load_goal_snapshot(resume_goal_id)
+            if resumed is None:
+                self._logger.warning(
+                    "[AutoAgent] resume_goal_id=%s: no persisted snapshot found — "
+                    "starting fresh", resume_goal_id,
+                )
+
         # The live execution state — carries the TruthContext across all steps
-        execution = GoalExecution(goal=goal, agent_id=self.agent_id)
+        if resumed is not None:
+            execution = resumed
+            execution.status = "executing"
+            execution.error = None
+            self._logger.info(
+                "[AutoAgent] Resuming goal %s: %d steps done, %d facts restored",
+                execution.goal_id, len(execution.completed), len(execution.truth.facts),
+            )
+        else:
+            execution = GoalExecution(goal=goal, agent_id=self.agent_id)
         replan_count = 0
         steps_run = 0
 
         # ── Phase 1: Plan ─────────────────────────────────────────────────────
-        execution.status = "planning"
-        try:
-            execution.plan = await planner.plan(
-                goal=goal,
-                goal_execution=execution,
-                context=context,
-            )
-        except PlannerError as exc:
-            self._logger.error("[AutoAgent] Planning failed: %s", exc)
-            execution.status = "failed"
-            execution.error = f"Planning failed: {exc}"
-            execution.completed_at = time.time()
-            return execution
+        if resumed is None:
+            execution.status = "planning"
+            try:
+                execution.plan = await planner.plan(
+                    goal=goal,
+                    goal_execution=execution,
+                    context=context,
+                )
+            except PlannerError as exc:
+                self._logger.error("[AutoAgent] Planning failed: %s", exc)
+                execution.status = "failed"
+                execution.error = f"Planning failed: {exc}"
+                execution.completed_at = time.time()
+                await self._persist_goal(execution)
+                return execution
 
-        self._logger.info(
-            "[AutoAgent] Plan ready: %d steps", len(execution.plan)
-        )
-        execution.status = "executing"
+            self._logger.info(
+                "[AutoAgent] Plan ready: %d steps", len(execution.plan)
+            )
+            execution.status = "executing"
+            # Durability: the plan exists before the first step runs
+            await self._persist_goal(execution)
 
         # ── Phase 2: Execute → Evaluate → loop ───────────────────────────────
-        remaining = list(execution.plan)
+        done_ids = {
+            cs.step.step_id
+            for cs in execution.completed
+            if getattr(cs.evaluation, "verdict", "") == "pass"
+        }
+        remaining = [s for s in execution.plan if s.step_id not in done_ids]
 
         while remaining and steps_run < max_steps:
             step = remaining.pop(0)
@@ -811,6 +842,8 @@ class AutoAgent(Profile):
 
             # Record: merges distilled_facts + evaluator findings into truth
             execution.record_completed(step, output, evaluation, elapsed)
+            # Durability: every completed step survives a crash (issue #73)
+            await self._persist_goal(execution)
 
             self._logger.info(
                 "[AutoAgent] Step %s: verdict=%s (confidence=%.2f) — %s",
@@ -946,4 +979,46 @@ class AutoAgent(Profile):
             execution.elapsed_ms,
             goal[:80],
         )
+        # Terminal snapshot — status, result, and full audit trail (issue #73)
+        await self._persist_goal(execution)
         return execution
+
+    # ── Goal persistence (issue #73) ──────────────────────────────────────
+
+    def _goal_blob_path(self, goal_id: str) -> str:
+        return f"goals/{self.agent_id}/{goal_id}.json"
+
+    async def _persist_goal(self, execution: Any) -> None:
+        """Best-effort durability for a goal execution — never fatal.
+
+        Saved after planning, after every completed step, and at terminal
+        states, so a crash mid-goal loses at most the in-flight step. Skipped
+        silently when no blob storage is attached.
+        """
+        blob = getattr(self._kernel, "blob_storage", None) if self._kernel else None
+        if blob is None:
+            return
+        try:
+            import json as _json
+            await blob.save(
+                self._goal_blob_path(execution.goal_id),
+                _json.dumps(execution.to_full_dict(), default=str),
+            )
+        except Exception as exc:  # noqa: BLE001 - durability is best-effort
+            self._logger.debug("[AutoAgent] Goal persist failed (non-fatal): %s", exc)
+
+    async def _load_goal_snapshot(self, goal_id: str) -> Optional[Any]:
+        """Rehydrate a persisted GoalExecution, or None when unavailable."""
+        blob = getattr(self._kernel, "blob_storage", None) if self._kernel else None
+        if blob is None:
+            return None
+        try:
+            import json as _json
+            raw = await blob.read(self._goal_blob_path(goal_id))
+            if not raw:
+                return None
+            from jarviscore.planning.goal_context import GoalExecution
+            return GoalExecution.from_snapshot(_json.loads(raw))
+        except Exception as exc:  # noqa: BLE001 - a bad snapshot must not crash the goal
+            self._logger.warning("[AutoAgent] Goal snapshot load failed: %s", exc)
+            return None

--- a/tests/test_planning.py
+++ b/tests/test_planning.py
@@ -602,3 +602,81 @@ class TestAgentOutputDistilledFacts:
     def test_failure_output_has_no_facts(self):
         out = AgentOutput(status="failure", summary="error occurred")
         assert out.distilled_facts() == {}
+
+
+# ── Issue #73: goal persistence & resume ──────────────────────────────────────
+
+class TestGoalSnapshotRoundTrip:
+
+    def _executed_goal(self):
+        ge = GoalExecution(goal="Analyse the market", agent_id="analyst-1")
+        ge.plan = [_make_step("step_01"), _make_step("step_02", task="Do Y")]
+        ge.plan_revision = 1
+        ge.status = "executing"
+        from jarviscore.context.truth import TruthFact
+        ge.truth.facts["api_auth"] = TruthFact(
+            value="oauth2", source="step_01", confidence=0.95
+        )
+        ge.record_completed(
+            ge.plan[0],
+            _make_output(summary="found the auth method"),
+            _make_evaluation(verdict="pass"),
+            elapsed_ms=120.0,
+        )
+        return ge
+
+    def test_full_dict_is_json_safe_and_carries_the_plan(self):
+        import json
+        ge = self._executed_goal()
+        data = json.loads(json.dumps(ge.to_full_dict(), default=str))
+        assert [s["step_id"] for s in data["plan"]] == ["step_01", "step_02"]
+        assert "truth_facts_full" in data
+        assert data["completed_steps"][0]["summary"] == "found the auth method"
+
+    def test_snapshot_round_trip_restores_plan_facts_and_history(self):
+        import json
+        ge = self._executed_goal()
+        data = json.loads(json.dumps(ge.to_full_dict(), default=str))
+
+        restored = GoalExecution.from_snapshot(data)
+
+        assert restored.goal == "Analyse the market"
+        assert restored.goal_id == ge.goal_id
+        assert restored.agent_id == "analyst-1"
+        assert [s.step_id for s in restored.plan] == ["step_01", "step_02"]
+        assert restored.plan_revision == 1
+        # Facts survive with value + confidence
+        assert restored.truth.facts["api_auth"].value == "oauth2"
+        assert restored.truth.facts["api_auth"].confidence == pytest.approx(0.95)
+        # History survives as duck-typed completed steps
+        assert len(restored.completed) == 1
+        cs = restored.completed[0]
+        assert cs.step.step_id == "step_01"
+        assert cs.evaluation.verdict == "pass"
+        assert cs.to_summary()["summary"] == "found the auth method"
+
+    def test_resumed_context_chains_into_next_step(self):
+        """The restored execution feeds context_for_next_step correctly."""
+        import json
+        ge = self._executed_goal()
+        restored = GoalExecution.from_snapshot(
+            json.loads(json.dumps(ge.to_full_dict(), default=str))
+        )
+        ctx = restored.context_for_next_step()
+        assert ctx["_goal_facts"]["api_auth"] == "oauth2"
+        assert ctx["_completed_steps"][0]["step_id"] == "step_01"
+
+    def test_planned_step_round_trip(self):
+        step = _make_step()
+        restored = PlannedStep.from_dict(step.to_dict())
+        assert restored == step
+
+    def test_bad_fact_is_skipped_not_fatal(self):
+        data = {
+            "goal": "G", "agent_id": "a", "goal_id": "goal-x",
+            "plan": [], "plan_revision": 0, "status": "executing",
+            "truth_facts_full": {"broken": {"not_a_fact_field": 1}},
+            "completed_steps": [],
+        }
+        restored = GoalExecution.from_snapshot(data)
+        assert "broken" not in restored.truth.facts


### PR DESCRIPTION
feat(planning): goal persistence + resume — to_full_dict earns its docstring (#73)

GoalExecution.to_full_dict() advertised "blob persistence" and nothing
called it; a crash on step 7 of 9 lost the plan, the facts, and the
audit trail. The WorkflowEngine has Redis state + resume; the
long-horizon path had nothing.

- Snapshot: to_full_dict() now carries the full plan (PlannedStep
  to_dict/from_dict), agent_id, complete truth facts with confidence/
  evidence (truth_facts_full), and per-step summaries. JSON-safe.
- Persist (best-effort, never fatal): after planning, after every
  completed step, and at terminal states — a crash loses at most the
  in-flight step. Path: goals/{agent_id}/{goal_id}.json via the
  kernel's blob storage; silently skipped when none is attached.
- Resume: execute_goal(..., resume_goal_id=) rehydrates the plan,
  the truth facts, and the completed history (as _ResumedStep records
  duck-typing everything downstream reads), then continues from the
  first step without a passing verdict. Missing/corrupt snapshots log
  and start fresh — resume never crashes a goal.
- from_snapshot() skips unrehydratable facts individually rather than
  voiding the restore.

Additive kwarg only; no existing call sites change. 6 new tests
(round-trip incl. context chaining from a restored execution, JSON
safety, bad-fact tolerance); planning/kernel/autoagent suites pass
unchanged.
