### PR TITLE
feat: DX harnesses - the developer-journey release gate

### DIFF
--- a/harnesses/README.md
+++ b/harnesses/README.md
@@ -1,0 +1,52 @@
+# DX Harnesses
+
+These scripts test JarvisCore the way a developer experiences it: by following
+the guides end to end. Unit tests prove functions work. These harnesses prove
+the developer journey works. Run them before every release and after any change
+to the profiles, the kernel, the planner, or the orchestration layer.
+
+## The harnesses
+
+| Script | Journey | Needs an LLM? |
+|---|---|---|
+| `dx_customagent.py` | CustomAgent: workflows, step identity, `mesh.fanout()` | No |
+| `dx_autoagent.py` | AutoAgent: loud pre-start errors, `single_response`, a kernel task | Yes |
+| `dx_goalmode.py` | Goal mode: planning with `depends_on`, parallel steps, persistence, resume | Yes |
+
+## Running them
+
+The CustomAgent harness runs offline:
+
+```bash
+python3 harnesses/dx_customagent.py
+```
+
+The other two need live LLM credentials in the environment (the same variables
+the framework reads, for example `AZURE_API_KEY` and `AZURE_ENDPOINT`):
+
+```bash
+set -a && source /path/to/your/.env && set +a
+python3 harnesses/dx_autoagent.py
+python3 harnesses/dx_goalmode.py
+```
+
+Each harness prints one line per check and exits non-zero if any check fails.
+
+## Why harnesses and not just tests
+
+Unit tests mock the LLM and the mesh, so they cannot catch a guide that
+recommends a method that does not exist, a contract that silently misroutes,
+or an envelope that only breaks with real model output. Each of those has
+happened. The harnesses caught them because they do exactly what the
+documentation tells a developer to do.
+
+When a harness fails, treat it as a release blocker: either the framework
+broke the journey or the documentation describes a journey that no longer
+exists. Fix whichever one is lying.
+
+## Adding a harness
+
+Write it as a developer story, not a test matrix. Pick one guide, follow it
+top to bottom, and check what a reader would expect at each step. Keep checks
+observable (status fields, result shapes, timing) and print clearly. If your
+harness needs credentials, say so in its docstring and in the table above.

--- a/harnesses/README.md
+++ b/harnesses/README.md
@@ -12,22 +12,31 @@ to the profiles, the kernel, the planner, or the orchestration layer.
 | `dx_customagent.py` | CustomAgent: workflows, step identity, `mesh.fanout()` | No |
 | `dx_autoagent.py` | AutoAgent: loud pre-start errors, `single_response`, a kernel task | Yes |
 | `dx_goalmode.py` | Goal mode: planning with `depends_on`, parallel steps, persistence, resume | Yes |
+| `prod_customagent_swarm.py` | A production CustomAgent swarm: DAG pipeline, fan-out with a poison item, 30 workflows of sustained load, failure semantics | No |
+| `prod_autoagent_swarm.py` | A production AutoAgent swarm with plan mode on: triage (simple asks must not plan), bounded context inside goals, flat repeated sessions, mixed-profile workflow | Yes |
+
+The two `prod_` harnesses are the stability gate. They simulate two developers
+running production swarms and assert the failure signatures that matter:
+over-planning, compounding context growth, cross-workflow contamination,
+timing drift, and memory growth under sustained load.
 
 ## Running them
 
-The CustomAgent harness runs offline:
+The CustomAgent harnesses run offline:
 
 ```bash
 python3 harnesses/dx_customagent.py
+python3 harnesses/prod_customagent_swarm.py
 ```
 
