### PR TITLE
feat(planning): dependency-parallel execution + planner robustness (#74)

### DIFF
--- a/jarviscore/docs/guides/autoagent.md
+++ b/jarviscore/docs/guides/autoagent.md
@@ -393,7 +393,7 @@ Control the loop ceiling with environment variables:
 
 ### Parallel steps in plans
 
-The planner declares `depends_on` per step — real data dependencies only. Steps with no ordering constraint between them run **concurrently** (bounded by `MAX_PARALLEL_STEPS`), and a step never runs before its dependencies have produced usable output. Plans without any `depends_on` execute strictly sequentially, exactly as before.
+The planner declares `depends_on` on each step, listing only the steps whose output it actually needs. Steps with no ordering constraint between them run at the same time, up to `MAX_PARALLEL_STEPS`. A step never starts before all of its dependencies have finished with a passing result. Plans that declare no `depends_on` at all run one step at a time, exactly as before.
 
 ```text
 plan: [
@@ -406,7 +406,7 @@ plan: [
 
 ### Goal persistence and resume
 
-Goal executions persist automatically when blob storage is attached — after planning, after every completed step, and at terminal states — under `goals/{agent_id}/{goal_id}.json`. A crash loses at most the in-flight step:
+Goal executions save themselves automatically when blob storage is attached. A snapshot is written after planning, after every completed step, and when the goal ends, under `goals/{agent_id}/{goal_id}.json`. If the process crashes, you lose at most the step that was running:
 
 ```python
 execution = await agent.execute_goal("Produce the Q2 analysis")
@@ -419,7 +419,7 @@ execution = await agent.execute_goal(
 )
 ```
 
-Resume continues from the first step without a passing verdict. A missing or corrupt snapshot logs a warning and starts fresh — resume never crashes a goal.
+Resume continues from the first step that has not passed yet. If the snapshot is missing or unreadable, the agent logs a warning and starts fresh. Resume never crashes a goal.
 
 ---
 

--- a/jarviscore/docs/guides/autoagent.md
+++ b/jarviscore/docs/guides/autoagent.md
@@ -389,6 +389,37 @@ Control the loop ceiling with environment variables:
 |---|---|---|
 | `MAX_GOAL_STEPS` | `30` | Hard ceiling on plan steps |
 | `MAX_REPLAN_ATTEMPTS` | `8` | Maximum replanning cycles before the goal fails |
+| `MAX_PARALLEL_STEPS` | `3` | Concurrency ceiling for independent plan steps |
+
+### Parallel steps in plans
+
+The planner declares `depends_on` per step — real data dependencies only. Steps with no ordering constraint between them run **concurrently** (bounded by `MAX_PARALLEL_STEPS`), and a step never runs before its dependencies have produced usable output. Plans without any `depends_on` execute strictly sequentially, exactly as before.
+
+```text
+plan: [
+  ("step_01_gather_risks",      []),                          # ┐ run in
+  ("step_02_gather_mitigations", []),                          # ┘ parallel
+  ("step_03_write_brief", ["step_01_gather_risks",
+                           "step_02_gather_mitigations"]),     # waits for both
+]
+```
+
+### Goal persistence and resume
+
+Goal executions persist automatically when blob storage is attached — after planning, after every completed step, and at terminal states — under `goals/{agent_id}/{goal_id}.json`. A crash loses at most the in-flight step:
+
+```python
+execution = await agent.execute_goal("Produce the Q2 analysis")
+goal_id = execution.goal_id                      # capture for resume
+
+# After a crash or restart:
+execution = await agent.execute_goal(
+    "Produce the Q2 analysis",
+    resume_goal_id=goal_id,                      # rehydrates plan, facts, history
+)
+```
+
+Resume continues from the first step without a passing verdict. A missing or corrupt snapshot logs a warning and starts fresh — resume never crashes a goal.
 
 ---
 

--- a/jarviscore/planning/planner.py
+++ b/jarviscore/planning/planner.py
@@ -68,8 +68,15 @@ Each step must have exactly these fields:
   "task"              : "<complete, self-contained task the agent can act on immediately>",
   "success_criterion" : "<concrete, observable condition that means this step is done>",
   "expected_findings" : ["<snake_case key this step should produce>", ...],
+  "depends_on"        : ["<step_ids that must complete first>", ...],
   "subagent_hint"     : "<MUST be exactly one of: researcher, coder, communicator, browser, null>"
 }
+
+CRITICAL — depends_on rules:
+  List the step_ids whose OUTPUT this step actually needs. Steps with no
+  ordering constraint between them may run IN PARALLEL — declare only real
+  data dependencies, not habitual sequence. An empty list means the step can
+  start immediately.
 
 CRITICAL — subagent_hint rules:
   "researcher"   → web search, analysis, investigation, strategy, planning, architecture
@@ -132,6 +139,30 @@ class Planner:
         self.llm = llm_client
         self._identity = system_prompt_excerpt[:400] if system_prompt_excerpt else ""
 
+    @staticmethod
+    def _clip(value: Any, limit: int) -> str:
+        """Honest cut — a planner working from amputated facts plans wrong."""
+        text = str(value)
+        if len(text) <= limit:
+            return text
+        return f"{text[:limit]}…[truncated: showing {limit} of {len(text)} chars]"
+
+    def _render_facts(self, facts: Dict[str, Any], limit: int = 20) -> str:
+        """Render known facts one per line with an honest count (#74).
+
+        Replaces the old clipped-JSON-blob rendering, which silently cut
+        facts mid-key at 800 chars — lost facts produce wrong plans.
+        """
+        if not facts:
+            return "None yet."
+        items = list(facts.items())
+        lines = [f"{len(items)} fact(s) known:"]
+        for key, value in items[:limit]:
+            lines.append(f"  - {key}: {self._clip(value, 200)}")
+        if len(items) > limit:
+            lines.append(f"  …and {len(items) - limit} more facts not shown")
+        return "\n".join(lines)
+
     async def plan(
         self,
         goal: str,
@@ -155,13 +186,13 @@ class Planner:
                           parsed into a valid plan.
         """
         known_facts = goal_execution.truth.to_flat_dict()
-        known_str = json.dumps(known_facts, default=str)[:800] if known_facts else "None yet."
+        known_str = self._render_facts(known_facts)
 
         ctx_note = ""
         if context:
             public = {k: v for k, v in context.items() if not str(k).startswith("_")}
             if public:
-                ctx_note = f"\nAvailable context:\n{json.dumps(public, default=str)[:300]}\n"
+                ctx_note = f"\nAvailable context:\n{self._clip(json.dumps(public, default=str), 600)}\n"
 
         prompt = self._build_initial_prompt(goal, known_str, ctx_note)
         return await self._call_and_parse(prompt, goal)
@@ -171,6 +202,8 @@ class Planner:
         goal_execution: GoalExecution,
         failed_step: Any,           # CompletedStep
         reason: str,
+        pending_steps: Optional[List[PlannedStep]] = None,
+        budget_note: str = "",
     ) -> List[PlannedStep]:
         """
         Recovery planning after a step failure.
@@ -183,20 +216,33 @@ class Planner:
             goal_execution: Full GoalExecution state at the point of failure.
             failed_step:    The CompletedStep that received a "fail" verdict.
             reason:         StepEvaluation.evaluator_note — why it failed.
+            pending_steps:  Steps not yet attempted — shown to the planner so
+                            good untouched work is kept, not churned (#74).
+            budget_note:    One line of execution economics (steps run vs.
+                            ceiling) so the plan fits the budget that's left.
 
         Returns:
-            Revised List[PlannedStep] for the remaining work.
+            Revised List[PlannedStep] for the remaining work. Steps whose ids
+            already completed are dropped defensively (prompt-only enforcement
+            was the previous, unreliable guard).
 
         Raises:
             PlannerError: if the LLM call fails or response is unparseable.
         """
         completed_summary = "\n".join(
-            f"  - [{cs.evaluation.verdict.upper()}] {cs.step.step_id}: {cs.step.task[:120]}"
+            f"  - [{cs.evaluation.verdict.upper()}] {cs.step.step_id}: {self._clip(cs.step.task, 120)}"
             for cs in goal_execution.completed
         )
 
         known_facts = goal_execution.truth.to_flat_dict()
-        known_str = json.dumps(known_facts, default=str)[:800] if known_facts else "None."
+        known_str = self._render_facts(known_facts)
+
+        pending_summary = ""
+        if pending_steps:
+            pending_summary = "\n".join(
+                f"  - {s.step_id}: {self._clip(s.task, 120)}"
+                for s in pending_steps
+            )
 
         prompt = self._build_replan_prompt(
             goal=goal_execution.goal,
@@ -204,8 +250,21 @@ class Planner:
             failed_step_task=failed_step.step.task,
             failure_reason=reason,
             known_facts_str=known_str,
+            pending_summary=pending_summary,
+            budget_note=budget_note,
         )
-        return await self._call_and_parse(prompt, goal_execution.goal)
+        revised = await self._call_and_parse(prompt, goal_execution.goal)
+
+        # Defensive: never re-run completed work, whatever the prompt said.
+        done_ids = {cs.step.step_id for cs in goal_execution.completed}
+        kept = [s for s in revised if s.step_id not in done_ids]
+        if len(kept) < len(revised):
+            dropped = [s.step_id for s in revised if s.step_id in done_ids]
+            logger.warning(
+                "[Planner] Replan re-included %d completed step(s) — dropped: %s",
+                len(dropped), dropped,
+            )
+        return kept
 
     # ── Prompt builders ───────────────────────────────────────────────────────
 
@@ -232,6 +291,8 @@ class Planner:
         failed_step_task: str,
         failure_reason: str,
         known_facts_str: str,
+        pending_summary: str = "",
+        budget_note: str = "",
     ) -> str:
         parts = [
             "An autonomous agent execution has partially failed. Produce a REVISED plan.\n\n",
@@ -244,6 +305,13 @@ class Planner:
         parts.append(f"\nFailed step: {failed_step_task}\n")
         parts.append(f"Failure reason: {failure_reason}\n")
         parts.append(f"Accumulated facts: {known_facts_str}\n")
+        if pending_summary:
+            parts.append(
+                f"\nSteps planned but NOT yet attempted — KEEP these (same step_id) "
+                f"unless the failure invalidates them:\n{pending_summary}\n"
+            )
+        if budget_note:
+            parts.append(f"\nExecution budget: {budget_note}\n")
         parts.append(
             "\nProduce a revised plan for the REMAINING work only. "
             "Change approach — do not repeat the same failed strategy.\n\n"
@@ -392,11 +460,44 @@ class Planner:
                 task=str(item["task"]),
                 success_criterion=str(item["success_criterion"]),
                 expected_findings=list(item.get("expected_findings") or []),
+                depends_on=[str(d) for d in (item.get("depends_on") or [])],
                 subagent_hint=hint,
             ))
+
+        self._validate_plan(steps)
 
         logger.info(
             "[Planner] Produced %d-step plan for goal: %s",
             len(steps), goal[:80],
         )
         return steps
+
+    @staticmethod
+    def _validate_plan(steps: List[PlannedStep]) -> None:
+        """Semantic validation the schema check cannot do (#74).
+
+        - Duplicate step_ids are a hard error: they corrupt keyed persistence,
+          resume, and dependency resolution.
+        - depends_on references to unknown step_ids are stripped with a
+          warning: a hallucinated dependency must not deadlock the plan.
+        - Self-dependencies are stripped for the same reason.
+        """
+        seen: set = set()
+        for step in steps:
+            if step.step_id in seen:
+                raise PlannerError(
+                    f"Plan contains duplicate step_id {step.step_id!r} — "
+                    f"step ids must be unique."
+                )
+            seen.add(step.step_id)
+
+        known = {s.step_id for s in steps}
+        for step in steps:
+            valid = [d for d in step.depends_on if d in known and d != step.step_id]
+            if len(valid) != len(step.depends_on):
+                stripped = [d for d in step.depends_on if d not in known or d == step.step_id]
+                logger.warning(
+                    "[Planner] Step %s: stripped invalid depends_on refs %s",
+                    step.step_id, stripped,
+                )
+                step.depends_on = valid

--- a/jarviscore/profiles/autoagent.py
+++ b/jarviscore/profiles/autoagent.py
@@ -799,7 +799,29 @@ class AutoAgent(Profile):
 
 
         while remaining and steps_run < max_steps:
-            step = remaining.pop(0)
+            # ── Dependency-aware step selection (issue #74, review fix) ──────
+            # A replanned or model-ordered plan may list a step before its
+            # dependency — never run a step whose depends_on are unsatisfied.
+            if plan_uses_deps:
+                step = next(
+                    (s for s in remaining
+                     if all(d in done_ids for d in s.depends_on)),
+                    None,
+                )
+                if step is None:
+                    _cancel_inflight()
+                    blocked = [s.step_id for s in remaining]
+                    execution.status = "failed"
+                    execution.error = (
+                        f"Dependency deadlock: no runnable step among {blocked} — "
+                        f"unsatisfied depends_on references"
+                    )
+                    execution.completed_at = time.time()
+                    await self._persist_goal(execution)
+                    return execution
+                remaining.remove(step)
+            else:
+                step = remaining.pop(0)
             steps_run += 1
 
             self._logger.info(
@@ -890,8 +912,10 @@ class AutoAgent(Profile):
 
             # Record: merges distilled_facts + evaluator findings into truth
             execution.record_completed(step, output, evaluation, elapsed)
-            if evaluation.verdict == "pass":
-                # Newly-satisfied dependencies unlock further co-ready steps
+            if evaluation.verdict != "fail":
+                # pass AND partial satisfy dependencies — the step produced
+                # usable output (fail routes through replan below). A partial
+                # verdict must not deadlock its dependents (review fix).
                 done_ids.add(step.step_id)
             # Durability: every completed step survives a crash (issue #73)
             await self._persist_goal(execution)

--- a/jarviscore/profiles/autoagent.py
+++ b/jarviscore/profiles/autoagent.py
@@ -8,6 +8,7 @@ For long-horizon autonomous work, set goal_oriented = True on your
 subclass — all tasks will be routed through the Plan → Execute → Evaluate
 loop automatically. The execute_task() contract is unchanged.
 """
+import asyncio
 import os
 import re
 import time
@@ -774,6 +775,29 @@ class AutoAgent(Profile):
         }
         remaining = [s for s in execution.plan if s.step_id not in done_ids]
 
+        # ── Dependency-aware parallelism (issue #74) ────────────────────────
+        # Plans that declare depends_on opt into concurrent execution of
+        # co-ready steps (speculative prefetch, bounded). Plans without any
+        # depends_on run exactly as before — strictly sequential.
+        plan_uses_deps = any(s.depends_on for s in execution.plan)
+        max_parallel = max(1, int(os.environ.get("MAX_PARALLEL_STEPS", "3")))
+        _inflight: Dict[str, "asyncio.Task"] = {}
+
+        def _cancel_inflight() -> None:
+            for _t in _inflight.values():
+                _t.cancel()
+            _inflight.clear()
+
+        async def _kernel_step(one_step, one_ctx):
+            return await self._kernel.execute(
+                task=one_step.task,
+                system_prompt=effective_system_prompt,
+                context=one_ctx,
+                agent_id=self.agent_id,
+                agent_default_role=one_step.subagent_hint or self.default_kernel_role,
+            )
+
+
         while remaining and steps_run < max_steps:
             step = remaining.pop(0)
             steps_run += 1
@@ -787,6 +811,29 @@ class AutoAgent(Profile):
             step_ctx = execution.context_for_next_step(base_context=context)
             step_ctx.update(step.to_context_extras())
 
+            # ── Speculative launch of co-ready steps (issue #74) ─────────────
+            # Steps whose declared dependencies are already satisfied cannot
+            # need this step's output — start them now, harvest when the loop
+            # reaches them. Size-1 plans and dep-free plans skip this block.
+            if plan_uses_deps:
+                co_ready = [
+                    s for s in remaining
+                    if s.step_id not in _inflight
+                    and all(d in done_ids for d in s.depends_on)
+                ]
+                slots = max_parallel - 1 - len(_inflight)
+                for extra in co_ready[:max(0, slots)]:
+                    extra_ctx = execution.context_for_next_step(base_context=context)
+                    extra_ctx.update(extra.to_context_extras())
+                    _inflight[extra.step_id] = asyncio.create_task(
+                        _kernel_step(extra, extra_ctx),
+                        name=f"goal-step-{extra.step_id}",
+                    )
+                    self._logger.info(
+                        "[AutoAgent] Speculatively launched co-ready step %s",
+                        extra.step_id,
+                    )
+
             # ── Execute step via Kernel (full OODA) ───────────────────────────
             step_start = time.time()
             try:
@@ -794,17 +841,16 @@ class AutoAgent(Profile):
                 if auth_mgr and self._kernel.auth_manager is not auth_mgr:
                     self._kernel.auth_manager = auth_mgr
 
-                output = await self._kernel.execute(
-                    task=step.task,
-                    system_prompt=effective_system_prompt,
-                    context=step_ctx,
-                    agent_id=self.agent_id,
-                    agent_default_role=step.subagent_hint or self.default_kernel_role,
-                )
+                inflight = _inflight.pop(step.step_id, None)
+                if inflight is not None:
+                    output = await inflight   # harvest the speculative run
+                else:
+                    output = await _kernel_step(step, step_ctx)
             except Exception as exc:
                 self._logger.error(
                     "[AutoAgent] Kernel raised on step %s: %s", step.step_id, exc
                 )
+                _cancel_inflight()
                 execution.status = "failed"
                 execution.error = f"Kernel exception on step {step.step_id}: {exc}"
                 execution.completed_at = time.time()
@@ -838,10 +884,15 @@ class AutoAgent(Profile):
                 execution.status = "failed"
                 execution.error = f"Evaluation error on step {step.step_id}: {exc}"
                 execution.completed_at = time.time()
+                _cancel_inflight()
+                await self._persist_goal(execution)
                 return execution
 
             # Record: merges distilled_facts + evaluator findings into truth
             execution.record_completed(step, output, evaluation, elapsed)
+            if evaluation.verdict == "pass":
+                # Newly-satisfied dependencies unlock further co-ready steps
+                done_ids.add(step.step_id)
             # Durability: every completed step survives a crash (issue #73)
             await self._persist_goal(execution)
 
@@ -853,6 +904,7 @@ class AutoAgent(Profile):
 
             # ── Handle verdict ────────────────────────────────────────────────
             if evaluation.needs_hitl:
+                _cancel_inflight()
                 # Audit log: only genuine HITL escalations reach here now
                 # (routine budget yields are downgraded to partial by evaluator)
                 self._logger.info(
@@ -903,6 +955,7 @@ class AutoAgent(Profile):
                         "[AutoAgent] Max replan attempts (%d) reached. Failing goal.",
                         max_replan_attempts,
                     )
+                    _cancel_inflight()
                     execution.status = "failed"
                     execution.error = (
                         f"Max replan attempts ({max_replan_attempts}) reached. "
@@ -918,10 +971,19 @@ class AutoAgent(Profile):
                 )
                 try:
                     completed_step = execution.completed[-1]
+                    # Invalidate speculative work — a revised plan must not
+                    # harvest results computed under the failed premise (#74).
+                    _cancel_inflight()
                     revised = await planner.replan(
                         goal_execution=execution,
                         failed_step=completed_step,
                         reason=evaluation.evaluator_note,
+                        pending_steps=list(remaining),
+                        budget_note=(
+                            f"{steps_run} of max {max_steps} steps used; "
+                            f"{max_steps - steps_run} remaining — the revised "
+                            f"plan must fit"
+                        ),
                     )
                     execution.plan_revision += 1
                     remaining = revised   # replace remaining steps with revised plan
@@ -939,6 +1001,7 @@ class AutoAgent(Profile):
                 continue  # proceed with revised plan
 
         # ── Phase 3: Safety check ─────────────────────────────────────────────
+        _cancel_inflight()
         if steps_run >= max_steps and remaining:
             self._logger.warning(
                 "[AutoAgent] max_steps=%d reached with %d steps still remaining.",

--- a/tests/test_planning.py
+++ b/tests/test_planning.py
@@ -680,3 +680,243 @@ class TestGoalSnapshotRoundTrip:
         }
         restored = GoalExecution.from_snapshot(data)
         assert "broken" not in restored.truth.facts
+
+
+# ── Issue #74: planner robustness ─────────────────────────────────────────────
+
+class _PlanLLM:
+    """Captures the prompt; returns a canned plan JSON."""
+
+    def __init__(self, plan_json):
+        self._plan_json = plan_json
+        self.prompts = []
+
+    async def generate(self, **kwargs):
+        self.prompts.append(kwargs["messages"][0]["content"])
+        return {"content": self._plan_json}
+
+
+def _step_json(step_id, depends_on=None):
+    import json
+    return {
+        "step_id": step_id,
+        "task": f"do {step_id}",
+        "success_criterion": "done",
+        "expected_findings": [],
+        "depends_on": depends_on or [],
+        "subagent_hint": None,
+    }
+
+
+class TestPlanValidation:
+
+    @pytest.mark.asyncio
+    async def test_duplicate_step_ids_are_a_hard_error(self):
+        import json
+        from jarviscore.planning.planner import Planner, PlannerError
+        llm = _PlanLLM(json.dumps({"steps": [_step_json("s1"), _step_json("s1")]}))
+        ge = GoalExecution(goal="G", agent_id="a")
+        with pytest.raises(PlannerError, match="duplicate step_id"):
+            await Planner(llm).plan(goal="G", goal_execution=ge)
+
+    @pytest.mark.asyncio
+    async def test_unknown_and_self_depends_on_refs_are_stripped(self):
+        import json
+        from jarviscore.planning.planner import Planner
+        llm = _PlanLLM(json.dumps({"steps": [
+            _step_json("s1"),
+            _step_json("s2", depends_on=["s1", "ghost_step", "s2"]),
+        ]}))
+        ge = GoalExecution(goal="G", agent_id="a")
+        steps = await Planner(llm).plan(goal="G", goal_execution=ge)
+        assert steps[1].depends_on == ["s1"]
+
+    @pytest.mark.asyncio
+    async def test_depends_on_round_trips_through_parse(self):
+        import json
+        from jarviscore.planning.planner import Planner
+        llm = _PlanLLM(json.dumps({"steps": [
+            _step_json("s1"), _step_json("s2", depends_on=["s1"]),
+        ]}))
+        ge = GoalExecution(goal="G", agent_id="a")
+        steps = await Planner(llm).plan(goal="G", goal_execution=ge)
+        assert steps[1].depends_on == ["s1"]
+
+
+class TestHonestPlannerPrompts:
+
+    @pytest.mark.asyncio
+    async def test_facts_render_one_per_line_with_count(self):
+        import json
+        from jarviscore.planning.planner import Planner
+        from jarviscore.context.truth import TruthFact
+        llm = _PlanLLM(json.dumps({"steps": [_step_json("s1")]}))
+        ge = GoalExecution(goal="G", agent_id="a")
+        for i in range(25):
+            ge.truth.facts[f"fact_{i:02d}"] = TruthFact(
+                value=f"v{i}", source="s", confidence=0.9
+            )
+        await Planner(llm).plan(goal="G", goal_execution=ge)
+        prompt = llm.prompts[0]
+        assert "25 fact(s) known:" in prompt
+        assert "- fact_00: v0" in prompt
+        assert "…and 5 more facts not shown" in prompt
+
+    @pytest.mark.asyncio
+    async def test_long_fact_values_carry_markers(self):
+        import json
+        from jarviscore.planning.planner import Planner
+        from jarviscore.context.truth import TruthFact
+        llm = _PlanLLM(json.dumps({"steps": [_step_json("s1")]}))
+        ge = GoalExecution(goal="G", agent_id="a")
+        ge.truth.facts["huge"] = TruthFact(value="H" * 700, source="s", confidence=0.9)
+        await Planner(llm).plan(goal="G", goal_execution=ge)
+        assert "…[truncated: showing 200 of 700 chars]" in llm.prompts[0]
+
+
+class TestReplanTailAndBudget:
+
+    def _failed_execution(self):
+        ge = GoalExecution(goal="G", agent_id="a")
+        ge.record_completed(
+            _make_step("s1"), _make_output(), _make_evaluation(verdict="fail"),
+            elapsed_ms=10.0,
+        )
+        return ge
+
+    @pytest.mark.asyncio
+    async def test_pending_tail_and_budget_reach_the_prompt(self):
+        import json
+        from jarviscore.planning.planner import Planner
+        llm = _PlanLLM(json.dumps({"steps": [_step_json("s9")]}))
+        ge = self._failed_execution()
+        pending = [_make_step("s2", task="untouched work")]
+
+        await Planner(llm).replan(
+            goal_execution=ge, failed_step=ge.completed[0], reason="broke",
+            pending_steps=pending,
+            budget_note="3 of max 30 steps used",
+        )
+        prompt = llm.prompts[0]
+        assert "NOT yet attempted — KEEP these" in prompt
+        assert "s2: untouched work" in prompt
+        assert "Execution budget: 3 of max 30 steps used" in prompt
+
+    @pytest.mark.asyncio
+    async def test_replan_drops_completed_ids_defensively(self):
+        import json
+        from jarviscore.planning.planner import Planner
+        # The model disobeys and re-includes the completed step s1
+        llm = _PlanLLM(json.dumps({"steps": [_step_json("s1"), _step_json("s2")]}))
+        ge = self._failed_execution()
+
+        revised = await Planner(llm).replan(
+            goal_execution=ge, failed_step=ge.completed[0], reason="broke",
+        )
+        assert [s.step_id for s in revised] == ["s2"]
+
+
+class TestDependencyParallelExecution:
+    """Plans that declare depends_on opt into concurrent co-ready steps."""
+
+    @pytest.mark.asyncio
+    async def test_co_ready_steps_overlap_and_dependents_wait(self, monkeypatch):
+        import asyncio
+        from unittest.mock import AsyncMock, patch
+        from jarviscore.profiles.autoagent import AutoAgent
+
+        class _GoalAgent(AutoAgent):
+            role = "goal-test"
+            capabilities = ["x"]
+            system_prompt = "test"
+
+        agent = _GoalAgent()
+        agent.llm = object()  # never called: planner/evaluator are patched
+
+        # Kernel fake: records in-flight overlap per step
+        in_flight = set()
+        overlap_seen = {"max": 0}
+        order = []
+
+        class _Kernel:
+            blob_storage = None
+            auth_manager = None
+
+            async def execute(self, task, **kwargs):
+                step_id = kwargs["context"]["step_id"]
+                in_flight.add(step_id)
+                overlap_seen["max"] = max(overlap_seen["max"], len(in_flight))
+                await asyncio.sleep(0.05)
+                in_flight.discard(step_id)
+                order.append(step_id)
+                return _make_output(summary=f"did {step_id}")
+
+        agent._kernel = _Kernel()
+
+        # Plan: a and b are independent; c depends on both
+        plan = [
+            PlannedStep("a", "task a", "done", depends_on=[]),
+            PlannedStep("b", "task b", "done", depends_on=[]),
+            PlannedStep("c", "task c", "done", depends_on=["a", "b"]),
+        ]
+
+        with patch(
+            "jarviscore.planning.planner.Planner.plan",
+            new=AsyncMock(return_value=plan),
+        ), patch(
+            "jarviscore.planning.evaluator.StepEvaluator.evaluate",
+            new=AsyncMock(return_value=_make_evaluation(verdict="pass")),
+        ):
+            execution = await agent.execute_goal("test parallel goal")
+
+        assert execution.status == "complete"
+        assert len(execution.completed) == 3
+        # a and b overlapped; c ran only after both finished
+        assert overlap_seen["max"] >= 2
+        assert order.index("c") == 2
+
+    @pytest.mark.asyncio
+    async def test_dep_free_plans_stay_strictly_sequential(self):
+        import asyncio
+        from unittest.mock import AsyncMock, patch
+        from jarviscore.profiles.autoagent import AutoAgent
+
+        class _GoalAgent(AutoAgent):
+            role = "goal-test-seq"
+            capabilities = ["x"]
+            system_prompt = "test"
+
+        agent = _GoalAgent()
+        agent.llm = object()
+
+        in_flight = set()
+        overlap_seen = {"max": 0}
+
+        class _Kernel:
+            blob_storage = None
+            auth_manager = None
+
+            async def execute(self, task, **kwargs):
+                step_id = kwargs["context"]["step_id"]
+                in_flight.add(step_id)
+                overlap_seen["max"] = max(overlap_seen["max"], len(in_flight))
+                await asyncio.sleep(0.02)
+                in_flight.discard(step_id)
+                return _make_output(summary=f"did {step_id}")
+
+        agent._kernel = _Kernel()
+
+        # Historical plan shape: no depends_on anywhere
+        plan = [PlannedStep(f"s{i}", f"task {i}", "done") for i in range(3)]
+
+        with patch(
+            "jarviscore.planning.planner.Planner.plan",
+            new=AsyncMock(return_value=plan),
+        ), patch(
+            "jarviscore.planning.evaluator.StepEvaluator.evaluate",
+            new=AsyncMock(return_value=_make_evaluation(verdict="pass")),
+        ):
+            execution = await agent.execute_goal("test sequential goal")
+
+        assert execution.status == "complete"
+        assert overlap_seen["max"] == 1  # byte-identical historical behavior

--- a/tests/test_planning.py
+++ b/tests/test_planning.py
@@ -920,3 +920,128 @@ class TestDependencyParallelExecution:
 
         assert execution.status == "complete"
         assert overlap_seen["max"] == 1  # byte-identical historical behavior
+
+    @pytest.mark.asyncio
+    async def test_misordered_plan_runs_dependency_first(self):
+        """Review fix: a step listed BEFORE its dependency must wait for it."""
+        from unittest.mock import AsyncMock, patch
+        from jarviscore.profiles.autoagent import AutoAgent
+
+        class _GoalAgent(AutoAgent):
+            role = "goal-test-order"
+            capabilities = ["x"]
+            system_prompt = "test"
+
+        agent = _GoalAgent()
+        agent.llm = object()
+        order = []
+
+        class _Kernel:
+            blob_storage = None
+            auth_manager = None
+
+            async def execute(self, task, **kwargs):
+                order.append(kwargs["context"]["step_id"])
+                return _make_output(summary="ok")
+
+        agent._kernel = _Kernel()
+
+        # b listed first but depends on a — the model misordered the list
+        plan = [
+            PlannedStep("b", "task b", "done", depends_on=["a"]),
+            PlannedStep("a", "task a", "done", depends_on=[]),
+        ]
+
+        with patch(
+            "jarviscore.planning.planner.Planner.plan",
+            new=AsyncMock(return_value=plan),
+        ), patch(
+            "jarviscore.planning.evaluator.StepEvaluator.evaluate",
+            new=AsyncMock(return_value=_make_evaluation(verdict="pass")),
+        ):
+            execution = await agent.execute_goal("test order goal")
+
+        assert execution.status == "complete"
+        assert order == ["a", "b"]
+
+    @pytest.mark.asyncio
+    async def test_unsatisfiable_deps_fail_honestly(self):
+        """Review fix: a dependency that can never pass is a loud failure."""
+        from unittest.mock import AsyncMock, patch
+        from jarviscore.profiles.autoagent import AutoAgent
+
+        class _GoalAgent(AutoAgent):
+            role = "goal-test-deadlock"
+            capabilities = ["x"]
+            system_prompt = "test"
+
+        agent = _GoalAgent()
+        agent.llm = object()
+
+        class _Kernel:
+            blob_storage = None
+            auth_manager = None
+
+            async def execute(self, task, **kwargs):
+                return _make_output(summary="ok")
+
+        agent._kernel = _Kernel()
+
+        # Planner validation strips unknown refs, so simulate the only path a
+        # bad ref can survive: a plan injected directly (e.g. resume of a
+        # snapshot written by an older version).
+        plan = [PlannedStep("b", "task b", "done", depends_on=["never_exists"])]
+
+        with patch(
+            "jarviscore.planning.planner.Planner.plan",
+            new=AsyncMock(return_value=plan),
+        ), patch(
+            "jarviscore.planning.evaluator.StepEvaluator.evaluate",
+            new=AsyncMock(return_value=_make_evaluation(verdict="pass")),
+        ):
+            execution = await agent.execute_goal("test deadlock goal")
+
+        assert execution.status == "failed"
+        assert "Dependency deadlock" in execution.error
+
+    @pytest.mark.asyncio
+    async def test_partial_verdict_does_not_deadlock_dependents(self):
+        """Review fix: partial output is usable output — dependents may run."""
+        from unittest.mock import AsyncMock, patch
+        from jarviscore.profiles.autoagent import AutoAgent
+
+        class _GoalAgent(AutoAgent):
+            role = "goal-test-partial"
+            capabilities = ["x"]
+            system_prompt = "test"
+
+        agent = _GoalAgent()
+        agent.llm = object()
+        order = []
+
+        class _Kernel:
+            blob_storage = None
+            auth_manager = None
+
+            async def execute(self, task, **kwargs):
+                order.append(kwargs["context"]["step_id"])
+                return _make_output(summary="ok")
+
+        agent._kernel = _Kernel()
+
+        plan = [
+            PlannedStep("a", "task a", "done", depends_on=[]),
+            PlannedStep("b", "task b", "done", depends_on=["a"]),
+        ]
+
+        with patch(
+            "jarviscore.planning.planner.Planner.plan",
+            new=AsyncMock(return_value=plan),
+        ), patch(
+            "jarviscore.planning.evaluator.StepEvaluator.evaluate",
+            new=AsyncMock(return_value=_make_evaluation(verdict="partial")),
+        ):
+            execution = await agent.execute_goal("test partial goal")
+
+        assert execution.status == "complete"
+        assert order == ["a", "b"]


### PR DESCRIPTION
feat(planning): dependency-parallel execution + planner robustness (#74)

1. Dependency-aware parallelism (opt-in by the plan itself):
   - Planner schema/prompt now teach depends_on ("declare only real data
     dependencies — unconstrained steps may run IN PARALLEL"); parse
     populates the PlannedStep field that already existed unused
   - execute_goal speculatively launches co-ready steps (dependencies
     all passed) alongside the current one, bounded by
     MAX_PARALLEL_STEPS (default 3), and harvests them when the loop
     arrives; replan/HITL/terminal paths cancel speculative work so a
     revised plan never harvests results computed under a failed
     premise
   - Plans with NO depends_on run byte-identically sequential (proven
     by an overlap-probe test); parallelism is plan-declared, never
     imposed

2. Semantic plan validation:
   - Duplicate step_ids: hard PlannerError (they corrupt persistence,
     resume, and dependency resolution)
   - Unknown/self depends_on refs: stripped with a warning — a
     hallucinated dependency must not deadlock the plan
   - Replan output defensively drops already-completed step_ids
     (prompt-only enforcement was the previous guard)

3. Honest planner prompts:
   - Facts render one per line with an explicit count and overflow
     ("25 fact(s) known … and 5 more not shown") instead of a JSON
     blob silently clipped at 800 chars — lost facts produce wrong
     plans; long values carry truncation markers

4. Replan keeps good work: the untouched pending tail is shown to the
   replanner ("KEEP these unless the failure invalidates them"), and a
   budget line (steps used vs. ceiling) makes revised plans fit the
   execution budget that is actually left.

Stacked on feat/goal-persistence (#77). 9 new tests (66 total in the
file) incl. concurrency overlap probes both ways; planning/kernel/
autoagent suites pass unchanged.
