### PR TITLE
cli: jarviscore inspect - read the flight recorder you already have

### DIFF
--- a/jarviscore/cli/__main__.py
+++ b/jarviscore/cli/__main__.py
@@ -14,6 +14,8 @@ Usage:
     jarviscore memory init
     jarviscore atom test --bundle slack --mode dry-run
     jarviscore atom list
+    jarviscore inspect                       # List recorded runs
+    jarviscore inspect <workflow_id>         # Timeline for one run
 """
 
 import sys
@@ -29,6 +31,7 @@ def main():
         print("  nexus      - Manage Nexus auth (init, register, status, list, test)")
         print("  memory     - Manage Athena MemOS (init, status, context, search)")
         print("  atom       - Validate, test, and list integration atoms")
+        print("  inspect    - Read recorded traces: what did my agents do?")
         sys.exit(1)
 
     command = sys.argv[1]
@@ -52,9 +55,12 @@ def main():
     elif command == 'atom':
         from .atom import main as atom_main
         atom_main()
+    elif command == 'inspect':
+        from .inspect import main as inspect_main
+        inspect_main()
     else:
         print(f"Unknown command: {command}")
-        print("\nAvailable commands: init, check, smoketest, nexus, memory, atom")
+        print("\nAvailable commands: init, check, smoketest, nexus, memory, atom, inspect")
         sys.exit(1)
 
 

--- a/jarviscore/cli/inspect.py
+++ b/jarviscore/cli/inspect.py
@@ -1,0 +1,229 @@
+"""
+jarviscore inspect - read trace JSONL files and show what your agents did.
+
+Every run already writes a flight record to traces/ (no Redis needed).
+This command turns those files into something a human can read:
+
+    jarviscore inspect                       # list recorded runs
+    jarviscore inspect <workflow_id>         # timeline for one run
+    jarviscore inspect <workflow_id> --errors    # failures and recoveries only
+    jarviscore inspect <workflow_id> --step <step_id>   # one step
+    jarviscore inspect --dir /path/to/traces     # non-default trace dir
+
+Design rules:
+- stdlib only, works offline, no framework imports required to read files
+- never truncate silently: long values are clipped with an explicit marker
+"""
+
+import argparse
+import json
+import os
+import sys
+from collections import defaultdict
+from datetime import datetime
+from typing import Any, Dict, List, Optional, Tuple
+
+CLIP = 160
+
+
+def _clip(value: Any, limit: int = CLIP) -> str:
+    text = str(value)
+    if len(text) <= limit:
+        return text
+    return f"{text[:limit]} [clipped: showing {limit} of {len(text)} chars]"
+
+
+def _parse_ts(raw: str) -> Optional[datetime]:
+    try:
+        return datetime.fromisoformat(raw)
+    except (ValueError, TypeError):
+        return None
+
+
+def _load_events(path: str) -> List[Dict[str, Any]]:
+    events: List[Dict[str, Any]] = []
+    try:
+        with open(path, "r", encoding="utf-8") as fh:
+            for line in fh:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    events.append(json.loads(line))
+                except json.JSONDecodeError:
+                    events.append({"type": "unparseable_line", "data": {"raw": _clip(line)}})
+    except OSError as exc:
+        print(f"cannot read {path}: {exc}", file=sys.stderr)
+    return events
+
+
+def _discover(trace_dir: str) -> Dict[str, List[str]]:
+    """Map workflow_id -> trace file paths, newest runs last."""
+    runs: Dict[str, List[str]] = defaultdict(list)
+    if not os.path.isdir(trace_dir):
+        return runs
+    for name in sorted(os.listdir(trace_dir)):
+        if not name.endswith(".jsonl"):
+            continue
+        path = os.path.join(trace_dir, name)
+        stem = name[: -len(".jsonl")]
+        workflow_id = stem.rsplit("_", 1)[0] if "_" in stem else stem
+        runs[workflow_id].append(path)
+    return runs
+
+
+def _run_summary(paths: List[str]) -> Dict[str, Any]:
+    first_ts = last_ts = None
+    steps = set()
+    tokens = 0
+    failures = 0
+    status = "unknown"
+    events_total = 0
+    for path in paths:
+        for event in _load_events(path):
+            events_total += 1
+            ts = _parse_ts(event.get("timestamp", ""))
+            if ts is not None:
+                if first_ts is None or ts < first_ts:
+                    first_ts = ts
+                if last_ts is None or ts > last_ts:
+                    last_ts = ts
+            step = event.get("step_id")
+            if step:
+                steps.add(step)
+            etype = event.get("type", "")
+            data = event.get("data", {}) or {}
+            if etype == "llm_response":
+                tokens += int(data.get("tokens", 0) or 0)
+            elif etype in ("step_failed", "error_recovery"):
+                failures += 1
+            elif etype == "workflow_complete":
+                status = str(data.get("status", "complete"))
+    duration = ""
+    if first_ts is not None and last_ts is not None:
+        duration = f"{(last_ts - first_ts).total_seconds():.1f}s"
+    return {
+        "steps": len(steps),
+        "events": events_total,
+        "tokens": tokens,
+        "failures": failures,
+        "status": status,
+        "started": first_ts.strftime("%Y-%m-%d %H:%M:%S") if first_ts else "?",
+        "duration": duration,
+    }
+
+
+def _list_runs(trace_dir: str) -> int:
+    runs = _discover(trace_dir)
+    if not runs:
+        print(f"no trace files in {trace_dir}/ (runs write them automatically)")
+        return 1
+    header = f"{'workflow':<32} {'started':<20} {'steps':>5} {'tokens':>8} {'fail':>4} {'dur':>8}  status"
+    print(header)
+    print("-" * len(header))
+    ordered = sorted(runs.items(), key=lambda kv: _run_summary(kv[1])["started"])
+    for workflow_id, paths in ordered:
+        s = _run_summary(paths)
+        print(
+            f"{_clip(workflow_id, 32):<32} {s['started']:<20} {s['steps']:>5} "
+            f"{s['tokens']:>8} {s['failures']:>4} {s['duration']:>8}  {s['status']}"
+        )
+    print(f"\n{len(runs)} run(s). Inspect one: jarviscore inspect <workflow>")
+    return 0
+
+
+_RENDERERS = {
+    "workflow_start": lambda d: f"workflow started ({d.get('step_count', '?')} steps planned)",
+    "workflow_complete": lambda d: f"workflow {d.get('status', 'complete')}: {_clip(d.get('summary', ''))}",
+    "step_claimed": lambda d: f"claimed by {d.get('agent_id', '?')}",
+    "step_complete": lambda d: f"step complete: {_clip(d.get('summary', d))}",
+    "step_failed": lambda d: f"STEP FAILED: {_clip(d.get('error', d))}",
+    "thinking": lambda d: f"thinking: {_clip(d.get('thought', d))}",
+    "kernel_delegate": lambda d: f"delegated to {d.get('subagent', '?')}: {_clip(d.get('task', ''))}",
+    "subagent_yield": lambda d: f"subagent {d.get('subagent', '?')} yielded: {_clip(d.get('reason', ''))}",
+    "tool_start": lambda d: f"tool {d.get('tool_name', d.get('tool', '?'))} {_clip(d.get('params', ''))}",
+    "tool_result": lambda d: f"  -> {_clip(d.get('result', d))}",
+    "llm_request": lambda d: f"llm call ({d.get('provider', '?')}/{d.get('model', '?')})",
+    "llm_response": lambda d: (
+        f"  -> {d.get('tokens', '?')} tokens in {d.get('latency_ms', '?')}ms"
+    ),
+    "error_recovery": lambda d: f"RECOVERY: {_clip(d.get('error', ''))} -> {_clip(d.get('action', ''))}",
+    "hitl_task_created": lambda d: f"HITL task created: {_clip(d)}",
+    "hitl_waiting": lambda d: f"HITL waiting: {_clip(d.get('reason', ''))}",
+    "hitl_resolved": lambda d: f"HITL resolved: {d.get('outcome', '?')}",
+    "mailbox_send": lambda d: f"mail -> {d.get('target', '?')}: {_clip(d.get('message_preview', ''))}",
+    "mailbox_receive": lambda d: f"mail <- {d.get('count', '?')} message(s)",
+    "context_snapshot": lambda d: f"context snapshot ({d.get('fact_count', '?')} facts, v{d.get('version', '?')})",
+}
+
+_ERROR_TYPES = {"step_failed", "error_recovery", "unparseable_line"}
+
+
+def _render_event(event: Dict[str, Any]) -> Tuple[str, str, bool]:
+    etype = event.get("type", "?")
+    data = event.get("data", {}) or {}
+    renderer = _RENDERERS.get(etype)
+    text = renderer(data) if renderer else f"{etype}: {_clip(data)}"
+    ts = event.get("timestamp", "")
+    clock = ts[11:19] if len(ts) >= 19 else "?"
+    return clock, text, etype in _ERROR_TYPES
+
+
+def _show_run(trace_dir: str, workflow_id: str, *, step: Optional[str], errors_only: bool) -> int:
+    runs = _discover(trace_dir)
+    matches = [wid for wid in runs if wid == workflow_id] or [
+        wid for wid in runs if wid.startswith(workflow_id)
+    ]
+    if not matches:
+        print(f"no run matching '{workflow_id}' in {trace_dir}/", file=sys.stderr)
+        return 1
+    if len(matches) > 1:
+        print(f"'{workflow_id}' is ambiguous: {', '.join(sorted(matches)[:6])}", file=sys.stderr)
+        return 1
+    wid = matches[0]
+    events: List[Dict[str, Any]] = []
+    for path in runs[wid]:
+        events.extend(_load_events(path))
+    events.sort(key=lambda e: e.get("timestamp", ""))
+
+    s = _run_summary(runs[wid])
+    print(f"run {wid} | started {s['started']} | {s['steps']} step(s) | "
+          f"{s['tokens']} tokens | {s['failures']} failure(s) | {s['duration']} | {s['status']}")
+    current_step = object()
+    shown = 0
+    for event in events:
+        if step and event.get("step_id") != step:
+            continue
+        clock, text, is_error = _render_event(event)
+        if errors_only and not is_error:
+            continue
+        event_step = event.get("step_id")
+        if event_step != current_step:
+            current_step = event_step
+            print(f"\n[{event_step or 'workflow'}]")
+        marker = "!! " if is_error else "   "
+        print(f"{marker}{clock}  {text}")
+        shown += 1
+    if shown == 0:
+        print("no events matched the filters")
+    return 0
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        prog="jarviscore inspect",
+        description="Read recorded traces and show what your agents actually did.",
+    )
+    parser.add_argument("workflow", nargs="?", help="workflow id (prefix ok); omit to list runs")
+    parser.add_argument("--dir", default="traces", help="trace directory (default: ./traces)")
+    parser.add_argument("--step", default=None, help="only events for this step id")
+    parser.add_argument("--errors", action="store_true", help="failures and recoveries only")
+    args = parser.parse_args()
+
+    if args.workflow is None:
+        sys.exit(_list_runs(args.dir))
+    sys.exit(_show_run(args.dir, args.workflow, step=args.step, errors_only=args.errors))
+
+
+if __name__ == "__main__":
+    main()

--- a/jarviscore/docs/guides/observability.md
+++ b/jarviscore/docs/guides/observability.md
@@ -58,7 +58,7 @@ Written even when Redis is unavailable. Each line is a self-contained JSON event
 
 ### Reading Traces: `jarviscore inspect`
 
-The JSONL channel means every run leaves a flight record on disk. The `inspect` command reads it back without Redis, without the framework running, and without writing your own parser:
+Every run leaves a flight record on disk. `inspect` reads it back: no Redis, no running mesh, no custom parser.
 
 ```bash
 jarviscore inspect                      # list recorded runs
@@ -68,7 +68,7 @@ jarviscore inspect wf-abc123 --step step-001
 jarviscore inspect --dir /var/traces    # non-default trace directory
 ```
 
-The run list shows steps, tokens, failure count, duration, and final status per workflow. The timeline groups events by step and renders each one on a single line: agent claims, thinking, delegations, tool calls with results, LLM calls with token counts and latency, and failures marked with `!!`. Workflow ids match by prefix, and long values are clipped with an explicit `[clipped: showing N of M chars]` marker, never silently.
+The run list shows steps, tokens, failures, duration, and status per workflow. The timeline groups events by step, one line each: claims, thinking, delegations, tool calls, LLM latency and tokens, failures marked `!!`. Workflow ids match by prefix. Long values are clipped with an explicit `[clipped: showing N of M chars]` marker, never silently.
 
 ### Trace Event Shape
 

--- a/jarviscore/docs/guides/observability.md
+++ b/jarviscore/docs/guides/observability.md
@@ -54,7 +54,21 @@ Subscribe from a dashboard, alerting system, or log aggregator to receive events
 ```
 Path: {trace_dir}/{workflow_id}_{step_id}.jsonl
 ```
-Written even when Redis is unavailable. Each line is a self-contained JSON event — parseable with any standard tooling.
+Written even when Redis is unavailable. Each line is a self-contained JSON event, parseable with any standard tooling.
+
+### Reading Traces: `jarviscore inspect`
+
+The JSONL channel means every run leaves a flight record on disk. The `inspect` command reads it back without Redis, without the framework running, and without writing your own parser:
+
+```bash
+jarviscore inspect                      # list recorded runs
+jarviscore inspect wf-abc123            # per-step timeline for one run
+jarviscore inspect wf-abc123 --errors   # failures and recoveries only
+jarviscore inspect wf-abc123 --step step-001
+jarviscore inspect --dir /var/traces    # non-default trace directory
+```
+
+The run list shows steps, tokens, failure count, duration, and final status per workflow. The timeline groups events by step and renders each one on a single line: agent claims, thinking, delegations, tool calls with results, LLM calls with token counts and latency, and failures marked with `!!`. Workflow ids match by prefix, and long values are clipped with an explicit `[clipped: showing N of M chars]` marker, never silently.
 
 ### Trace Event Shape
 

--- a/jarviscore/docs/reference/cli.md
+++ b/jarviscore/docs/reference/cli.md
@@ -20,6 +20,7 @@ Commands:
   nexus       Manage credential infrastructure
   memory      Manage agent memory infrastructure
   atom        Validate, test, and list integration atoms
+  inspect     Read recorded traces from past runs
 ```
 
 ---
@@ -374,3 +375,32 @@ jarviscore/integrations/atoms
 ```
 
 See [Testing Atoms](../guides/testing-atoms.md) for the full workflow — from writing a new atom to promoting it to `verified`.
+
+---
+
+## jarviscore inspect
+
+Reads recorded traces and shows what your agents actually did. Requires `TRACE_ENABLED=true` on the runs you want to inspect.
+
+```bash
+# List recorded runs
+jarviscore inspect
+
+# Timeline for one run (workflow id prefix is enough)
+jarviscore inspect wf-2024
+
+# Failures and recoveries only
+jarviscore inspect wf-2024 --errors
+
+# Events for a single step
+jarviscore inspect wf-2024 --step analyze
+```
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `workflow` | `str` | (none) | Workflow id, prefix match accepted; omit to list runs |
+| `--dir` | `str` | `./traces` | Directory containing trace JSONL files |
+| `--step` | `str` | (none) | Only show events for this step id |
+| `--errors` | flag | off | Only show failures and recoveries |
+
+See [Observability](../guides/observability.md) for how traces are recorded and what each event means.

--- a/pytest-of-muyukanikizito/pytest-0/test_discover_groups_files_by_current
+++ b/pytest-of-muyukanikizito/pytest-0/test_discover_groups_files_by_current
@@ -1,0 +1,1 @@
+/Users/muyukanikizito/.jc-worktrees/inspect/pytest-of-muyukanikizito/pytest-0/test_discover_groups_files_by_0

--- a/pytest-of-muyukanikizito/pytest-0/test_list_runs_empty_dir_is_hecurrent
+++ b/pytest-of-muyukanikizito/pytest-0/test_list_runs_empty_dir_is_hecurrent
@@ -1,0 +1,1 @@
+/Users/muyukanikizito/.jc-worktrees/inspect/pytest-of-muyukanikizito/pytest-0/test_list_runs_empty_dir_is_he0

--- a/pytest-of-muyukanikizito/pytest-0/test_list_runs_renders_tablecurrent
+++ b/pytest-of-muyukanikizito/pytest-0/test_list_runs_renders_tablecurrent
@@ -1,0 +1,1 @@
+/Users/muyukanikizito/.jc-worktrees/inspect/pytest-of-muyukanikizito/pytest-0/test_list_runs_renders_table0

--- a/pytest-of-muyukanikizito/pytest-0/test_run_summary_aggregates_stcurrent
+++ b/pytest-of-muyukanikizito/pytest-0/test_run_summary_aggregates_stcurrent
@@ -1,0 +1,1 @@
+/Users/muyukanikizito/.jc-worktrees/inspect/pytest-of-muyukanikizito/pytest-0/test_run_summary_aggregates_st0

--- a/pytest-of-muyukanikizito/pytest-0/test_show_run_errors_only_filtcurrent
+++ b/pytest-of-muyukanikizito/pytest-0/test_show_run_errors_only_filtcurrent
@@ -1,0 +1,1 @@
+/Users/muyukanikizito/.jc-worktrees/inspect/pytest-of-muyukanikizito/pytest-0/test_show_run_errors_only_filt0

--- a/pytest-of-muyukanikizito/pytest-0/test_show_run_prefix_match_andcurrent
+++ b/pytest-of-muyukanikizito/pytest-0/test_show_run_prefix_match_andcurrent
@@ -1,0 +1,1 @@
+/Users/muyukanikizito/.jc-worktrees/inspect/pytest-of-muyukanikizito/pytest-0/test_show_run_prefix_match_and0

--- a/pytest-of-muyukanikizito/pytest-0/test_show_run_renders_timelinecurrent
+++ b/pytest-of-muyukanikizito/pytest-0/test_show_run_renders_timelinecurrent
@@ -1,0 +1,1 @@
+/Users/muyukanikizito/.jc-worktrees/inspect/pytest-of-muyukanikizito/pytest-0/test_show_run_renders_timeline0

--- a/pytest-of-muyukanikizito/pytest-0/test_show_run_unknown_workflowcurrent
+++ b/pytest-of-muyukanikizito/pytest-0/test_show_run_unknown_workflowcurrent
@@ -1,0 +1,1 @@
+/Users/muyukanikizito/.jc-worktrees/inspect/pytest-of-muyukanikizito/pytest-0/test_show_run_unknown_workflow0

--- a/pytest-of-muyukanikizito/pytest-0/test_unparseable_lines_survivecurrent
+++ b/pytest-of-muyukanikizito/pytest-0/test_unparseable_lines_survivecurrent
@@ -1,0 +1,1 @@
+/Users/muyukanikizito/.jc-worktrees/inspect/pytest-of-muyukanikizito/pytest-0/test_unparseable_lines_survive0

--- a/pytest-of-muyukanikizito/pytest-1/test_discover_groups_files_by_current
+++ b/pytest-of-muyukanikizito/pytest-1/test_discover_groups_files_by_current
@@ -1,0 +1,1 @@
+/Users/muyukanikizito/.jc-worktrees/inspect/pytest-of-muyukanikizito/pytest-1/test_discover_groups_files_by_0

--- a/pytest-of-muyukanikizito/pytest-1/test_list_runs_empty_dir_is_hecurrent
+++ b/pytest-of-muyukanikizito/pytest-1/test_list_runs_empty_dir_is_hecurrent
@@ -1,0 +1,1 @@
+/Users/muyukanikizito/.jc-worktrees/inspect/pytest-of-muyukanikizito/pytest-1/test_list_runs_empty_dir_is_he0

--- a/pytest-of-muyukanikizito/pytest-1/test_list_runs_renders_tablecurrent
+++ b/pytest-of-muyukanikizito/pytest-1/test_list_runs_renders_tablecurrent
@@ -1,0 +1,1 @@
+/Users/muyukanikizito/.jc-worktrees/inspect/pytest-of-muyukanikizito/pytest-1/test_list_runs_renders_table0

--- a/pytest-of-muyukanikizito/pytest-1/test_run_summary_aggregates_stcurrent
+++ b/pytest-of-muyukanikizito/pytest-1/test_run_summary_aggregates_stcurrent
@@ -1,0 +1,1 @@
+/Users/muyukanikizito/.jc-worktrees/inspect/pytest-of-muyukanikizito/pytest-1/test_run_summary_aggregates_st0

--- a/pytest-of-muyukanikizito/pytest-1/test_show_run_errors_only_filtcurrent
+++ b/pytest-of-muyukanikizito/pytest-1/test_show_run_errors_only_filtcurrent
@@ -1,0 +1,1 @@
+/Users/muyukanikizito/.jc-worktrees/inspect/pytest-of-muyukanikizito/pytest-1/test_show_run_errors_only_filt0

--- a/pytest-of-muyukanikizito/pytest-1/test_show_run_prefix_match_andcurrent
+++ b/pytest-of-muyukanikizito/pytest-1/test_show_run_prefix_match_andcurrent
@@ -1,0 +1,1 @@
+/Users/muyukanikizito/.jc-worktrees/inspect/pytest-of-muyukanikizito/pytest-1/test_show_run_prefix_match_and0

--- a/pytest-of-muyukanikizito/pytest-1/test_show_run_renders_timelinecurrent
+++ b/pytest-of-muyukanikizito/pytest-1/test_show_run_renders_timelinecurrent
@@ -1,0 +1,1 @@
+/Users/muyukanikizito/.jc-worktrees/inspect/pytest-of-muyukanikizito/pytest-1/test_show_run_renders_timeline0

--- a/pytest-of-muyukanikizito/pytest-1/test_show_run_unknown_workflowcurrent
+++ b/pytest-of-muyukanikizito/pytest-1/test_show_run_unknown_workflowcurrent
@@ -1,0 +1,1 @@
+/Users/muyukanikizito/.jc-worktrees/inspect/pytest-of-muyukanikizito/pytest-1/test_show_run_unknown_workflow0

--- a/pytest-of-muyukanikizito/pytest-1/test_unparseable_lines_survivecurrent
+++ b/pytest-of-muyukanikizito/pytest-1/test_unparseable_lines_survivecurrent
@@ -1,0 +1,1 @@
+/Users/muyukanikizito/.jc-worktrees/inspect/pytest-of-muyukanikizito/pytest-1/test_unparseable_lines_survive0

--- a/pytest-of-muyukanikizito/pytest-current
+++ b/pytest-of-muyukanikizito/pytest-current
@@ -1,0 +1,1 @@
+/Users/muyukanikizito/.jc-worktrees/inspect/pytest-of-muyukanikizito/pytest-1

--- a/tests/test_cli_inspect.py
+++ b/tests/test_cli_inspect.py
@@ -1,0 +1,121 @@
+"""Tests for `jarviscore inspect` - the trace reader."""
+
+import json
+import os
+
+import pytest
+
+from jarviscore.cli.inspect import _clip, _discover, _list_runs, _run_summary, _show_run
+
+
+def _write_trace(trace_dir, workflow_id, step_id, events):
+    os.makedirs(trace_dir, exist_ok=True)
+    path = os.path.join(trace_dir, f"{workflow_id}_{step_id}.jsonl")
+    with open(path, "a", encoding="utf-8") as fh:
+        for i, (etype, data) in enumerate(events):
+            fh.write(json.dumps({
+                "workflow_id": workflow_id,
+                "step_id": step_id,
+                "timestamp": f"2026-08-04T10:00:{i:02d}+00:00",
+                "type": etype,
+                "data": data,
+            }) + "\n")
+    return path
+
+
+@pytest.fixture
+def trace_dir(tmp_path):
+    d = str(tmp_path / "traces")
+    _write_trace(d, "research-run", "step-1", [
+        ("workflow_start", {"step_count": 2}),
+        ("step_claimed", {"agent_id": "researcher"}),
+        ("llm_request", {"provider": "claude", "model": "sonnet"}),
+        ("llm_response", {"tokens": 420, "latency_ms": 900}),
+        ("tool_start", {"tool_name": "web_search", "params": {"q": "x"}}),
+        ("tool_result", {"result": "found 3 sources"}),
+        ("step_complete", {"summary": "research done"}),
+    ])
+    _write_trace(d, "research-run", "step-2", [
+        ("step_claimed", {"agent_id": "writer"}),
+        ("step_failed", {"error": "provider timeout"}),
+        ("error_recovery", {"error": "provider timeout", "action": "retried with fallback"}),
+        ("workflow_complete", {"status": "complete", "summary": "done"}),
+    ])
+    _write_trace(d, "other-run", "s1", [
+        ("workflow_start", {"step_count": 1}),
+        ("workflow_complete", {"status": "failed", "summary": "boom"}),
+    ])
+    return d
+
+
+def test_discover_groups_files_by_workflow(trace_dir):
+    runs = _discover(trace_dir)
+    assert set(runs) == {"research-run", "other-run"}
+    assert len(runs["research-run"]) == 2
+
+
+def test_run_summary_aggregates_steps_tokens_failures(trace_dir):
+    runs = _discover(trace_dir)
+    s = _run_summary(runs["research-run"])
+    assert s["steps"] == 2
+    assert s["tokens"] == 420
+    assert s["failures"] == 2      # step_failed + error_recovery
+    assert s["status"] == "complete"
+    assert s["duration"].endswith("s")
+
+
+def test_list_runs_renders_table(trace_dir, capsys):
+    assert _list_runs(trace_dir) == 0
+    out = capsys.readouterr().out
+    assert "research-run" in out
+    assert "other-run" in out
+    assert "workflow" in out       # header
+
+
+def test_list_runs_empty_dir_is_helpful(tmp_path, capsys):
+    assert _list_runs(str(tmp_path / "nowhere")) == 1
+    assert "no trace files" in capsys.readouterr().out
+
+
+def test_show_run_renders_timeline_grouped_by_step(trace_dir, capsys):
+    assert _show_run(trace_dir, "research-run", step=None, errors_only=False) == 0
+    out = capsys.readouterr().out
+    assert "[step-1]" in out and "[step-2]" in out
+    assert "web_search" in out
+    assert "420 tokens" in out
+    assert "STEP FAILED: provider timeout" in out
+    assert "!! " in out            # error marker
+
+
+def test_show_run_errors_only_filter(trace_dir, capsys):
+    assert _show_run(trace_dir, "research-run", step=None, errors_only=True) == 0
+    out = capsys.readouterr().out
+    assert "STEP FAILED" in out and "RECOVERY" in out
+    assert "web_search" not in out
+
+
+def test_show_run_prefix_match_and_ambiguity(trace_dir, capsys):
+    assert _show_run(trace_dir, "research", step=None, errors_only=False) == 0
+    # shared prefix of both runs is ambiguous
+    _write_trace(trace_dir, "research-run-b", "s1", [("workflow_start", {})])
+    assert _show_run(trace_dir, "research", step=None, errors_only=False) == 1
+    assert "ambiguous" in capsys.readouterr().err
+
+
+def test_show_run_unknown_workflow(trace_dir, capsys):
+    assert _show_run(trace_dir, "nope", step=None, errors_only=False) == 1
+    assert "no run matching" in capsys.readouterr().err
+
+
+def test_clip_marks_truncation_honestly():
+    assert _clip("short") == "short"
+    clipped = _clip("x" * 500, 100)
+    assert clipped.startswith("x" * 100)
+    assert "[clipped: showing 100 of 500 chars]" in clipped
+
+
+def test_unparseable_lines_survive_as_events(trace_dir, capsys):
+    with open(os.path.join(trace_dir, "research-run_step-1.jsonl"), "a") as fh:
+        fh.write("not json at all\n")
+    assert _show_run(trace_dir, "research-run", step=None, errors_only=True) == 0
+    assert "unparseable_line" in capsys.readouterr().out


### PR DESCRIPTION
## What

`jarviscore inspect`: a stdlib-only CLI that reads the trace JSONL files TraceManager already writes and renders them for humans.

```
jarviscore inspect                      # list recorded runs
jarviscore inspect <workflow>           # per-step timeline
jarviscore inspect <workflow> --errors  # failures and recoveries only
jarviscore inspect <workflow> --step s2 # one step
jarviscore inspect --dir /var/traces    # non-default trace dir
```

Run list shows steps, tokens, failures, duration, and status per workflow. The timeline groups by step and renders one line per event: claims, thinking, delegations, tool calls with results, LLM calls with token counts and latency, failures marked `!!`.

## Why

Every run already leaves a flight record in `traces/`, but the framework shipped no way to read it back. Operating our own agents, we ended up writing throwaway parser scripts every time we needed to answer "what did the agent actually do last night". That is a framework gap, not a user problem: the JSONL channel exists precisely so the record survives without Redis, so the reader should not need Redis, a dashboard, or a running mesh either.

## Design rules

- stdlib only, works offline against the files
- prefix matching on workflow ids with honest ambiguity errors
- nothing truncated silently: long values carry `[clipped: showing N of M chars]`
- corrupt lines surface as `unparseable_line` events instead of being skipped

## Tests

10 new tests in `tests/test_cli_inspect.py`: discovery and grouping, summary aggregation (steps, tokens, failures, duration, status), timeline rendering, error filter, prefix match and ambiguity, unknown workflow, honest clipping, corrupt-line survival.

Docs: new "Reading Traces" section in the observability guide.