-The other two need live LLM credentials in the environment (the same variables
+The others need live LLM credentials in the environment (the same variables
 the framework reads, for example `AZURE_API_KEY` and `AZURE_ENDPOINT`):
 
 ```bash
 set -a && source /path/to/your/.env && set +a
 python3 harnesses/dx_autoagent.py
 python3 harnesses/dx_goalmode.py
+python3 harnesses/prod_autoagent_swarm.py
 ```
 
 Each harness prints one line per check and exits non-zero if any check fails.

--- a/harnesses/dx_autoagent.py
+++ b/harnesses/dx_autoagent.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""DX Harness 2 - the AutoAgent developer journey (REAL LLM).
+
+Simulates a developer following the AutoAgent guide with live Azure OpenAI:
+1. Pre-start misuse -> loud, actionable error
+2. single_response contract -> one completion, real answer
+3. A researcher-style task through the kernel OODA loop
+4. Goal mode with depends_on -> plan, execute, facts accumulate
+
+Requires AZURE_API_KEY etc. in the environment (sourced from billy/.env).
+"""
+import asyncio
+import sys
+import time
+
+PASS, FAIL = "✅", "❌"
+failures = []
+
+
+def check(name, cond, detail=""):
+    print(f"  {PASS if cond else FAIL} {name}" + (f" - {detail}" if detail and not cond else ""))
+    if not cond:
+        failures.append(name)
+
+
+async def main():
+    from jarviscore import Mesh, MeshMode, AutoAgent
+
+    class ResearchAgent(AutoAgent):
+        role = "researcher_dx"
+        capabilities = ["research", "analysis"]
+        system_prompt = (
+            "You are a precise research analyst. Be concise. When asked for "
+            "a direct answer, answer in one short paragraph."
+        )
+
+    print("== AutoAgent developer journey (live LLM) ==")
+
+    # 1. Pre-start misuse is loud (issue #63/JC-002)
+    orphan = ResearchAgent()
+    try:
+        await orphan.execute_task({"task": "anything"})
+        check("pre-start use raises a descriptive error", False, "no error raised")
+    except RuntimeError as exc:
+        check("pre-start use raises a descriptive error", "mesh.start" in str(exc))
+    except Exception as exc:  # noqa: BLE001
+        check("pre-start use raises a descriptive error", False, f"wrong error: {exc}")
+
+    mesh = Mesh(mode=MeshMode.AUTONOMOUS)
+    mesh.add(ResearchAgent)
+    await mesh.start()
+    try:
+        agent = mesh.get_agent("researcher_dx")
+
+        # 2. single_response - one completion, no codegen (JC-001/003)
+        t0 = time.monotonic()
+        result = await agent.execute_task({
+            "task": "In one sentence: why do trading systems prefer bounded concurrency?",
+            "context": {"execution_contract": {"execution_shape": "single_response"}},
+        })
+        dt = time.monotonic() - t0
+        check("single_response returns success", result.get("status") == "success",
+              str(result)[:200])
+        answer = str(result.get("output", ""))
+        check("single_response gives a real prose answer", len(answer) > 40, answer[:120])
+        check("single_response reports real token telemetry",
+              (result.get("tokens") or {}).get("total", 0) > 0)
+        # Deterministic proof of the direct path: the envelope marker is only
+        # stamped when the kernel pipeline was bypassed. Wall-clock checks are
+        # provider-latency lottery and do not belong in a release gate.
+        check("single_response bypassed the kernel pipeline",
+              result.get("execution_shape") == "single_response",
+              f"envelope: {str(result)[:150]}")
+        print(f"      answer ({dt:.1f}s): {answer[:110]}…")
+
+        # 3. Kernel OODA path - a bounded analysis task
+        result2 = await agent.execute_task({
+            "task": (
+                "List exactly three risks of running two identical trading "
+                "bots on one broker account. Return JSON: "
+                '{"risks": ["...", "...", "..."]}'
+            ),
+        })
+        check("kernel task returns a status", result2.get("status") in
+              ("success", "yield", "failure"), str(result2)[:200])
+        check("kernel task succeeded", result2.get("status") == "success",
+              str(result2.get("error"))[:200])
+    finally:
+        await mesh.stop()
+
+    print()
+    if failures:
+        print(f"{FAIL} AutoAgent journey: {len(failures)} failure(s): {failures}")
+        sys.exit(1)
+    print(f"{PASS} AutoAgent journey: all checks passed")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/harnesses/dx_customagent.py
+++ b/harnesses/dx_customagent.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""DX Harness 1 - the CustomAgent developer journey.
+
+Simulates a developer following the CustomAgent guide end to end:
+message-driven agent, workflow execution, result identity, fanout.
+No LLM required - this is the infrastructure contract.
+"""
+import asyncio
+import sys
+
+PASS, FAIL = "✅", "❌"
+failures = []
+
+
+def check(name, cond, detail=""):
+    print(f"  {PASS if cond else FAIL} {name}" + (f" - {detail}" if detail and not cond else ""))
+    if not cond:
+        failures.append(name)
+
+
+async def main():
+    from jarviscore import Mesh, MeshMode, CustomAgent
+
+    class AnalystAgent(CustomAgent):
+        role = "analyst"
+        capabilities = ["analysis"]
+
+        async def on_peer_request(self, msg):
+            payload = msg.data.get("payload") or msg.data.get("task", "")
+            return {"status": "success", "read": str(payload).upper()}
+
+    print("== CustomAgent developer journey ==")
+
+    mesh = Mesh(mode=MeshMode.AUTONOMOUS)
+    mesh.add(AnalystAgent)
+    await mesh.start()
+    try:
+        # 1. Workflow execution through on_peer_request delegation
+        results = await mesh.workflow("dx-custom-1", [
+            {"id": "read_a", "agent": "analyst", "task": "hello"},
+            {"id": "read_b", "agent": "analyst", "task": "world"},
+        ])
+        check("workflow returns results in step order", len(results) == 2)
+        check("every result carries step_id (#62)",
+              [r.get("step_id") for r in results] == ["read_a", "read_b"],
+              f"got {[r.get('step_id') for r in results]}")
+        check("success results carry the agent's payload",
+              results[0].get("output", {}).get("read") == "HELLO",
+              f"got {results[0]}")
+
+        # 2. Dynamic fan-out (#52)
+        fanout = await mesh.fanout(
+            "dx-custom-fanout",
+            agent="analysis",           # capability-based resolution
+            items=["alpha", "beta", "gamma", "delta"],
+            task=lambda s: f"read {s}",
+            context=lambda s: {"payload": s},
+            concurrency=2,
+            budget=3,
+        )
+        check("fanout respects the budget honestly",
+              len(fanout.results) == 3 and fanout.skipped == ["delta"])
+        check("fanout results in item order with identity",
+              [r["item"] for r in fanout.results] == ["alpha", "beta", "gamma"]
+              and all("step_id" in r for r in fanout.results))
+        check("fanout aggregation works",
+              fanout.aggregate(len) == 3)
+    finally:
+        await mesh.stop()
+
+    print()
+    if failures:
+        print(f"{FAIL} CustomAgent journey: {len(failures)} failure(s): {failures}")
+        sys.exit(1)
+    print(f"{PASS} CustomAgent journey: all checks passed")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/harnesses/dx_goalmode.py
+++ b/harnesses/dx_goalmode.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""DX Harness 3 - goal mode: plan -> depends_on -> execute -> persist (REAL LLM).
+
+The long-horizon developer journey: goal_oriented AutoAgent plans a
+multi-step task, the planner emits depends_on, execution honors it,
+facts accumulate in truth, and the execution persists for resume.
+"""
+import asyncio
+import json
+import sys
+
+PASS, FAIL = "✅", "❌"
+failures = []
+
+
+def check(name, cond, detail=""):
+    print(f"  {PASS if cond else FAIL} {name}" + (f" - {detail}" if detail and not cond else ""))
+    if not cond:
+        failures.append(name)
+
+
+async def main():
+    from jarviscore import Mesh, AutoAgent
+
+    class PlannerAgent(AutoAgent):
+        role = "planner_dx"
+        capabilities = ["research", "analysis", "writing"]
+        goal_oriented = True
+        system_prompt = (
+            "You are a concise research analyst. Keep every step's output "
+            "under 150 words. Never use web search - reason from knowledge."
+        )
+
+    print("== Goal-mode developer journey (live LLM) ==")
+
+    mesh = Mesh()
+    mesh.add(PlannerAgent)
+    await mesh.start()
+    try:
+        agent = mesh.get_agent("planner_dx")
+
+        goal = (
+            "Produce a three-part brief on running trading bots safely: "
+            "(1) list the top three operational risks, (2) list three "
+            "mitigations for those risks, (3) combine both into a short "
+            "final brief. Parts 1 and 2 are independent of each other; "
+            "part 3 needs both."
+        )
+        execution = await agent.execute_goal(goal, max_steps=8)
+
+        check("goal completes", execution.status == "complete",
+              f"status={execution.status} error={execution.error}")
+        check("plan had 3+ steps", len(execution.plan) >= 3,
+              f"{len(execution.plan)} steps")
+        deps_declared = any(s.depends_on for s in execution.plan)
+        check("planner declared depends_on (#74)", deps_declared,
+              f"plan: {[(s.step_id, s.depends_on) for s in execution.plan]}")
+        check("all steps completed", len(execution.completed) >= 3)
+        check("truth accumulated facts", len(execution.truth.facts) > 0,
+              f"{len(execution.truth.facts)} facts")
+        check("final result synthesized", bool(execution.result) and len(str(execution.result)) > 50)
+
+        print(f"      plan: {[(s.step_id, s.depends_on) for s in execution.plan]}")
+        print(f"      facts: {list(execution.truth.facts.keys())[:6]}")
+
+        # Persistence round-trip (#73) - snapshot -> rehydrate
+        snapshot = json.loads(json.dumps(execution.to_full_dict(), default=str))
+        from jarviscore.planning.goal_context import GoalExecution
+        restored = GoalExecution.from_snapshot(snapshot)
+        check("snapshot rehydrates plan + history (#73)",
+              len(restored.plan) == len(execution.plan)
+              and len(restored.completed) == len(execution.completed))
+        ctx = restored.context_for_next_step()
+        check("restored execution chains context (#72/#73)",
+              isinstance(ctx.get("_goal_facts"), dict)
+              and len(ctx.get("_completed_steps", [])) == len(execution.completed))
+    finally:
+        await mesh.stop()
+
+    print()
+    if failures:
+        print(f"{FAIL} Goal-mode journey: {len(failures)} failure(s): {failures}")
+        sys.exit(1)
+    print(f"{PASS} Goal-mode journey: all checks passed")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/harnesses/prod_autoagent_swarm.py
+++ b/harnesses/prod_autoagent_swarm.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python3
+"""Production harness: an AutoAgent swarm with plan mode on (REAL LLM).
+
+Persona: a developer building a research swarm with AutoAgent and
+goal_oriented=True, then running it the way production traffic arrives:
+simple asks mixed with genuinely complex goals, repeated sessions on
+the same agent, and a mixed-profile swarm workflow.
+
+Targets the two reported production failures directly:
+1. "Plan mode plans everything" - simple asks must route direct to the
+   Kernel (planner_mode=direct_kernel); only complex work may plan.
+2. "Context grows unendingly" - per-step input tokens inside a goal must
+   stay bounded, and repeated tasks on one agent must not inflate.
+
+Requires live LLM credentials (source billy/.env).
+"""
+import asyncio
+import sys
+
+PASS, FAIL = "✅", "❌"
+failures = []
+
+
+def check(name, cond, detail=""):
+    print(f"  {PASS if cond else FAIL} {name}" + (f" - {detail}" if detail and not cond else ""))
+    if not cond:
+        failures.append(name)
+
+
+def step_input_tokens(execution):
+    """Per-step input token trajectory from a GoalExecution."""
+    out = []
+    for cs in getattr(execution, "completed", []) or []:
+        meta = getattr(getattr(cs, "output", None), "metadata", None) or {}
+        toks = meta.get("tokens") or {}
+        out.append(int(toks.get("input", 0) or 0))
+    return out
+
+
+async def main():
+    from jarviscore import Mesh, AutoAgent
+
+    class ResearchLead(AutoAgent):
+        role = "research_lead"
+        capabilities = ["research", "analysis", "writing"]
+        goal_oriented = True
+        system_prompt = (
+            "You are a concise research analyst. Keep every answer under "
+            "150 words. Never use web search - reason from knowledge."
+        )
+
+    class BriefWriter(AutoAgent):
+        role = "brief_writer"
+        capabilities = ["writing"]
+        system_prompt = "You write tight one-paragraph executive briefs."
+
+    print("== Production AutoAgent swarm (live LLM) ==")
+    mesh = Mesh()
+    mesh.add(ResearchLead)
+    mesh.add(BriefWriter)
+    await mesh.start()
+
+    try:
+        lead = mesh.get_agent("research_lead")
+
+        # ── Phase 1: triage - plan mode must NOT plan everything ──────
+        print("\n-- Phase 1: triage under goal_oriented=True --")
+        simple_asks = [
+            "What does ETL stand for? One sentence.",
+            "Is this sentence positive or negative: 'The rollout went smoothly.' One word.",
+            "Summarize in one line: caching reduces repeated computation by storing results.",
+        ]
+        misplanned = []
+        for ask in simple_asks:
+            r = await lead.execute_task({"task": ask})
+            ge = r.get("goal_execution") or {}
+            if ge.get("planner_mode") != "direct_kernel":
+                misplanned.append((ask[:40], ge.get("planner_mode"),
+                                   ge.get("total_steps_planned")))
+            print(f"      [{ge.get('complexity', '?')}] {ask[:60]}")
+        check("simple asks route direct to Kernel, never the Planner",
+              not misplanned, f"misplanned: {misplanned}")
+
+        complex_ask = (
+            "Create a complete incident-response playbook for a small trading "
+            "desk covering data, execution, and infrastructure failures. "
+            "Part 1: inventory at least six failure modes across the three "
+            "areas. Part 2: define detection signals for each failure mode "
+            "from part 1. Part 3: write a response runbook for each failure "
+            "mode, drawing on parts 1 and 2. Part 4: write an executive "
+            "summary that references every earlier part. Each part depends "
+            "on the ones before it - this cannot be answered in one response."
+        )
+        r = await lead.execute_task({"task": complex_ask})
+        ge = r.get("goal_execution") or {}
+        planned = ge.get("planner_mode") != "direct_kernel" and ge.get("total_steps_planned", 0) >= 2
+        check("genuinely complex work does plan",
+              r.get("status") == "success" and planned,
+              f"status={r.get('status')} goal_execution={ge}")
+        check("planned goal reports real token telemetry (#63)",
+              (r.get("tokens") or {}).get("total", 0) > 0)
+
+        # ── Phase 2: context stays bounded inside a goal ──────────────
+        print("\n-- Phase 2: context growth inside a goal --")
+        execution = await lead.execute_goal(
+            "Write a four-part operations handbook for a small trading desk: "
+            "(1) data-quality checks, (2) execution risk controls, "
+            "(3) incident response steps, (4) a summary page that draws on "
+            "all three earlier parts.",
+            max_steps=8,
+        )
+        check("goal completes", execution.status == "complete",
+              f"status={execution.status} error={execution.error}")
+        traj = step_input_tokens(execution)
+        real = [t for t in traj if t > 0]
+        print(f"      input-token trajectory per step: {traj}")
+        check("per-step input tokens stay under budget ceiling",
+              all(t < 40_000 for t in traj), f"trajectory={traj}")
+        # Per-step totals are cumulative across a step's OODA turns, so they
+        # vary with turn count. Unbounded context growth has a distinct
+        # signature: a compounding monotonic climb that ends far above where
+        # it started. Oscillation is turn-count variance, not growth.
+        if len(real) >= 3:
+            climbing = all(real[i + 1] > real[i] * 1.15 for i in range(len(real) - 1))
+            check("context does not compound step over step",
+                  not (climbing and real[-1] > real[0] * 3),
+                  f"monotonic climb, trajectory={traj}")
+        check("facts accumulate without exploding the prompt",
+              0 < len(execution.truth.facts) <= 50,
+              f"{len(execution.truth.facts)} facts")
+
+        # ── Phase 3: repeated sessions on one agent stay flat ─────────
+        print("\n-- Phase 3: repeated sessions, same agent --")
+        flat_ask = "Name one benefit of code review. One sentence."
+        inputs = []
+        for i in range(4):
+            r = await lead.execute_task({"task": flat_ask})
+            toks = (r.get("tokens") or {}).get("input", 0)
+            inputs.append(int(toks or 0))
+            ok = r.get("status") == "success"
+            if not ok:
+                check(f"repeat {i + 1} succeeds", False, str(r)[:150])
+        print(f"      input tokens across identical asks: {inputs}")
+        pos = [t for t in inputs if t > 0]
+        check("no state bleeds across tasks (flat input tokens)",
+              len(pos) >= 2 and max(pos) < min(pos) * 2 + 1500,
+              f"inputs={inputs}")
+
+        # ── Phase 4: mixed-profile swarm workflow ─────────────────────
+        print("\n-- Phase 4: mixed swarm workflow --")
+        results = await mesh.workflow("swarm-brief", [
+            {"id": "facts", "agent": "research_lead",
+             "task": "List three facts about rate limiting in APIs. Be brief."},
+            {"id": "brief", "agent": "brief_writer",
+             "task": "Write a one-paragraph brief on why APIs need rate limiting.",
+             "context": {"execution_contract": {"execution_shape": "single_response"}}},
+        ])
+        by_id = {r.get("step_id"): r for r in results}
+        check("swarm workflow: both agents succeed",
+              all(r.get("status") == "success" for r in results),
+              f"{[(r.get('step_id'), r.get('status'), str(r.get('error'))[:80]) for r in results]}")
+        check("swarm workflow: single_response bypassed the kernel",
+              by_id.get("brief", {}).get("execution_shape") == "single_response",
+              f"envelope keys: {list(by_id.get('brief', {}).keys())}")
+        check("swarm workflow: telemetry present on both steps",
+              all((r.get("tokens") or {}).get("total", 0) > 0 for r in results))
+    finally:
+        await mesh.stop()
+
+    print()
+    if failures:
+        print(f"{FAIL} AutoAgent swarm: {len(failures)} failure(s): {failures}")
+        sys.exit(1)
+    print(f"{PASS} AutoAgent swarm: all checks passed")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/harnesses/prod_customagent_swarm.py
+++ b/harnesses/prod_customagent_swarm.py
@@ -1,0 +1,226 @@
+#!/usr/bin/env python3
+"""Production harness: a CustomAgent swarm under sustained load.
+
+Persona: a developer building a market-data processing desk with
+CustomAgent. Four agents with real (deterministic) brains, wired into
+DAG pipelines, dynamic fan-out, and then 30 back-to-back workflows on
+one mesh to prove the swarm is stable: no cross-workflow contamination,
+no timing drift, no unbounded memory growth.
+
+No LLM required. This is the infrastructure contract under load.
+"""
+import asyncio
+import resource
+import sys
+import time
+
+PASS, FAIL = "✅", "❌"
+failures = []
+
+
+def check(name, cond, detail=""):
+    print(f"  {PASS if cond else FAIL} {name}" + (f" - {detail}" if detail and not cond else ""))
+    if not cond:
+        failures.append(name)
+
+
+def rss_mb():
+    # ru_maxrss is bytes on macOS, KB on Linux
+    v = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+    return v / (1024 * 1024) if sys.platform == "darwin" else v / 1024
+
+
+async def main():
+    from jarviscore import Mesh, CustomAgent
+    from jarviscore.orchestration.workflow_builder import WorkflowBuilder
+
+    # ── Dana's desk: four agents, real deterministic brains ──────────
+
+    class IngestorAgent(CustomAgent):
+        role = "ingestor"
+        capabilities = ["ingest"]
+
+        async def on_peer_request(self, msg):
+            raw = str(msg.data.get("payload") or msg.data.get("task", ""))
+            return {"status": "success", "records": raw.strip().lower().split(",")}
+
+    class AnalystAgent(CustomAgent):
+        role = "desk_analyst"
+        capabilities = ["analysis"]
+
+        async def on_peer_request(self, msg):
+            text = str(msg.data.get("payload") or msg.data.get("task", ""))
+            if "poison" in text:
+                raise ValueError("upstream feed corrupt for this symbol")
+            return {"status": "success", "score": sum(ord(c) for c in text) % 100, "echo": text}
+
+    class RiskAgent(CustomAgent):
+        role = "risk"
+        capabilities = ["risk"]
+
+        async def on_peer_request(self, msg):
+            text = str(msg.data.get("payload") or msg.data.get("task", ""))
+            return {"status": "success", "flag": "HIGH" if "9" in text else "LOW", "seen": text[:120]}
+
+    class ReporterAgent(CustomAgent):
+        role = "reporter"
+        capabilities = ["report"]
+
+        async def on_peer_request(self, msg):
+            text = str(msg.data.get("payload") or msg.data.get("task", ""))
+            return {"status": "success", "report": f"REPORT[{text[:200]}]"}
+
+    print("== Production CustomAgent swarm ==")
+    mesh = Mesh()
+    for cls in (IngestorAgent, AnalystAgent, RiskAgent, ReporterAgent):
+        mesh.add(cls)
+    await mesh.start()
+
+    try:
+        # ── Phase 1: DAG pipeline with result references ──────────────
+        print("\n-- Phase 1: DAG pipeline --")
+        wf = (
+            WorkflowBuilder()
+            .step("ingest", "ingestor", "AAPL,MSFT,NVDA")
+            .step("analyse", "desk_analyst", "analyse: {ingest.result}", depends_on=["ingest"])
+            .step("risk", "risk", "risk-check: {analyse.result}", depends_on=["analyse"])
+            .step("report", "reporter", "final: {risk.result}", depends_on=["risk"])
+            .build(title="desk-pipeline", team="desk")
+        )
+        results = await wf.execute(mesh)
+        by_id = {r["step_id"]: r for r in results}
+        check("pipeline: all 4 steps returned", len(results) == 4,
+              f"got {[r.get('step_id') for r in results]}")
+        check("pipeline: every step succeeded",
+              all(r["status"] == "success" for r in results),
+              f"{[(r['step_id'], r['status'], r.get('error')) for r in results]}")
+        # WorkflowBuilder wraps: result["output"] == {"status", "output": <agent dict>}
+        risk_seen = str(by_id.get("risk", {}).get("output", ""))
+        check("pipeline: downstream step received upstream output",
+              "risk-check" in risk_seen and "score" in risk_seen,
+              f"risk saw: {risk_seen[:200]!r}")
+
+        # ── Phase 2: dynamic fan-out with a poison item ───────────────
+        print("\n-- Phase 2: fan-out board scan (24 symbols, 1 poison) --")
+        symbols = [f"SYM{i:02d}" for i in range(23)] + ["poison-feed"]
+        fan = await mesh.fanout(
+            "board-scan",
+            agent="analysis",
+            items=symbols,
+            task=lambda s: f"deep-read {s}",
+            context=lambda s: {"payload": s},
+            concurrency=6,
+            budget=20,
+            on_error="collect",
+        )
+        check("fanout: budget honored with skipped reported",
+              len(fan.results) == 20 and len(fan.skipped) == 4,
+              f"results={len(fan.results)} skipped={fan.skipped}")
+        check("fanout: results in item order with identity",
+              [r["item"] for r in fan.results] == symbols[:20]
+              and all("step_id" in r for r in fan.results))
+        check("fanout: partial failure is honest, siblings unaffected",
+              len(fan.failed) == 0 and len(fan.succeeded) == 20,
+              f"failed={[(f.get('item'), str(f.get('error'))[:60]) for f in fan.failed]}")
+        # NOTE: fanout results carry the agent dict under "output" (the
+        # workflows guide's fanout example says r["payload"] - doc bug, filed)
+        scores = fan.aggregate(lambda rs: [r["output"]["score"] for r in rs if r.get("output")])
+        check("fanout: aggregation over typed payloads", len(scores) == 20)
+
+        # poison actually poisons when selected
+        fan2 = await mesh.fanout(
+            "poison-scan",
+            agent="analysis",
+            items=["SYMOK", "poison-feed", "SYMOK2"],
+            task=lambda s: f"deep-read {s}",
+            context=lambda s: {"payload": s},
+            concurrency=3,
+            on_error="collect",
+        )
+        check("fanout: poison item fails alone, in collect mode",
+              len(fan2.failed) == 1 and len(fan2.succeeded) == 2
+              and fan2.failed[0].get("item") == "poison-feed",
+              f"failed={[(f.get('item'), str(f.get('error'))[:80]) for f in fan2.failed]}")
+
+        # ── Phase 3: sustained load, 30 workflows on one mesh ─────────
+        print("\n-- Phase 3: sustained load (30 workflows, same mesh) --")
+        rss_before = rss_mb()
+        durations = []
+        bleed = 0
+        for w in range(30):
+            token = f"wf{w:03d}-token"
+            t0 = time.monotonic()
+            res = await mesh.workflow(f"load-{w}", [
+                {"id": "a", "agent": "desk_analyst", "task": f"tick {token}",
+                 "context": {"payload": f"tick {token}"}},
+                {"id": "b", "agent": "risk", "task": f"risk {token}",
+                 "context": {"payload": f"risk {token}"}},
+                {"id": "c", "agent": "reporter", "task": f"report {token}",
+                 "context": {"payload": f"report {token}"}},
+            ])
+            durations.append(time.monotonic() - t0)
+            ok = (len(res) == 3 and all(r["status"] == "success" for r in res))
+            if not ok:
+                bleed += 1
+                continue
+            # cross-workflow contamination check: each payload must carry
+            # THIS workflow's token and no other workflow's token
+            for r in res:
+                blob = str(r.get("output", ""))
+                if token not in blob or any(
+                    f"wf{x:03d}-token" in blob for x in range(30) if f"wf{x:03d}" != f"wf{w:03d}"
+                ):
+                    bleed += 1
+        rss_after = rss_mb()
+        first5 = sum(durations[:5]) / 5
+        last5 = sum(durations[-5:]) / 5
+        check("load: all 30 workflows correct, zero cross-workflow bleed",
+              bleed == 0, f"bleed count={bleed}")
+        check("load: no timing drift across the run",
+              last5 < max(first5 * 3, first5 + 0.5),
+              f"first5={first5:.3f}s last5={last5:.3f}s")
+        check("load: memory growth bounded",
+              (rss_after - rss_before) < 200,
+              f"rss grew {rss_after - rss_before:.1f} MB")
+        print(f"      timing: first5={first5 * 1000:.0f}ms last5={last5 * 1000:.0f}ms "
+              f"rss: {rss_before:.0f} -> {rss_after:.0f} MB")
+
+        # ── Phase 4: failure semantics do not wedge the mesh ──────────
+        print("\n-- Phase 4: failure semantics --")
+        wf_fail = (
+            WorkflowBuilder()
+            .step("bad", "desk_analyst", "poison this one", depends_on=[])
+            .step("dependent", "reporter", "needs: {bad.result}", depends_on=["bad"])
+            .step("sibling", "risk", "independent risk pass")
+            .build(title="failure-semantics", team="desk")
+        )
+        fres = await wf_fail.execute(mesh)
+        fby = {r["step_id"]: r for r in fres}
+        check("failure: bad step reports failure with identity",
+              fby.get("bad", {}).get("status") == "failure",
+              f"bad={fby.get('bad')}")
+        check("failure: dependent step is blocked, not silently run",
+              fby.get("dependent", {}).get("status") != "success",
+              f"dependent={fby.get('dependent', {}).get('status')}")
+        check("failure: independent sibling still runs",
+              fby.get("sibling", {}).get("status") == "success",
+              f"sibling={fby.get('sibling', {}).get('status')}")
+        # mesh still healthy after the failure
+        after = await mesh.workflow("post-failure", [
+            {"id": "ok", "agent": "reporter", "task": "still alive",
+             "context": {"payload": "still alive"}},
+        ])
+        check("failure: mesh healthy after a failed workflow",
+              after[0]["status"] == "success")
+    finally:
+        await mesh.stop()
+
+    print()
+    if failures:
+        print(f"{FAIL} CustomAgent swarm: {len(failures)} failure(s): {failures}")
+        sys.exit(1)
+    print(f"{PASS} CustomAgent swarm: all checks passed")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
Promotes the release-gate harnesses from /tmp into the repo, as agreed.

These test the developer journeys end to end, following the guides:

| Harness | Journey | Needs |
|---|---|---|
| `dx_customagent.py` | Workflows, step identity (#62), `mesh.fanout()` (#52) | Offline |
| `dx_autoagent.py` | Loud pre-start errors (#63), `single_response` contract, kernel task | Live LLM keys |
| `dx_goalmode.py` | Planning with `depends_on` (#74), parallel steps, fact accumulation, persistence + resume (#72/#73) | Live LLM keys |

Each one has already caught a real bug the mocked unit suite could not see: a phantom method recommended by a docstring, a misrouted execution contract, and a flaky wall-clock check now replaced with a deterministic envelope marker (`execution_shape`).

The README sets the standing rule: a failing harness blocks release, because either the framework broke the journey or the documentation describes a journey that no longer exists.

**Merge this LAST.** The harnesses exercise the new surface (fanout, single_response, depends_on, resume) and only pass once #64-#78 are merged. Verified green against the integration preview of all eleven branches, with live Azure for the two LLM harnesses.
