### PR TITLE
docs: landing page says why we exist, getting started picks one path

### DIFF
--- a/jarviscore/docs/TROUBLESHOOTING.md
+++ b/jarviscore/docs/TROUBLESHOOTING.md
@@ -4,7 +4,7 @@ icon: material/wrench
 
 # Troubleshooting
 
-Common issues and solutions for JarvisCore developers — from installation through production mesh deployments.
+Common issues and solutions for JarvisCore developers: from installation through production mesh deployments.
 
 ---
 
@@ -71,15 +71,15 @@ Then validate:
 jarviscore check --validate-llm
 ```
 
-### `Error code: 401 — Unauthorized`
+### `Error code: 401: Unauthorized`
 
 Invalid or expired API key. Verify the key value, check expiry, and for Azure confirm `AZURE_ENDPOINT` and `AZURE_DEPLOYMENT` are set.
 
-### `Error code: 429 — Rate limit exceeded`
+### `Error code: 429: Rate limit exceeded`
 
 Wait 60 seconds, then retry. If persistent, upgrade your API plan or switch to a less-loaded model.
 
-### `Error code: 529 — Overloaded`
+### `Error code: 529: Overloaded`
 
 Provider temporarily overloaded (common with Claude). The smoke test retries automatically 3 times. Retry manually after a few seconds or add a secondary provider.
 
@@ -92,7 +92,7 @@ Provider temporarily overloaded (common with Claude). The smoke test retries aut
 Default timeout is controlled by `SANDBOX_TIMEOUT`. Increase it in `.env`:
 
 ```bash
-SANDBOX_TIMEOUT=600   # seconds — default is 300
+SANDBOX_TIMEOUT=600   # seconds: default is 300
 ```
 
 ### `Sandbox execution failed`
@@ -105,7 +105,7 @@ The framework auto-repairs up to 3 times. If all attempts fail:
    cat traces/<workflow>_<step>.jsonl | python -m json.tool | grep error
    ```
 
-2. Make the task more explicit — the agent needs to know exactly what to produce:
+2. Make the task more explicit: the agent needs to know exactly what to produce:
    ```python
    system_prompt = """
    You are a Python expert. Generate clean, working code.
@@ -125,7 +125,7 @@ The LLM could not generate working code in 3 tries. Simplify the task or add mor
 
 **This is a known diagnostic tell.** Real LLM-driven computation takes 1–30 seconds. Sub-10ms means the sandbox code crashed instantly.
 
-**Cause:** Agent-generated code raised `NameError: name 'context' is not defined` — the sandbox caught it silently.
+**Cause:** Agent-generated code raised `NameError: name 'context' is not defined`. The sandbox caught it silently.
 
 **Fix:** Confirm `autoagent.py` passes context to the sandbox:
 
@@ -170,15 +170,15 @@ results = await mesh.workflow("wf-1", [
 
 ### `self.mailbox is None` / `self._redis_store is None`
 
-Infrastructure attributes are injected by the Mesh **after** `__init__` runs — they are only available inside `setup()`:
+Infrastructure attributes are injected by the Mesh **after** `__init__` runs: they are only available inside `setup()`:
 
 ```python
-# ❌ Wrong — __init__ runs before injection
+# ❌ Wrong: __init__ runs before injection
 class MyAgent(CustomAgent):
     def __init__(self):
         self.memory = UnifiedMemory(redis_store=self._redis_store)  # None!
 
-# ✅ Correct — setup() runs after injection
+# ✅ Correct: setup() runs after injection
 class MyAgent(CustomAgent):
     async def setup(self):
         await super().setup()
@@ -214,7 +214,7 @@ grep REDIS_URL .env
 ```
 
 > [!NOTE]
-> Without `REDIS_URL`, the Mesh degrades gracefully — `_redis_store` and `mailbox` become `None`. Workflow execution still works but checkpointing, mailboxes, and distributed coordination are disabled.
+> Without `REDIS_URL`, the Mesh degrades gracefully: `_redis_store` and `mailbox` become `None`. Workflow execution still works but checkpointing, mailboxes, and distributed coordination are disabled.
 
 ### `EpisodicLedger.append()` fails / events not in Redis
 
@@ -271,14 +271,14 @@ redis-cli del "claim:wf-id:step-id"
 
 Each process needs a **unique port**. A shared `.env` with a single `BIND_PORT` won't work for four nodes.
 
-**Recommended approach — explicit config dict:**
+**Recommended approach: explicit config dict:**
 
 ```python
-BIND_PORT = 7949   # this script's port — part of its identity
+BIND_PORT = 7949   # this script's port: part of its identity
 mesh = Mesh(config={"bind_port": BIND_PORT, ...})
 ```
 
-**Production approach — per-process env var:**
+**Production approach: per-process env var:**
 
 ```bash
 JARVISCORE_BIND_PORT=7949 python synthesizer.py
@@ -332,7 +332,7 @@ LLM_ENDPOINT=http://localhost:8000
 LLM_MODEL=Qwen/Qwen2.5-Coder-32B-Instruct
 ```
 
-Also simplify the system prompt — shorter, more specific prompts generate faster.
+Also simplify the system prompt: shorter, more specific prompts generate faster.
 
 ### High API costs
 
@@ -352,7 +352,7 @@ The smoke test is stricter than examples. Run with `--verbose` to see which asse
 jarviscore smoketest --verbose
 ```
 
-If retrying eventually passes, it is temporary LLM overload — not a code issue.
+If retrying eventually passes, it is temporary LLM overload: not a code issue.
 
 ### All tests pass but my agent fails
 

--- a/jarviscore/docs/changelog.md
+++ b/jarviscore/docs/changelog.md
@@ -30,6 +30,7 @@ All notable changes to JarvisCore Framework are documented here. This project fo
 <div class="changelog-contributors">
 <a href="https://github.com/ekizito96" title="Muyukani Ephraim Kizito"><img src="https://github.com/ekizito96.png?size=32" alt="ekizito96"></a>
 </div>
+<a class="changelog-release-link" href="https://github.com/Prescott-Data/jarviscore-framework/releases/tag/v1.2.0" target="_blank" rel="noopener noreferrer">View release on GitHub →</a>
 </div>
 
 A large, fully backward-compatible release. It hardens the AutoAgent
@@ -69,8 +70,6 @@ removed or altered, so upgrading from 1.1.0 is a drop-in.
 - Removed internal-project references and development artifacts from the public tree.
 
 </div>
-<a class="changelog-release-link" href="https://github.com/Prescott-Data/jarviscore-framework/releases/tag/v1.2.0" target="_blank" rel="noopener noreferrer">View release on GitHub →</a>
-</div>
 
 <div class="changelog-release" markdown>
 
@@ -80,6 +79,7 @@ removed or altered, so upgrading from 1.1.0 is a drop-in.
 <div class="changelog-contributors">
 <a href="https://github.com/ekizito96" title="Muyukani Ephraim Kizito"><img src="https://github.com/ekizito96.png?size=32" alt="ekizito96"></a>
 </div>
+<a class="changelog-release-link" href="https://github.com/Prescott-Data/jarviscore-framework/releases/tag/v1.1.0" target="_blank" rel="noopener noreferrer">View release on GitHub →</a>
 </div>
 
 This release fixes all critical regressions introduced in v1.0.3 that rendered AutoAgent unusable, adds new AI engineering primitives (cognitive routing, intent normalization, structured output validation), and marks the beginning of strict SemVer compliance. **Versions 1.0.3 and 1.0.4 are deprecated and will be yanked from PyPI.**

--- a/jarviscore/docs/changelog.md
+++ b/jarviscore/docs/changelog.md
@@ -9,13 +9,13 @@ hide:
 All notable changes to JarvisCore Framework are documented here. This project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 !!! warning "Versioning Policy (effective v1.1.0)"
-    Releases prior to v1.1.0 did not follow SemVer consistently — new features
+    Releases prior to v1.1.0 did not follow SemVer consistently: new features
     were shipped in patch releases and a breaking change landed in v0.3.1 (a
     patch). Starting with **v1.1.0**, this project adheres to strict SemVer:
 
-    - **PATCH** (1.1.**x**) — backward-compatible bug fixes only.
-    - **MINOR** (1.**x**.0) — new features, new public API surface, backward-compatible behavioral changes.
-    - **MAJOR** (**x**.0.0) — breaking changes to the public API.
+    - **PATCH** (1.1.**x**): backward-compatible bug fixes only.
+    - **MINOR** (1.**x**.0): new features, new public API surface, backward-compatible behavioral changes.
+    - **MAJOR** (**x**.0.0): breaking changes to the public API.
 
     Versions **1.0.3** and **1.0.4** contain critical regressions and should be
     avoided. They will be yanked from PyPI. Pin `jarviscore-framework>=1.1.0`.
@@ -86,35 +86,35 @@ This release fixes all critical regressions introduced in v1.0.3 that rendered A
 
 **Fixed**
 
-- **[#32] Output schema enforcement** — `Agent.output_schema` (Pydantic `BaseModel`) is now passed through the Kernel into `CoderSubAgent`, which validates sandbox output against the schema via `model_validate()`. Schema violations fail fast with a clear error instead of silently returning unstructured data.
-- **[#33] CoderSubAgent sandbox hallucination** — `CoderSubAgent.get_system_prompt()` now appends a dynamic `SANDBOX ENVIRONMENT` manifest listing all pre-loaded modules and globals in the sandbox namespace. This grounds the LLM in what is actually available, preventing hallucinated imports and undefined-name errors.
-- **[#34] Complexity gate before Planner** — `AutoAgent.execute_task()` now runs a `TaskComplexityClassifier` before dispatching to the Planner DAG. Non-complex tasks bypass the full Plan → Execute → Evaluate loop, while classifier contract failures now fail visibly instead of silently falling through to the Planner.
-- **[#35] FunctionRegistry semantic search miss** — `CoderSubAgent._tool_check_registry()` now normalizes verbose task descriptions into concise canonical intents via `IntentNormalizer` before calling `semantic_search()`. This eliminates embedding distance drift caused by prompt verbosity.
-- **[#36] AutoAgent vs CustomAgent boundary** — Added `p2p_responder` attribute to the `Agent` base class (`False` by default, `True` on `CustomAgent`). `JarvisLifespan` now only creates background `asyncio.Task` instances for agents with `p2p_responder=True`, and raises `RuntimeError` at startup if a `p2p_responder` agent does not override `run()`.
-- **[#37] Semantic vs execution status** — `ResultHandler.process_result()` now tracks `semantic_success` separately from execution status. `CoderSubAgent._tool_execute_code()` includes an evaluator hook that flags outputs where `success=False` or `status="failure"` even when the sandbox execution itself succeeded. Fixed `TypeError` when `cost_usd` is `None`.
-- **[#38] Sandbox namespace leak into ZMQ coroutine cleanup** — `SandboxExecutor._execute_sync()` and `_execute_async()` now restore `namespace['__builtins__']` to the actual `builtins` module in a `finally` block. This prevents `KeyError: '__builtins__'` crashes in ZMQ's Cython backend during coroutine garbage collection.
-- **Structured Kernel routing** — keyword role matching has been replaced by a typed `TaskRouter`. Explicit planner/profile roles are honored first; otherwise the router returns a validated role, confidence, reason, and evidence flag. Invalid or low-confidence routing fails visibly. Custom roles must register `kernel_role_profiles`.
-- **Strict subagent completion protocol** — unparseable LLM responses now fail as protocol violations instead of being returned as successful raw content.
-- **Coder proof-of-work contract** — `CoderSubAgent` must produce sandbox execution evidence before completion; structured prose results alone are no longer accepted for coder work.
-- **Workflow terminal status handling** — only `success` completes a workflow step. `yield`, `hitl`, `blocked`, `error`, and unknown statuses are recorded as failures rather than satisfying dependencies.
-- **WorkflowBuilder failure visibility** — agent-returned `failure`, `yield`, `blocked`, `hitl`, or unknown statuses are now preserved instead of being wrapped as step `success`.
-- **Distributed workflow output integrity** — a remote step marked `completed` without persisted output now returns failure rather than fabricating a successful empty result.
-- **AutoAgent Kernel failure visibility** — Kernel exceptions now return an explicit failure instead of silently falling back to the legacy direct-codegen pipeline.
-- **Profile routing explicitness** — missing `default_kernel_role` in a profile no longer implies `communicator`; applications must opt into profile-level routing hints.
-- **`_run_context` AttributeError in CoderSubAgent** — Changed direct attribute access to `getattr(self, '_run_context', {})` to prevent `AttributeError` when `_run_context` is not yet initialized.
+- **[#32] Output schema enforcement**: `Agent.output_schema` (Pydantic `BaseModel`) is now passed through the Kernel into `CoderSubAgent`, which validates sandbox output against the schema via `model_validate()`. Schema violations fail fast with a clear error instead of silently returning unstructured data.
+- **[#33] CoderSubAgent sandbox hallucination**: `CoderSubAgent.get_system_prompt()` now appends a dynamic `SANDBOX ENVIRONMENT` manifest listing all pre-loaded modules and globals in the sandbox namespace. This grounds the LLM in what is actually available, preventing hallucinated imports and undefined-name errors.
+- **[#34] Complexity gate before Planner**: `AutoAgent.execute_task()` now runs a `TaskComplexityClassifier` before dispatching to the Planner DAG. Non-complex tasks bypass the full Plan → Execute → Evaluate loop, while classifier contract failures now fail visibly instead of silently falling through to the Planner.
+- **[#35] FunctionRegistry semantic search miss**: `CoderSubAgent._tool_check_registry()` now normalizes verbose task descriptions into concise canonical intents via `IntentNormalizer` before calling `semantic_search()`. This eliminates embedding distance drift caused by prompt verbosity.
+- **[#36] AutoAgent vs CustomAgent boundary**: Added `p2p_responder` attribute to the `Agent` base class (`False` by default, `True` on `CustomAgent`). `JarvisLifespan` now only creates background `asyncio.Task` instances for agents with `p2p_responder=True`, and raises `RuntimeError` at startup if a `p2p_responder` agent does not override `run()`.
+- **[#37] Semantic vs execution status**: `ResultHandler.process_result()` now tracks `semantic_success` separately from execution status. `CoderSubAgent._tool_execute_code()` includes an evaluator hook that flags outputs where `success=False` or `status="failure"` even when the sandbox execution itself succeeded. Fixed `TypeError` when `cost_usd` is `None`.
+- **[#38] Sandbox namespace leak into ZMQ coroutine cleanup**: `SandboxExecutor._execute_sync()` and `_execute_async()` now restore `namespace['__builtins__']` to the actual `builtins` module in a `finally` block. This prevents `KeyError: '__builtins__'` crashes in ZMQ's Cython backend during coroutine garbage collection.
+- **Structured Kernel routing**: keyword role matching has been replaced by a typed `TaskRouter`. Explicit planner/profile roles are honored first; otherwise the router returns a validated role, confidence, reason, and evidence flag. Invalid or low-confidence routing fails visibly. Custom roles must register `kernel_role_profiles`.
+- **Strict subagent completion protocol**: unparseable LLM responses now fail as protocol violations instead of being returned as successful raw content.
+- **Coder proof-of-work contract**: `CoderSubAgent` must produce sandbox execution evidence before completion; structured prose results alone are no longer accepted for coder work.
+- **Workflow terminal status handling**: only `success` completes a workflow step. `yield`, `hitl`, `blocked`, `error`, and unknown statuses are recorded as failures rather than satisfying dependencies.
+- **WorkflowBuilder failure visibility**: agent-returned `failure`, `yield`, `blocked`, `hitl`, or unknown statuses are now preserved instead of being wrapped as step `success`.
+- **Distributed workflow output integrity**: a remote step marked `completed` without persisted output now returns failure rather than fabricating a successful empty result.
+- **AutoAgent Kernel failure visibility**: Kernel exceptions now return an explicit failure instead of silently falling back to the legacy direct-codegen pipeline.
+- **Profile routing explicitness**: missing `default_kernel_role` in a profile no longer implies `communicator`; applications must opt into profile-level routing hints.
+- **`_run_context` AttributeError in CoderSubAgent**: Changed direct attribute access to `getattr(self, '_run_context', {})` to prevent `AttributeError` when `_run_context` is not yet initialized.
 
 **Added**
 
-- `TaskComplexityClassifier` (`jarviscore.planning.classifier`) — LLM-based cognitive router that classifies tasks as "trivial", "moderate", or "complex" to determine whether the full Planner DAG is needed.
-- `IntentNormalizer` (`jarviscore.execution.intent_normalizer`) — Distills verbose task descriptions into concise canonical intents for accurate embedding-based semantic search.
-- `Agent.p2p_responder` attribute — Boolean flag distinguishing reactive task workers (AutoAgent) from proactive mesh citizens (CustomAgent) at the framework level.
-- `Agent.output_schema` attribute — Optional Pydantic `BaseModel` class for end-to-end structured output validation through the Kernel pipeline.
-- `semantic_success` field in `ResultHandler` result data — Enables downstream consumers to distinguish between "code ran without errors" and "task actually achieved its goal".
-- `SandboxExecutor.get_manifest()` / `CoderSandbox.get_manifest()` — Introspect the sandbox namespace for prompt injection into the CoderSubAgent system prompt.
+- `TaskComplexityClassifier` (`jarviscore.planning.classifier`): LLM-based cognitive router that classifies tasks as "trivial", "moderate", or "complex" to determine whether the full Planner DAG is needed.
+- `IntentNormalizer` (`jarviscore.execution.intent_normalizer`): Distills verbose task descriptions into concise canonical intents for accurate embedding-based semantic search.
+- `Agent.p2p_responder` attribute: Boolean flag distinguishing reactive task workers (AutoAgent) from proactive mesh citizens (CustomAgent) at the framework level.
+- `Agent.output_schema` attribute: Optional Pydantic `BaseModel` class for end-to-end structured output validation through the Kernel pipeline.
+- `semantic_success` field in `ResultHandler` result data: Enables downstream consumers to distinguish between "code ran without errors" and "task actually achieved its goal".
+- `SandboxExecutor.get_manifest()` / `CoderSandbox.get_manifest()`: Introspect the sandbox namespace for prompt injection into the CoderSubAgent system prompt.
 
 **Deprecated**
 
-- Versions `1.0.3` and `1.0.4` — contain critical AutoAgent regressions. Will be yanked from PyPI. Users should pin `>=1.1.0`.
+- Versions `1.0.3` and `1.0.4`: contain critical AutoAgent regressions. Will be yanked from PyPI. Users should pin `>=1.1.0`.
 
 </div>
 
@@ -134,7 +134,7 @@ This release fixes all critical regressions introduced in v1.0.3 that rendered A
 **Documentation**
 
 - Mobile drawer fully resolved: Level 1 nav items clickable on all viewports, back arrow restored, site name text hidden in mobile view.
-- Section `index.md` entry points added for Concepts, Guides, and Reference — each section now has an overview landing page with icon cards.
+- Section `index.md` entry points added for Concepts, Guides, and Reference: each section now has an overview landing page with icon cards.
 - CSS tab icons removed from sections that use frontmatter-defined icons, eliminating duplication.
 - README expanded and restructured with additional examples and API reference.
 
@@ -161,33 +161,33 @@ This release fixes all critical regressions introduced in v1.0.3 that rendered A
 
 **Documentation**
 
-- Launched the full MkDocs documentation site — Getting Started, Concepts, Guides, Reference, Examples, and Enterprise sections.
+- Launched the full MkDocs documentation site: Getting Started, Concepts, Guides, Reference, Examples, and Enterprise sections.
 - New guides: AutoAgent, CustomAgent, Workflows, Chat, HITL, Nexus, Knowledge Base, System Prompts, Observability, FastAPI Integration, Internet Search, Migration (CrewAI + LangGraph), Testing.
 - New concept pages: Architecture, Memory, Nexus, P2P, System Bundles, Agent Personas.
 - New examples: Financial Pipeline, Research Network, Support Swarm, Content Pipeline, Investment Committee.
 - Synced all 15 brand SVG variants to `docs/assets/` and removed legacy unreferenced `logo.png` / `logo.svg`.
-- `guides/testing.md`: documented `ExampleMockLLMClient` — tool-validating mock LLM for unit testing agents with tool use.
+- `guides/testing.md`: documented `ExampleMockLLMClient`: tool-validating mock LLM for unit testing agents with tool use.
 - Fixed deprecated `Mesh(mode=...)` calls in `README.md`, `guides/production.md`, `guides/browser-automation.md`, and `guides/adapters.md`.
 
 **Added**
 
-- `mesh.run_task(agent, task, context, complexity)` — primary user-facing API for dispatching a single task to an agent by role with multi-tier model routing.
-- `P2P_ENABLED=true` env var support — `Settings.p2p_enabled` is now merged into Mesh config at startup.
-- `HITLCategory` enum with hard enforcement on `HITLQueue.request()` — valid categories: `auth_required`, `data_required`, `critical_action`. Invalid categories raise `ValueError`.
-- Planner subagent hints are strict — valid hints are accepted exactly and invalid hints fail visibly instead of being remapped.
-- `STEP_OUTPUT_MAX_BYTES` (default 200 KB) and `STEP_OUTPUT_PREVIEW_BYTES` (default 20 KB) — large step outputs stored as truncated preview with `_overflow` flag.
-- Idempotent write guard on `RedisStore.save_step_output()` — a successful result will not be overwritten by a subsequent error payload from a stalled re-execution.
-- Azure Content Filter visibility in `LLMClient` — raw provider content-filter rejections now fail visibly by default. `AZURE_CONTENT_FILTER_REPAIR_ENABLED=true` explicitly opts into Azure-specific prompt repair after the raw prompt is rejected.
-- `Kernel._get_model_for_tier()` — clean multi-tier model resolution: complexity hint → `TASK_MODEL_NANO` / `TASK_MODEL_STANDARD` / `TASK_MODEL_HEAVY` → legacy fallback.
-- `MailboxManager` schema normalisation — handles both the current flat envelope schema and the pre-v1.0.2 double-nested schema transparently.
-- **Vertex AI provider** (`LLMProvider.VERTEX_AI`): GCP-native Gemini access via Application Default Credentials (ADC). No API key required — authenticate with `gcloud auth application-default login` or attach a service account. Config: `VERTEX_AI_ENABLED=true`, `VERTEX_AI_PROJECT`, `VERTEX_AI_LOCATION` (default `us-central1`), `VERTEX_AI_MODEL` (default `gemini-2.5-flash`). Slots into the fallback chain after Gemini: **Azure → Claude → vLLM → Gemini → Vertex AI**.
-- `_normalize_tools_for_gemini()` static method — auto-converts tool schemas to Gemini `function_declarations` format. Accepts Anthropic/PeerTool (`input_schema`), flat (`name`+`parameters`), or already-native formats.
+- `mesh.run_task(agent, task, context, complexity)`: primary user-facing API for dispatching a single task to an agent by role with multi-tier model routing.
+- `P2P_ENABLED=true` env var support: `Settings.p2p_enabled` is now merged into Mesh config at startup.
+- `HITLCategory` enum with hard enforcement on `HITLQueue.request()`: valid categories: `auth_required`, `data_required`, `critical_action`. Invalid categories raise `ValueError`.
+- Planner subagent hints are strict: valid hints are accepted exactly and invalid hints fail visibly instead of being remapped.
+- `STEP_OUTPUT_MAX_BYTES` (default 200 KB) and `STEP_OUTPUT_PREVIEW_BYTES` (default 20 KB): large step outputs stored as truncated preview with `_overflow` flag.
+- Idempotent write guard on `RedisStore.save_step_output()`: a successful result will not be overwritten by a subsequent error payload from a stalled re-execution.
+- Azure Content Filter visibility in `LLMClient`: raw provider content-filter rejections now fail visibly by default. `AZURE_CONTENT_FILTER_REPAIR_ENABLED=true` explicitly opts into Azure-specific prompt repair after the raw prompt is rejected.
+- `Kernel._get_model_for_tier()`: clean multi-tier model resolution: complexity hint → `TASK_MODEL_NANO` / `TASK_MODEL_STANDARD` / `TASK_MODEL_HEAVY` → legacy fallback.
+- `MailboxManager` schema normalisation: handles both the current flat envelope schema and the pre-v1.0.2 double-nested schema transparently.
+- **Vertex AI provider** (`LLMProvider.VERTEX_AI`): GCP-native Gemini access via Application Default Credentials (ADC). No API key required: authenticate with `gcloud auth application-default login` or attach a service account. Config: `VERTEX_AI_ENABLED=true`, `VERTEX_AI_PROJECT`, `VERTEX_AI_LOCATION` (default `us-central1`), `VERTEX_AI_MODEL` (default `gemini-2.5-flash`). Slots into the fallback chain after Gemini: **Azure → Claude → vLLM → Gemini → Vertex AI**.
+- `_normalize_tools_for_gemini()` static method: auto-converts tool schemas to Gemini `function_declarations` format. Accepts Anthropic/PeerTool (`input_schema`), flat (`name`+`parameters`), or already-native formats.
 - Shared `_call_genai_client()` helper: both `_call_gemini` and `_call_vertex_ai` delegate here for consistent token accounting and cost calculation.
 - Tool-call response parsing in `_call_genai_client`: when a Gemini/Vertex AI response contains `function_call` parts, `tool_calls` is populated and `content` is set to `""`.
 - Token pricing entries for `gemini-2.5-flash`, `gemini-2.5-pro`, `gemini-3.1-pro`, `gemini-3.1-pro-preview`.
-- Process-wide LLM concurrency semaphore (`LLM_MAX_CONCURRENT` env var) — prevents thundering-herd 429s in multi-agent deployments.
-- `llm.nano_model` and `llm.planner_model` properties — tier-aware model selection for `StepEvaluator` and `Planner`.
-- `max_completion_tokens` alias in `generate()` — callers can use GPT-5.x SDK naming convention interchangeably with `max_tokens`.
+- Process-wide LLM concurrency semaphore (`LLM_MAX_CONCURRENT` env var): prevents thundering-herd 429s in multi-agent deployments.
+- `llm.nano_model` and `llm.planner_model` properties: tier-aware model selection for `StepEvaluator` and `Planner`.
+- `max_completion_tokens` alias in `generate()`: callers can use GPT-5.x SDK naming convention interchangeably with `max_tokens`.
 
 **Fixed**
 
@@ -204,7 +204,7 @@ This release fixes all critical regressions introduced in v1.0.3 that rendered A
 
 **Changed**
 
-- `mesh.workflow()` no longer restricted to autonomous mode — works across all mesh configurations.
+- `mesh.workflow()` no longer restricted to autonomous mode: works across all mesh configurations.
 - CLI references updated from `python -m jarviscore.cli.*` to the `jarviscore` entry-point CLI.
 
 </div>
@@ -275,7 +275,7 @@ This release fixes all critical regressions introduced in v1.0.3 that rendered A
 
 **Changed**
 
-- Version: 0.4.0 → 1.0.0 — stable public release.
+- Version: 0.4.0 → 1.0.0: stable public release.
 - Documentation URL updated to custom domain: `https://jarviscore.developers.prescottdata.io/`
 
 **Added**
@@ -284,7 +284,7 @@ This release fixes all critical regressions introduced in v1.0.3 that rendered A
 - CONTRIBUTING.md with CLA links, ruff tooling, PR checklist.
 - CODE_OF_CONDUCT.md community standards.
 - ENTERPRISE.md for OSS vs Enterprise comparison.
-- `examples/investment_committee/` — 7-agent multi-step workflow with web dashboard (AutoAgent + CustomAgent, parallel step execution, LTM institutional memory, FastAPI dashboard on port 8004).
+- `examples/investment_committee/`: 7-agent multi-step workflow with web dashboard (AutoAgent + CustomAgent, parallel step execution, LTM institutional memory, FastAPI dashboard on port 8004).
 
 </div>
 
@@ -303,52 +303,52 @@ This release fixes all critical regressions introduced in v1.0.3 that rendered A
 
 This was the largest release in JarvisCore history, introducing the complete infrastructure stack across nine phases. It added persistent storage, context distillation, telemetry, the mailbox messaging system, the function registry, the Kernel OODA loop, distributed workflow execution, Nexus authentication, and the unified memory architecture.
 
-**Phase 1 — Foundation Layer**
+**Phase 1: Foundation Layer**
 
 `LocalBlobStorage` / `AzureBlobStorage` with `save(path, data)` / `load(path)` for any artifact. `RedisContextStore` for full Redis-backed step output, workflow graph, mailbox, HITL, and checkpoint methods. Configured via `STORAGE_BACKEND`, `STORAGE_BASE_PATH`, and `REDIS_URL`.
 
-**Phase 2 — Context Distillation**
+**Phase 2: Context Distillation**
 
 `Evidence`, `TruthFact`, `TruthContext`, `AgentOutput` Pydantic models. `distill_output()`, `scrub_sensitive()`, `merge_facts()` utilities. `ContextManager` for token-budget aware prompt building (priority stack: mission → plan → scratchpad → LTM → tool history → variables). `JarvisContext` enhanced with `truth`, `mailbox`, `tracer`, `human_tasks` fields.
 
-**Phase 3 — Telemetry and Tracing**
+**Phase 3: Telemetry and Tracing**
 
 `TraceEventType` enum covering workflow, step, kernel cognition, tool, mailbox, HITL, and context events. `TraceManager` with three output channels: Redis List (persistent), Redis PubSub (real-time), and JSONL (compliance fallback). `record_step_execution(duration, status)` Prometheus histogram and counter, enabled via `PROMETHEUS_ENABLED=true`.
 
-**Phase 4 — MailboxManager**
+**Phase 4: MailboxManager**
 
 `self.mailbox.send(target_id, payload)` / `read(max_messages)` for async agent messaging. Backed by Redis Streams, available in all modes when `REDIS_URL` is set.
 
-**Phase 5 — Function Registry**
+**Phase 5: Function Registry**
 
 `CodeRegistry` auto-registers successfully executed code per task and promotes to `VERIFIED` on first success. Available as `agent.code_registry` in AutoAgent, persisted to `{log_dir}/function_registry/`. Includes `update_execution_stats(func_name, success, execution_time)` for graduation tracking.
 
-**Phase 6 — Kernel / SubAgent OODA Loop**
+**Phase 6: Kernel / SubAgent OODA Loop**
 
 The `Kernel` replaces AutoAgent's linear codegen → sandbox → repair pipeline with a supervised OODA loop. `ExecutionLease` enforces token/turn/wall-clock budgets per subagent role. `AgentCognitionManager` tracks budget spend per phase, detects spinning (same tool 3+ times), and enforces cognitive gates. `AdaptiveHITLPolicy` with `HumanTask` pauses execution when confidence or risk triggers fire. Coder dispatches require executable proof of work before completion.
 
-**Phase 7 — Distributed WorkflowEngine**
+**Phase 7: Distributed WorkflowEngine**
 
 `WorkflowEngine` persists DAG to Redis hash `workflow_graph:{wf_id}` for crash recovery. When no local agent matches a step, the engine resets status to `"pending"` and polls Redis. `Mesh._run_distributed_worker()` scans `jarviscore:active_workflows`, checks `are_dependencies_met()`, atomically claims steps via SETNX, executes, and writes output to Redis.
 
-**Phase 7D — AuthenticationManager (Nexus)**
+**Phase 7D: AuthenticationManager (Nexus)**
 
 Set `requires_auth = True` on any agent and the Mesh injects `self._auth_manager` before `setup()`. Full NexusClient flow: `request_connection → browser OAuth → poll ACTIVE → resolve_strategy → apply headers`. Graceful degradation when `NEXUS_GATEWAY_URL` is not set.
 
-**Phase 8 — Memory Architecture**
+**Phase 8: Memory Architecture**
 
 `UnifiedMemory(workflow_id, step_id, agent_id, redis_store, blob_storage)` with `.episodic` (EpisodicLedger via Redis Streams), `.ltm` (LongTermMemory via Redis), and `.scratch` (in-memory WorkingScratchpad). `RedisMemoryAccessor` reads step outputs across the workflow.
 
-**Phase 9 — Mesh Integration and Auto-Injection**
+**Phase 9: Mesh Integration and Auto-Injection**
 
 Before each agent's `setup()`, the Mesh injects `_redis_store`, `_blob_storage`, and `mailbox`. Prometheus server starts automatically when `PROMETHEUS_ENABLED=true`. Agents use injected infrastructure directly with zero boilerplate.
 
 **Production Examples**
 
-- `financial_pipeline.py` — AutoAgent autonomous, 3-step financial analysis pipeline.
-- `research_synthesizer.py` + `research_node_1/2/3.py` — AutoAgent 4-node SWIM research cluster.
-- `support_swarm.py` — CustomAgent P2P, 4-agent support routing with Nexus auth.
-- `content_pipeline.py` — CustomAgent distributed, content pipeline with LTM.
+- `financial_pipeline.py`: AutoAgent autonomous, 3-step financial analysis pipeline.
+- `research_synthesizer.py` + `research_node_1/2/3.py`: AutoAgent 4-node SWIM research cluster.
+- `support_swarm.py`: CustomAgent P2P, 4-agent support routing with Nexus auth.
+- `content_pipeline.py`: CustomAgent distributed, content pipeline with LTM.
 
 **Fixed**
 

--- a/jarviscore/docs/concepts/agent-personas.md
+++ b/jarviscore/docs/concepts/agent-personas.md
@@ -9,7 +9,7 @@ Every JarvisCore agent has a **persona** composed of two complementary layers: c
 Understanding personas is important because it is the mechanism through which the Kernel receives grounded domain knowledge. Without a well-defined persona, an agent reasons from general LLM priors. With a complete persona, the agent reasons from a specific, authoritative operational context.
 
 > [!NOTE]
-> **Coming from Anthropic's `SKILLS.md`?** JarvisCore's persona system is the equivalent — but structured, typed, and automatically wired into your agent's system prompt and peer discovery. [See the comparison below.](#skillsmd-and-the-personas-equivalent)
+> **Coming from Anthropic's `SKILLS.md`?** JarvisCore's persona system is the equivalent: but structured, typed, and automatically wired into your agent's system prompt and peer discovery. [See the comparison below.](#skillsmd-and-the-personas-equivalent)
 
 ---
 
@@ -51,15 +51,15 @@ An agent profile is a YAML file that adds structured, domain-specific intelligen
 
 Profiles are loaded by `AgentProfile.load(role_name)`, which is called automatically by `AutoAgent.setup()`. The framework looks for the profile YAML at:
 
-1. `{JARVISCORE_PROFILES_DIR}/{role_name}.yaml` — your application's profile directory (set this in your `.env`).
-2. `jarviscore/profiles/agents/{role_name}.yaml` — bundled fallback profiles (example only).
+1. `{JARVISCORE_PROFILES_DIR}/{role_name}.yaml`: your application's profile directory (set this in your `.env`).
+2. `jarviscore/profiles/agents/{role_name}.yaml`: bundled fallback profiles (example only).
 
 Always set `JARVISCORE_PROFILES_DIR` in your application. The bundled profiles are provided as a reference template, not as production profiles.
 
 ### Profile YAML Schema
 
 ```yaml title="profiles/agents/researcher.yaml"
-role: "Researcher — Market Intelligence Agent"
+role: "Researcher, Market Intelligence Agent"
 
 expertise:
   - Systematic primary and secondary source research
@@ -107,7 +107,7 @@ default_kernel_role: "researcher"
 `AgentProfile.to_prompt_block()` renders the YAML fields into a structured markdown section:
 
 ```
-## ROLE INTELLIGENCE: RESEARCHER — MARKET INTELLIGENCE AGENT
+## ROLE INTELLIGENCE: RESEARCHER: MARKET INTELLIGENCE AGENT
 
 ### Expertise
 - Systematic primary and secondary source research
@@ -123,7 +123,7 @@ default_kernel_role: "researcher"
 - Research reports in the standardised company template
 ...
 
-### Standing Operating Procedures (follow autonomously — do not wait to be asked)
+### Standing Operating Procedures (follow autonomously: do not wait to be asked)
 1. Always cross-reference findings across at least three independent sources before asserting a claim.
 2. Flag conflicting data points explicitly rather than resolving them silently.
 ...
@@ -200,7 +200,7 @@ The combination of `role` and `capabilities` gives you both exact-match and capa
 
 ## SKILLS.md and the Personas Equivalent
 
-Anthropic popularised `SKILLS.md` — a markdown file that describes what an agent can do, what tools it has access to, and how it should behave. It's a simple, portable convention for grounding an LLM in a specific context.
+Anthropic popularised `SKILLS.md`: a markdown file that describes what an agent can do, what tools it has access to, and how it should behave. It's a simple, portable convention for grounding an LLM in a specific context.
 
 JarvisCore's persona system covers the same ground, with more structure:
 
@@ -208,17 +208,17 @@ JarvisCore's persona system covers the same ground, with more structure:
 |---|---|
 | Freeform markdown | Typed YAML schema with enforced fields |
 | Written once, manually maintained | Per-role YAML, loaded automatically by the framework |
-| No enforcement — LLM reads it as instructions | `sops:` rendered as numbered SOPs; `escalates_to:` wired into HITL |
+| No enforcement: LLM reads it as instructions | `sops:` rendered as numbered SOPs; `escalates_to:` wired into HITL |
 | Separate from code | `capabilities:` drives live P2P peer discovery |
 | Tool descriptions are free text | System Bundles provide typed, versioned atoms (see [System Bundles](system-bundles.md)) |
 
-The key difference is that a `SKILLS.md` describes what an agent *might* do. A JarvisCore persona shapes what the agent *is* — and the `capabilities` list directly controls how other agents discover and route to it at runtime.
+The key difference is that a `SKILLS.md` describes what an agent *might* do. A JarvisCore persona shapes what the agent *is*: and the `capabilities` list directly controls how other agents discover and route to it at runtime.
 
 **The migration pattern** for teams coming from `SKILLS.md` is straightforward:
 
 ```yaml title="profiles/agents/analyst.yaml"
 # Your SKILLS.md content maps to:
-role: "Analyst — Financial Intelligence"       # was: # Role: Financial Analyst
+role: "Analyst: Financial Intelligence"       # was: # Role: Financial Analyst
 
 expertise:                                      # was: ## Skills\n- Financial modelling
   - Financial modelling and DCF analysis

--- a/jarviscore/docs/concepts/agents.md
+++ b/jarviscore/docs/concepts/agents.md
@@ -6,7 +6,7 @@ icon: material/robot-outline
 
 An agent in JarvisCore is a Python class with two things: an **identity** and an **execution model**. The identity tells the mesh *who* the agent is and *what* it can do. The execution model defines *how* it processes work.
 
-Every other concept in the framework — memory, model routing, personas, peer communication — operates on top of this foundation. Read this page before any of the others.
+Every other concept in the framework (memory, model routing, personas, peer communication) operates on top of this foundation. Read this page before any of the others.
 
 ---
 
@@ -60,7 +60,7 @@ The `role` and `capabilities` are common to all agents. What differs is how each
 
 ### AutoAgent
 
-`AutoAgent` gives the agent an internal OODA reasoning loop. You provide the system prompt and optional configuration; the framework handles the rest — LLM calls, tool selection, code generation, web search, sandboxed execution, autonomous repair, and replanning.
+`AutoAgent` gives the agent an internal OODA reasoning loop. You provide the system prompt and optional configuration; the framework handles the rest: LLM calls, tool selection, code generation, web search, sandboxed execution, autonomous repair, and replanning.
 
 ```python
 class ResearcherAgent(AutoAgent):
@@ -71,11 +71,11 @@ class ResearcherAgent(AutoAgent):
 
 The Kernel inside `AutoAgent` decides which sub-agent to route each task to (Coder, Researcher, Communicator, or Browser), executes it through the OODA loop, and returns a structured result. You do not write the execution logic.
 
-Use `AutoAgent` when the steps needed to complete a task are not known in advance — when the agent needs to reason about what to do next.
+Use `AutoAgent` when the steps needed to complete a task are not known in advance: when the agent needs to reason about what to do next.
 
 ### CustomAgent
 
-`CustomAgent` exposes the execution loop directly. You implement `on_peer_request()` (for P2P messages) and optionally `execute_task()` (for workflow tasks). The framework still provides memory, peer communication, and credential injection — you control what runs.
+`CustomAgent` exposes the execution loop directly. You implement `on_peer_request()` (for P2P messages) and optionally `execute_task()` (for workflow tasks). The framework still provides memory, peer communication, and credential injection: you control what runs.
 
 ```python
 from jarviscore import CustomAgent
@@ -90,7 +90,7 @@ class DataTransformerAgent(CustomAgent):
         return {"status": "success", "result": result}
 ```
 
-Use `CustomAgent` when the execution sequence is deterministic and known in advance — pipelines, formatters, gateways, or wrappers around existing code.
+Use `CustomAgent` when the execution sequence is deterministic and known in advance: pipelines, formatters, gateways, or wrappers around existing code.
 
 ---
 
@@ -112,7 +112,7 @@ Mesh.start()
     │       └── self._auth_manager   # injected when requires_auth=True + NEXUS_GATEWAY_URL set
     │
     ▼
-Running — processes tasks and/or peer messages
+Running: processes tasks and/or peer messages
     │
     ▼
 Mesh.stop()
@@ -131,7 +131,7 @@ async def teardown(self):
     await super().teardown()         # always call super last
 ```
 
-Do not do expensive work in `__init__` — the Mesh injects infrastructure *after* construction and *before* `setup()`. Anything that requires `self._redis_store` or `self.peers` belongs in `setup()`.
+Do not do expensive work in `__init__`: the Mesh injects infrastructure *after* construction and *before* `setup()`. Anything that requires `self._redis_store` or `self.peers` belongs in `setup()`.
 
 ---
 
@@ -142,7 +142,7 @@ The Mesh injects infrastructure stores into every agent between `__init__` and `
 | Attribute | Type | Available when |
 |---|---|---|
 | `self._redis_store` | `RedisStore` | `REDIS_URL` is set |
-| `self._blob_storage` | `BlobStorage` | Always — local filesystem by default |
+| `self._blob_storage` | `BlobStorage` | Always: local filesystem by default |
 | `self.peers` | `PeerClient` | `P2P_ENABLED=true` |
 | `self.mailbox` | `MailboxManager` | `REDIS_URL` is set |
 | `self._auth_manager` | `AuthenticationManager` | `requires_auth = True` on the class and `NEXUS_GATEWAY_URL` is set |
@@ -154,7 +154,7 @@ None of these are required. Every injected attribute is `None` when its infrastr
 
 ## How Identity Drives Everything
 
-The `role` and `capabilities` you set on the class are not just labels — they actively control how the framework routes and connects your agent.
+The `role` and `capabilities` you set on the class are not just labels: they actively control how the framework routes and connects your agent.
 
 | What it controls | Driven by |
 |---|---|
@@ -165,7 +165,7 @@ The `role` and `capabilities` you set on the class are not just labels — they 
 | Workflow step routing (`{"agent": "researcher", "task": "..."}`) | `role` |
 | HITL escalation targets | Defined in the agent's YAML profile |
 
-The `role` is the primary key for the entire mesh. Choose it deliberately — it should be a stable slug that reflects the agent's function, not its implementation.
+The `role` is the primary key for the entire mesh. Choose it deliberately: it should be a stable slug that reflects the agent's function, not its implementation.
 
 ---
 
@@ -191,9 +191,9 @@ asyncio.run(main())
 
 ## Further Reading
 
-- [Architecture Overview](./architecture.md) — the Mesh, Kernel, and OODA loop
-- [Agent Personas](./agent-personas.md) — how YAML profiles add domain intelligence to identity
-- [Model Routing](./model-routing.md) — how `role` determines which LLM tier is used
-- [P2P Communication](./p2p.md) — how agents discover and message each other
-- [AutoAgent Guide](../guides/autoagent.md) — full reference for autonomous reasoning agents
-- [CustomAgent Guide](../guides/customagent.md) — full reference for deterministic worker agents
+- [Architecture Overview](./architecture.md): the Mesh, Kernel, and OODA loop
+- [Agent Personas](./agent-personas.md): how YAML profiles add domain intelligence to identity
+- [Model Routing](./model-routing.md): how `role` determines which LLM tier is used
+- [P2P Communication](./p2p.md): how agents discover and message each other
+- [AutoAgent Guide](../guides/autoagent.md): full reference for autonomous reasoning agents
+- [CustomAgent Guide](../guides/customagent.md): full reference for deterministic worker agents

--- a/jarviscore/docs/concepts/architecture.md
+++ b/jarviscore/docs/concepts/architecture.md
@@ -142,9 +142,9 @@ You can implement custom sub-agents by subclassing `BaseSubAgent`. Custom sub-ag
 
 If you are new to JarvisCore, follow this reading order:
 
-1. [Agents](./agents.md) — what an agent is, its identity, lifecycle, and the two execution models.
-2. [Model Routing](./model-routing.md) — understand how LLM calls are routed to the right model tier.
-3. [Memory](./memory.md) — understand how agents persist and retrieve context.
-4. [Agent Personas](./agent-personas.md) — understand how profiles shape agent behaviour.
-5. [P2P Communication](./p2p.md) — understand how agents communicate across a mesh.
+1. [Agents](./agents.md): what an agent is, its identity, lifecycle, and the two execution models.
+2. [Model Routing](./model-routing.md): understand how LLM calls are routed to the right model tier.
+3. [Memory](./memory.md): understand how agents persist and retrieve context.
+4. [Agent Personas](./agent-personas.md): understand how profiles shape agent behaviour.
+5. [P2P Communication](./p2p.md): understand how agents communicate across a mesh.
 6. Then proceed to the [Getting Started guide](../getting-started.md) to write your first agent.

--- a/jarviscore/docs/concepts/index.md
+++ b/jarviscore/docs/concepts/index.md
@@ -4,7 +4,7 @@ icon: material/brain
 
 # Concepts
 
-Core concepts behind the JarvisCore framework — how agents are structured, how they coordinate, and how the system scales from a single agent to a fleet.
+Core concepts behind the JarvisCore framework: how agents are structured, how they coordinate, and how the system scales from a single agent to a fleet.
 
 <div class="grid cards" markdown>
 
@@ -16,7 +16,7 @@ Core concepts behind the JarvisCore framework — how agents are structured, how
 
 -   :material-robot: **Agents**
 
-    AutoAgent, CustomAgent, and sub-agents — the building blocks of every system.
+    AutoAgent, CustomAgent, and sub-agents: the building blocks of every system.
 
     [Read more →](agents.md)
 
@@ -40,7 +40,7 @@ Core concepts behind the JarvisCore framework — how agents are structured, how
 
 -   :material-package-variant-closed: **System Bundles & Atoms**
 
-    Composable units of logic — Atoms inside Bundles.
+    Composable units of logic: Atoms inside Bundles.
 
     [Read more →](system-bundles.md)
 

--- a/jarviscore/docs/concepts/language-models.md
+++ b/jarviscore/docs/concepts/language-models.md
@@ -6,7 +6,7 @@ icon: material/chip
 
 JarvisCore is built for a world where no single model does everything well. A model that excels at code generation tends to be overkill for classifying a yes/no decision. A model capable of deep multi-step reasoning is too slow and expensive for summarising a conversation. A model that drives a browser needs to see screenshots; a model writing a Slack message does not.
 
-Rather than exposing this complexity to developers, JarvisCore assigns every LLM call to a **role** — a named capability that determines how the model is prompted, what it returns, and which model tier it runs on.
+Rather than exposing this complexity to developers, JarvisCore assigns every LLM call to a **role**: a named capability that determines how the model is prompted, what it returns, and which model tier it runs on.
 
 ---
 
@@ -20,7 +20,7 @@ The `Planner` and `ResearcherSubAgent` use the reasoning role by default.
 
 ### Coding
 
-The coding role generates, reviews, and repairs executable code. It is given explicit tool schemas, a working scratchpad, and structured feedback on execution failures. The expected output is always code or a structured tool call — never free-form prose.
+The coding role generates, reviews, and repairs executable code. It is given explicit tool schemas, a working scratchpad, and structured feedback on execution failures. The expected output is always code or a structured tool call: never free-form prose.
 
 `CoderSubAgent` owns this role. It is the only role with no generic fallback tier: if `CODING_MODEL` is unset, it inherits the provider default deployment.
 
@@ -34,7 +34,7 @@ A text-only model assigned to the browser role will run but cannot interpret scr
 
 ### Nano / Fast
 
-The nano role handles classification, short message drafting, and context compression — tasks where low latency and cost matter more than depth. Prompts are short, outputs are small, and the expected result is a verdict or a brief string.
+The nano role handles classification, short message drafting, and context compression: tasks where low latency and cost matter more than depth. Prompts are short, outputs are small, and the expected result is a verdict or a brief string.
 
 `CommunicatorSubAgent`, `StepEvaluator`, and the auto-summariser run on the nano role.
 
@@ -42,7 +42,7 @@ The nano role handles classification, short message drafting, and context compre
 
 ## The Completion Interface
 
-All four roles go through a single client — `UnifiedLLMClient` — which normalises provider differences before the call and after the response.
+All four roles go through a single client (`UnifiedLLMClient`) which normalises provider differences before the call and after the response.
 
 **Before the call**, the client handles parameter incompatibilities automatically:
 
@@ -50,7 +50,7 @@ All four roles go through a single client — `UnifiedLLMClient` — which norma
 - `gpt-5.x` rejects non-default `temperature` → parameter is stripped
 - Providers that do not support `response_format: json_object` → parameter is silently omitted
 
-**After the call**, every response — regardless of provider — arrives in the same shape:
+**After the call**, every response (regardless of provider) arrives in the same shape:
 
 ```python
 {
@@ -63,7 +63,7 @@ All four roles go through a single client — `UnifiedLLMClient` — which norma
 }
 ```
 
-Structured output (JSON mode) is requested by passing `response_format={"type": "json_object"}` to `llm.generate()`. The client forwards this when the provider supports it. If the returned content is not valid JSON, the Kernel retries the call with an explicit repair prompt before surfacing a failure — you do not handle JSON parse errors in agent code.
+Structured output (JSON mode) is requested by passing `response_format={"type": "json_object"}` to `llm.generate()`. The client forwards this when the provider supports it. If the returned content is not valid JSON, the Kernel retries the call with an explicit repair prompt before surfacing a failure: you do not handle JSON parse errors in agent code.
 
 **Provider fallback** runs automatically when a provider is unavailable or returns a 5xx. The order is: Azure OpenAI → Claude → vLLM → Gemini. Rate limit responses (HTTP 429) trigger exponential backoff before the fallback chain is tried.
 
@@ -71,12 +71,12 @@ Structured output (JSON mode) is requested by passing `response_format={"type": 
 
 ## Embedding
 
-Embedding calls — used by `UnifiedMemory` for semantic search and RAG retrieval — run outside the four roles above. They are handled by a dedicated embedding client and are not routed through `UnifiedLLMClient`. Configure the embedding model separately if you are using Athena MemOS or a custom retrieval layer.
+Embedding calls (used by `UnifiedMemory` for semantic search and RAG retrieval) run outside the four roles above. They are handled by a dedicated embedding client and are not routed through `UnifiedLLMClient`. Configure the embedding model separately if you are using Athena MemOS or a custom retrieval layer.
 
 ---
 
 ## What Comes Next
 
-Each of the four roles maps to a **capability tier** — a named slot in your environment configuration that you point at a specific deployment. That mapping, the fallback chain between tiers, and how to override complexity per task are covered in the next section.
+Each of the four roles maps to a **capability tier**: a named slot in your environment configuration that you point at a specific deployment. That mapping, the fallback chain between tiers, and how to override complexity per task are covered in the next section.
 
 **[Model Routing →](model-routing.md)**

--- a/jarviscore/docs/concepts/memory.md
+++ b/jarviscore/docs/concepts/memory.md
@@ -74,9 +74,9 @@ mem = UnifiedMemory(
     workflow_id="wf-abc123",
     step_id="step-1",
     agent_id="researcher",
-    redis_store=redis_store,        # Optional — enables Tiers 2 and 3
-    blob_storage=blob_storage,      # Optional — enables Tiers 1 and 3
-    athena_client=athena_client,    # Optional — enables Tier 4
+    redis_store=redis_store,        # Optional: enables Tiers 2 and 3
+    blob_storage=blob_storage,      # Optional: enables Tiers 1 and 3
+    athena_client=athena_client,    # Optional: enables Tier 4
 )
 ```
 
@@ -89,7 +89,7 @@ await mem.log_turn(
     turn_id="t1",
     thought="Identifying relevant data sources for the market analysis.",
     action="http_get",
-    result="200 OK — retrieved 42 records",
+    result="200 OK, retrieved 42 records",
     tokens=1240,
 )
 ```
@@ -126,11 +126,11 @@ Assembles the full context bundle for Kernel cold-start or crash recovery. Retur
 
 | Key | Type | Source |
 |---|---|---|
-| `ltm_summary` | `str` or `None` | LongTermMemory — compressed narrative |
-| `recent_turns` | `list` | EpisodicLedger — last N turns |
-| `checkpoint` | `str` or `None` | Redis — last Kernel state snapshot |
-| `scratchpad` | `str` | WorkingScratchpad — current working notes |
-| `athena_context` | `dict` or `None` | Athena — STM events and MTM chains |
+| `ltm_summary` | `str` or `None` | LongTermMemory: compressed narrative |
+| `recent_turns` | `list` | EpisodicLedger: last N turns |
+| `checkpoint` | `str` or `None` | Redis: last Kernel state snapshot |
+| `scratchpad` | `str` | WorkingScratchpad: current working notes |
+| `athena_context` | `dict` or `None` | Athena: STM events and MTM chains |
 
 ```python
 bundle = await mem.rehydrate_bundle(ledger_tail=10)
@@ -229,6 +229,6 @@ See the [CLI Reference](../reference/cli.md) for the complete argument specifica
 
 ## Further Reading
 
-- [Athena MemOS (GitHub)](https://github.com/Prescott-Data/athena) — Open-source memory operating system: STM/MTM/LTM pipeline, vector store, and knowledge graph
-- [CLI Reference: memory](../reference/cli.md#jarviscore-memory) — Full argument specification for `jarviscore memory` subcommands
-- [Architecture Overview](architecture.md) — How memory fits into the OODA loop and the Kernel execution model
+- [Athena MemOS (GitHub)](https://github.com/Prescott-Data/athena): Open-source memory operating system with an STM/MTM/LTM pipeline, vector store, and knowledge graph
+- [CLI Reference: memory](../reference/cli.md#jarviscore-memory): Full argument specification for `jarviscore memory` subcommands
+- [Architecture Overview](architecture.md): How memory fits into the OODA loop and the Kernel execution model

--- a/jarviscore/docs/concepts/model-routing.md
+++ b/jarviscore/docs/concepts/model-routing.md
@@ -140,12 +140,12 @@ results = await mesh.workflow("report-001", [
     {
         "agent": "analyst",
         "task": "Is the word 'quarterly' in this text?",
-        "complexity": "nano",    # simple lookup — use the fast tier
+        "complexity": "nano",    # simple lookup: use the fast tier
     },
     {
         "agent": "analyst",
         "task": "Model the 5-year cashflow impact of our pricing change across all segments.",
-        "complexity": "heavy",   # deep reasoning — use the most capable tier
+        "complexity": "heavy",   # deep reasoning: use the most capable tier
     },
 ])
 ```
@@ -233,8 +233,8 @@ The tier system works with any provider that implements this interface. Complexi
 
 ## Further Reading
 
-- [Language Models](./language-models.md) — LLM roles, the completion interface, and CUA vs multimodal for browser automation
-- [Architecture Overview](./architecture.md) — how the Kernel, sub-agents, and ExecutionLease fit together
-- [AutoAgent Guide](../guides/autoagent.md) — `complexity` overrides and execution budgets
-- [Configuration Reference](../reference/configuration.md) — all environment variables including LLM tier keys
-- [Observability](../guides/observability.md) — tracing which model and provider handled each LLM call
+- [Language Models](./language-models.md): LLM roles, the completion interface, and CUA vs multimodal for browser automation
+- [Architecture Overview](./architecture.md): how the Kernel, sub-agents, and ExecutionLease fit together
+- [AutoAgent Guide](../guides/autoagent.md): `complexity` overrides and execution budgets
+- [Configuration Reference](../reference/configuration.md): all environment variables including LLM tier keys
+- [Observability](../guides/observability.md): tracing which model and provider handled each LLM call

--- a/jarviscore/docs/concepts/p2p.md
+++ b/jarviscore/docs/concepts/p2p.md
@@ -163,8 +163,8 @@ if response:
 
 | Parameter | Type | Default | Description |
 |---|---|---|---|
-| `target` | `str` | — | Target agent role or `agent_id` |
-| `message` | `dict` | — | Request payload |
+| `target` | `str` |: | Target agent role or `agent_id` |
+| `message` | `dict` |: | Request payload |
 | `timeout` | `float` | `30.0` | Seconds to wait for a response |
 | `context` | `dict` | `None` | Optional metadata |
 
@@ -240,8 +240,8 @@ Sends a request without blocking. Returns a `request_id` immediately.
 
 | Parameter | Type | Default | Description |
 |---|---|---|---|
-| `target` | `str` | — | Target agent role or `agent_id` |
-| `message` | `dict` | — | Request payload |
+| `target` | `str` |: | Target agent role or `agent_id` |
+| `message` | `dict` |: | Request payload |
 | `timeout` | `float` | `120.0` | Time to keep the request active before expiry |
 | `context` | `dict` | `None` | Optional metadata |
 
@@ -253,7 +253,7 @@ Checks for a response to a previously sent async request.
 
 | Parameter | Type | Default | Description |
 |---|---|---|---|
-| `request_id` | `str` | — | ID returned by `ask_async()` |
+| `request_id` | `str` |: | ID returned by `ask_async()` |
 | `timeout` | `float` | `0.0` | Seconds to wait if no response is available yet |
 | `remove` | `bool` | `True` | Remove the entry from the inbox after reading |
 

--- a/jarviscore/docs/concepts/planning.md
+++ b/jarviscore/docs/concepts/planning.md
@@ -88,7 +88,7 @@ Two outcomes short-circuit the LLM call entirely:
 
 If the step execution returned `status == "failure"`, the evaluator immediately returns `fail` without calling the LLM. The agent already knows it failed.
 
-If the step returned `status == "yield"`, the evaluator checks the yield type. Routine budget exhaustion (`YIELD_BUDGET_EXHAUSTED`, `YIELD_LEASE_EXHAUSTED`, `YIELD_EMERGENCY_TURN_FUSE`) is treated as `partial`, not `hitl`. The goal loop replans with smaller, more bounded steps rather than pausing for human review. Only convergence stalls — where the agent tried multiple strategies and still could not make progress — produce a genuine `hitl` verdict.
+If the step returned `status == "yield"`, the evaluator checks the yield type. Routine budget exhaustion (`YIELD_BUDGET_EXHAUSTED`, `YIELD_LEASE_EXHAUSTED`, `YIELD_EMERGENCY_TURN_FUSE`) is treated as `partial`, not `hitl`. The goal loop replans with smaller, more bounded steps rather than pausing for human review. Only convergence stalls (where the agent tried multiple strategies and still could not make progress) produce a genuine `hitl` verdict.
 
 ---
 
@@ -106,7 +106,7 @@ Valid routing hints are: `researcher`, `coder`, `communicator`, `browser`.
 
 A `PlannerError` is a hard failure. The Planner does not retry with a degraded plan and does not silently return a partial result. If the LLM call fails, the JSON is malformed, the response contains no valid steps array, or a step is missing `task` or `success_criterion`, the error surfaces immediately to the caller.
 
-The goal execution layer handles this by marking the goal as failed. There is no automatic retry of the planning call itself — planning failures typically indicate a prompt issue, a model configuration issue, or an unreachable LLM, none of which benefit from a blind retry.
+The goal execution layer handles this by marking the goal as failed. There is no automatic retry of the planning call itself: planning failures typically indicate a prompt issue, a model configuration issue, or an unreachable LLM, none of which benefit from a blind retry.
 
 An `EvaluatorError` follows the same pattern: invalid or unparseable evaluation responses raise immediately rather than defaulting to any verdict.
 

--- a/jarviscore/docs/concepts/system-bundles.md
+++ b/jarviscore/docs/concepts/system-bundles.md
@@ -6,9 +6,9 @@ icon: material/puzzle
 
 JarvisCore's integration model is built around two related ideas: **atoms** and **system bundles**.
 
-An **atom** is a single, versioned, self-contained Python function that performs one action against one external system — send a Slack message, create a GitHub issue, read a Google Sheet row. It has a fixed signature, it owns its HTTP transport, and it never holds state.
+An **atom** is a single, versioned, self-contained Python function that performs one action against one external system: send a Slack message, create a GitHub issue, read a Google Sheet row. It has a fixed signature, it owns its HTTP transport, and it never holds state.
 
-A **system bundle** is a generated Python class that groups all atoms for a given system together — `SlackCapabilities`, `GitHubCapabilities`, `StripeCapabilities` — making them available to agent code and the code sandbox as a typed, injectable unit.
+A **system bundle** is a generated Python class that groups all atoms for a given system together (`SlackCapabilities`, `GitHubCapabilities`, `StripeCapabilities`) making them available to agent code and the code sandbox as a typed, injectable unit.
 
 > [!NOTE]
 > **Coming from MCP?** System bundles are JarvisCore's native alternative to MCP tool servers. They are simpler (plain Python functions, no server process), tighter to the agent runtime, and carry an execution history that drives automatic promotion to production-ready status. [See the MCP comparison below.](#this-is-not-mcp)
@@ -45,11 +45,11 @@ def slack_send_message(auth_info: dict, channel: str, text: str, thread_ts: str 
 
 | Property | Rule |
 |---|---|
-| First parameter | Always `auth_info: dict` — populated by Nexus at call time |
-| Return type | Always `dict` — structured, never raw HTTP response |
-| Transport | Self-contained — imports requests internally |
-| State | Stateless — no class, no instance, no side effects beyond the API call |
-| Error handling | Raises on failure — the sandbox catches and reports |
+| First parameter | Always `auth_info: dict`: populated by Nexus at call time |
+| Return type | Always `dict`: structured, never raw HTTP response |
+| Transport | Self-contained: imports requests internally |
+| State | Stateless: no class, no instance, no side effects beyond the API call |
+| Error handling | Raises on failure: the sandbox catches and reports |
 
 Atoms intentionally embed their own `import requests` rather than relying on a shared HTTP client. This makes them independently executable in the code sandbox and portable across contexts.
 
@@ -120,7 +120,7 @@ Stage advances automatically when `update_execution_stats(success=True)` is call
 
 ## JIT: Just-In-Time Compilation
 
-The registry's most powerful capability is JIT — agent code generation for systems and actions that don't yet have a pre-built atom.
+The registry's most powerful capability is JIT: agent code generation for systems and actions that don't yet have a pre-built atom.
 
 When a task requires calling an external system and no matching atom exists in the registry, `CoderSubAgent` follows this fallback ladder:
 
@@ -144,9 +144,9 @@ When a task requires calling an external system and no matching atom exists in t
    └── Atom available for reuse in future calls
 ```
 
-This means the first time your agent needs to call, say, `quickbooks_create_invoice`, it writes and tests that function live. Every subsequent call skips straight to step 1 — the atom is already in the registry.
+This means the first time your agent needs to call, say, `quickbooks_create_invoice`, it writes and tests that function live. Every subsequent call skips straight to step 1: the atom is already in the registry.
 
-**Naming convention:** All atoms registered by CoderSubAgent follow `{system}_{action}` — e.g. `stripe_create_payment_intent`, `notion_create_page`, `github_list_open_prs`.
+**Naming convention:** All atoms registered by CoderSubAgent follow `{system}_{action}`: e.g. `stripe_create_payment_intent`, `notion_create_page`, `github_list_open_prs`.
 
 ---
 
@@ -207,7 +207,7 @@ JarvisCore ships with 77 pre-built atoms across 19 system bundles, seeded at sta
 
 ## This Is Not MCP
 
-The Model Context Protocol (MCP) by Anthropic is a standard for connecting LLM applications to external tools via a client-server protocol. It's a well-designed standard — MCP servers run as separate processes, expose tools via a JSON-RPC-like protocol, and clients discover and call them at runtime.
+The Model Context Protocol (MCP) by Anthropic is a standard for connecting LLM applications to external tools via a client-server protocol. It's a well-designed standard: MCP servers run as separate processes, expose tools via a JSON-RPC-like protocol, and clients discover and call them at runtime.
 
 JarvisCore's atom model takes a different approach, and it's worth being explicit about the trade-offs:
 
@@ -217,11 +217,11 @@ JarvisCore's atom model takes a different approach, and it's worth being explici
 | **Discovery** | MCP client discovers tools at runtime from the server | Registry lookup; JIT generation if missing |
 | **Transport** | JSON-RPC over stdio/HTTP | Direct Python call in sandbox |
 | **Versioning** | Server manages versions | Immutable `_v1`, `_v2` files + SHA256 |
-| **Execution history** | Not tracked | Tracked — drives candidate→verified→golden promotion |
+| **Execution history** | Not tracked | Tracked: drives candidate→verified→golden promotion |
 | **New tools** | Write a new MCP server handler | `CoderSubAgent` generates the atom JIT from a task description |
-| **Auth** | Varies by implementation | Always via Nexus — credentials never in agent code |
+| **Auth** | Varies by implementation | Always via Nexus: credentials never in agent code |
 
-**Does JarvisCore support MCP tools?** Not natively — there is no built-in MCP client. However, `CustomAgent` is flexible enough to wrap an MCP client directly:
+**Does JarvisCore support MCP tools?** Not natively: there is no built-in MCP client. However, `CustomAgent` is flexible enough to wrap an MCP client directly:
 
 ```python
 class MCPAgent(CustomAgent):
@@ -240,7 +240,7 @@ class MCPAgent(CustomAgent):
         return result
 ```
 
-This pattern lets teams adopt JarvisCore's orchestration, memory, and P2P mesh while keeping existing MCP tool servers intact. The atom model and MCP are not mutually exclusive — they operate at different layers.
+This pattern lets teams adopt JarvisCore's orchestration, memory, and P2P mesh while keeping existing MCP tool servers intact. The atom model and MCP are not mutually exclusive: they operate at different layers.
 
 **The pragmatic question** for teams evaluating JarvisCore: if you have MCP servers already built and working, wrap them in a `CustomAgent`. If you are starting fresh, atoms give you versioning, execution history, and JIT generation out of the box.
 
@@ -248,6 +248,6 @@ This pattern lets teams adopt JarvisCore's orchestration, memory, and P2P mesh w
 
 ## Further Reading
 
-- [System Bundles & Integrations Guide](../guides/integrations.md) — how to use pre-built atoms in agent code
-- [Nexus: Credential Federation](nexus.md) — how `auth_info` is populated at call time
-- [AutoAgent Guide](../guides/autoagent.md) — how `CoderSubAgent` selects and executes atoms
+- [System Bundles & Integrations Guide](../guides/integrations.md): how to use pre-built atoms in agent code
+- [Nexus: Credential Federation](nexus.md): how `auth_info` is populated at call time
+- [AutoAgent Guide](../guides/autoagent.md): how `CoderSubAgent` selects and executes atoms

--- a/jarviscore/docs/examples/content-pipeline.md
+++ b/jarviscore/docs/examples/content-pipeline.md
@@ -17,7 +17,7 @@ icon: material/text-box-edit
 
 ## What it does
 
-Four `CustomAgent` specialists run a content production pipeline. Unlike the Financial Pipeline (which uses `AutoAgent` with LLM code generation), these agents implement `execute_task()` directly in pure Python — deterministic, testable, no LLM required.
+Four `CustomAgent` specialists run a content production pipeline. Unlike the Financial Pipeline (which uses `AutoAgent` with LLM code generation), these agents implement `execute_task()` directly in pure Python: deterministic, testable, no LLM required.
 
 Cross-step data flows via `RedisMemoryAccessor`: each subsequent agent reads the previous step's output from Redis rather than receiving it as a function argument.
 
@@ -46,7 +46,7 @@ await mesh.start()
 
 # Verify what was detected
 print(mesh.has_capability("redis"))   # True when Redis is up
-print(mesh.has_capability("blob"))    # True — LocalBlobStorage always available
+print(mesh.has_capability("blob"))    # True: LocalBlobStorage always available
 ```
 
 1. No `mode=` argument. The Mesh detects Redis from `REDIS_URL` (or the config dict) at `start()` time and activates the workflow engine with Redis persistence automatically.
@@ -70,7 +70,7 @@ class WriterAgent(CustomAgent):
 ```
 
 1. `RedisMemoryAccessor` wraps the `RedisMemoryStore` with workflow-scoped key lookups.
-2. `accessor.get("research")` reads `step_output:{workflow_id}:research` from Redis — written by `WorkflowEngine` immediately after the research step completes.
+2. `accessor.get("research")` reads `step_output:{workflow_id}:research` from Redis, written by `WorkflowEngine` immediately after the research step completes.
 
 ---
 
@@ -91,7 +91,7 @@ class PublisherAgent(CustomAgent):
             await self.memory.ltm.save_summary(style_summary)  # (1)!
 ```
 
-1. On the next run, `WriterAgent.setup()` loads this via `self.memory.ltm.load_summary()` and injects it into the draft — the pipeline gets progressively smarter across runs without any code changes.
+1. On the next run, `WriterAgent.setup()` loads this via `self.memory.ltm.load_summary()` and injects it into the draft: the pipeline gets progressively smarter across runs without any code changes.
 
 ---
 

--- a/jarviscore/docs/examples/financial-pipeline.md
+++ b/jarviscore/docs/examples/financial-pipeline.md
@@ -66,7 +66,7 @@ results = await mesh.workflow("financial-daily-001", [
 
 1. Pass `redis_url` in the config dict. The Mesh detects the Redis connection at `start()` time and activates the workflow engine with persistence automatically. No `mode=` argument needed.
 2. `depends_on` tells the `WorkflowEngine` to wait until `fetch` succeeds. The `fetch` output is injected into the analyst's execution context automatically.
-3. Chained dependency — `report` waits for `analyse`. Context includes both prior step outputs.
+3. Chained dependency: `report` waits for `analyse`. Context includes both prior step outputs.
 
 ---
 
@@ -76,7 +76,7 @@ results = await mesh.workflow("financial-daily-001", [
 class MarketDataAgent(AutoAgent):
     role = "market_data"
     capabilities = ["market_data", "data_collection", "finance"]
-    system_prompt = "..."  # LLM prompt — store result in variable named 'result'
+    system_prompt = "..."  # LLM prompt: store result in variable named 'result'
 
     async def setup(self):
         await super().setup()
@@ -91,8 +91,8 @@ class MarketDataAgent(AutoAgent):
         )
 ```
 
-1. `self._redis_store` — a live `RedisMemoryStore`, ready to use. `None` if Redis is unavailable (example degrades gracefully).
-2. `self._blob_storage` — a `LocalBlobStorage` instance. On cloud deployments swap for `S3BlobStorage` via config.
+1. `self._redis_store`: a live `RedisMemoryStore`, ready to use. `None` if Redis is unavailable (example degrades gracefully).
+2. `self._blob_storage`: a `LocalBlobStorage` instance. On cloud deployments swap for `S3BlobStorage` via config.
 
 ---
 

--- a/jarviscore/docs/examples/index.md
+++ b/jarviscore/docs/examples/index.md
@@ -4,7 +4,7 @@ icon: material/book-open-variant
 
 # Examples
 
-Real, runnable programs that demonstrate JarvisCore in production-grade scenarios. Each example is a complete Python script (or multi-script cluster) in the [`examples/`](https://github.com/Prescott-Data/jarviscore-framework/tree/main/examples) directory of the repo — clone it, set up infra, and run.
+Real, runnable programs that demonstrate JarvisCore in production-grade scenarios. Each example is a complete Python script (or multi-script cluster) in the [`examples/`](https://github.com/Prescott-Data/jarviscore-framework/tree/main/examples) directory of the repo: clone it, set up infra, and run.
 
 ## Prerequisites
 
@@ -46,7 +46,7 @@ pip install -e ".[redis,prometheus]"
 
 === "Want the full picture?"
 
-    **[Investment Committee](investment-committee.md)** is the most advanced example — it mixes `AutoAgent` and `CustomAgent` profiles in a single mesh with a real multi-role deliberation pipeline.
+    **[Investment Committee](investment-committee.md)** is the most advanced example: it mixes `AutoAgent` and `CustomAgent` profiles in a single mesh with a real multi-role deliberation pipeline.
 
 ---
 
@@ -58,7 +58,7 @@ from jarviscore import Mesh
 # The Mesh requires no mode= argument.
 # It probes available infrastructure at start() and enables features accordingly.
 
-mesh = Mesh()                        # Minimal — workflow engine only
+mesh = Mesh()                        # Minimal: workflow engine only
 mesh = Mesh(config={"redis_url": "redis://localhost:6379/0"})  # + Redis persistence
 mesh = Mesh(config={"p2p_enabled": True})   # + SWIM discovery + ZMQ messaging
 
@@ -67,9 +67,9 @@ await mesh.start()
 # Inspect what was detected
 mesh.has_capability("redis")         # True when Redis is reachable
 mesh.has_capability("peer_swim")     # True when P2P stack is active
-mesh.has_capability("blob")          # True — LocalBlobStorage always available
-mesh.has_capability("workflow")      # True — WorkflowEngine always enabled
+mesh.has_capability("blob")          # True: LocalBlobStorage always available
+mesh.has_capability("workflow")      # True: WorkflowEngine always enabled
 ```
 
 > [!TIP]
-> You can also set `REDIS_URL` and `P2P_ENABLED=true` in your `.env` file — the Mesh reads these automatically, so you don't need to pass them in the `config` dict.
+> You can also set `REDIS_URL` and `P2P_ENABLED=true` in your `.env` file: the Mesh reads these automatically, so you don't need to pass them in the `config` dict.

--- a/jarviscore/docs/examples/investment-committee.md
+++ b/jarviscore/docs/examples/investment-committee.md
@@ -17,7 +17,7 @@ icon: material/cash-multiple
 
 ## What it does
 
-The flagship example. Seven specialist agents form a real investment committee that deliberates over a stock allocation decision. Each agent plays a distinct professional role — market analyst, financial analyst, technical analyst, risk officer, knowledge agent, memo writer, and committee chair.
+The flagship example. Seven specialist agents form a real investment committee that deliberates over a stock allocation decision. Each agent plays a distinct professional role: market analyst, financial analyst, technical analyst, risk officer, knowledge agent, memo writer, and committee chair.
 
 This is the only example that **mixes** `AutoAgent` and `CustomAgent` profiles in the same mesh, and uses the most complex workflow DAG across all examples.
 
@@ -39,10 +39,10 @@ The committee chair reads the full memo and all prior analyses, then outputs a s
 ```bash
 cd examples/investment_committee
 
-# Quick mode — fundamentals only (1 step, fast)
+# Quick mode: fundamentals only (1 step, fast)
 python committee.py --mode quick --ticker AAPL
 
-# Full mode — complete deliberation pipeline (6 steps)
+# Full mode: complete deliberation pipeline (6 steps)
 python committee.py --mode full --ticker NVDA --amount 1500000
 python committee.py --mode full --ticker AMD  --amount 2000000
 ```
@@ -57,13 +57,13 @@ from jarviscore import Mesh
 mesh = Mesh(config={"redis_url": REDIS_URL})   # (1)!
 
 for AgentClass in [
-    MarketAnalystAgent,      # AutoAgent — uses yfinance + LLM analysis
-    FinancialAnalystAgent,   # AutoAgent — pulls P/E, P/S, EV/EBITDA
-    TechnicalAnalystAgent,   # AutoAgent — RSI, MA crossover, trend
-    RiskOfficerAgent,        # AutoAgent — VaR, mandate compliance
-    KnowledgeAgent,          # CustomAgent — reads from LTM, no LLM needed (2)!
-    MemoWriterAgent,         # AutoAgent — synthesises all prior outputs
-    CommitteeChairAgent,     # AutoAgent — final BUY/HOLD/PASS decision
+    MarketAnalystAgent,      # AutoAgent: uses yfinance + LLM analysis
+    FinancialAnalystAgent,   # AutoAgent: pulls P/E, P/S, EV/EBITDA
+    TechnicalAnalystAgent,   # AutoAgent: RSI, MA crossover, trend
+    RiskOfficerAgent,        # AutoAgent: VaR, mandate compliance
+    KnowledgeAgent,          # CustomAgent: reads from LTM, no LLM needed (2)!
+    MemoWriterAgent,         # AutoAgent: synthesises all prior outputs
+    CommitteeChairAgent,     # AutoAgent: final BUY/HOLD/PASS decision
 ]:
     mesh.add(AgentClass)
 
@@ -71,7 +71,7 @@ await mesh.start()
 ```
 
 1. No `mode=` argument. `Mesh()` detects Redis and activates the workflow engine with persistence automatically.
-2. `KnowledgeAgent` is a `CustomAgent` that reads from long-term memory — mixing profiles lets you use the right tool for each role.
+2. `KnowledgeAgent` is a `CustomAgent` that reads from long-term memory: mixing profiles lets you use the right tool for each role.
 
 ---
 
@@ -113,7 +113,7 @@ results = await mesh.workflow(wf_id, steps)
 ```
 
 1. `risk_assessment` fans in from two parallel analyses. The `WorkflowEngine` waits for both before dispatching.
-2. `memo_draft` is the convergence point — it waits for all five preceding steps and receives all their outputs as `previous_step_results` in the execution context.
+2. `memo_draft` is the convergence point: it waits for all five preceding steps and receives all their outputs as `previous_step_results` in the execution context.
 
 ---
 
@@ -149,7 +149,7 @@ print(f"Allocation: ${out.get('allocation_usd', 0):,.0f}")
 print(f"Conviction: {out.get('conviction')}")
 ```
 
-1. `_extract_output()` strips Markdown fences, attempts `json.loads()`, and falls back to an empty dict — so the rest of your code never has to branch on whether the output is a string or a dict.
+1. `_extract_output()` strips Markdown fences, attempts `json.loads()`, and falls back to an empty dict: so the rest of your code never has to branch on whether the output is a string or a dict.
 
 The same pattern applies inside `CommitteeChairAgent` when reading the memo from a prior step:
 

--- a/jarviscore/docs/examples/research-network.md
+++ b/jarviscore/docs/examples/research-network.md
@@ -17,7 +17,7 @@ icon: material/magnify
 
 ## What it does
 
-A four-node cluster where each process runs a single specialist researcher. The `Synthesizer` acts as the workflow coordinator and SWIM seed — it submits a 4-step research workflow to Redis and then all nodes race to claim matching steps based on their declared `capabilities`.
+A four-node cluster where each process runs a single specialist researcher. The `Synthesizer` acts as the workflow coordinator and SWIM seed: it submits a 4-step research workflow to Redis and then all nodes race to claim matching steps based on their declared `capabilities`.
 
 ```
 Terminal A: Synthesizer    → Submits workflow, waits for results
@@ -34,7 +34,7 @@ No manual wiring. Each node declares its capabilities and the mesh's distributed
 ## Run order
 
 ```bash
-# Terminal A — start synthesizer FIRST (it is the SWIM seed)
+# Terminal A: start synthesizer FIRST (it is the SWIM seed)
 python examples/research_synthesizer.py
 
 # Then start nodes in any order
@@ -61,8 +61,8 @@ mesh.add(SynthesizerAgent)
 await mesh.start()
 
 # Check what the Mesh detected
-print(mesh.has_capability("redis"))         # True — Redis connected
-print(mesh.has_capability("peer_swim"))     # True — SWIM/ZMQ active
+print(mesh.has_capability("redis"))         # True: Redis connected
+print(mesh.has_capability("peer_swim"))     # True: SWIM/ZMQ active
 ```
 
 1. Set `p2p_enabled: True` (or `P2P_ENABLED=true` in `.env`) to activate the SWIM peer transport. The Mesh detects Redis automatically from `REDIS_URL`.
@@ -89,7 +89,7 @@ class TechResearchAgent(AutoAgent):
 ```
 
 1. The distributed worker loop scans for pending workflow steps whose `agent` field matches any string in `capabilities`. No explicit routing needed.
-2. `step_id` must match the `id` field in the workflow definition — this is how the worker claims the step atomically via Redis `SETNX`.
+2. `step_id` must match the `id` field in the workflow definition: this is how the worker claims the step atomically via Redis `SETNX`.
 
 ---
 

--- a/jarviscore/docs/examples/support-swarm.md
+++ b/jarviscore/docs/examples/support-swarm.md
@@ -17,7 +17,7 @@ icon: material/lifebuoy
 
 ## What it does
 
-Four `CustomAgent` specialists form a P2P swarm. There is no central workflow orchestrator — routing is event-driven via the mailbox. A `GatewayAgent` receives inbound queries, classifies them by keyword, and routes each to the correct specialist via a mailbox message.
+Four `CustomAgent` specialists form a P2P swarm. There is no central workflow orchestrator: routing is event-driven via the mailbox. A `GatewayAgent` receives inbound queries, classifies them by keyword, and routes each to the correct specialist via a mailbox message.
 
 ```
 Customer query → GatewayAgent
@@ -46,7 +46,7 @@ mesh = Mesh(config={
     "bind_host": "127.0.0.1",
     "bind_port": 7960,
     "node_name": "support-swarm",
-    # Auth — optional, only needed for Nexus flow testing
+    # Auth: optional, only needed for Nexus flow testing
     "auth_mode": "production",
     "nexus_gateway_url": NEXUS_GATEWAY,
 })
@@ -57,7 +57,7 @@ mesh.add(BillingAgent)
 mesh.add(EscalationAgent)
 await mesh.start()
 
-# P2P agents drive themselves — use run_forever() for persistent loops
+# P2P agents drive themselves: use run_forever() for persistent loops
 # or call agent methods directly for scripted tests (as this example does)
 ```
 
@@ -116,7 +116,7 @@ class TechnicalAgent(CustomAgent):
 ```
 
 1. Setting `requires_auth = True` tells `Mesh.start()` to inject an `AuthenticationManager` as `self._auth_manager`.
-2. `self._auth_manager` is `None` when `NEXUS_GATEWAY_URL` is not set — guard with `if self._auth_manager` to degrade gracefully.
+2. `self._auth_manager` is `None` when `NEXUS_GATEWAY_URL` is not set: guard with `if self._auth_manager` to degrade gracefully.
 3. `get_connection_id()` drives the full Nexus protocol: `POST /v1/request-connection` → browser OAuth consent → `GET /v1/check-connection/{id}` poll until `ACTIVE` → `GET /v1/token/{id}` resolve strategy. The `connection_id` is then passed to `NexusCallProxy` which injects the correct `Authorization` header for every outbound request.
 
 **To test the real Nexus flow**, set in `.env`:

--- a/jarviscore/docs/getting-started.md
+++ b/jarviscore/docs/getting-started.md
@@ -184,6 +184,21 @@ Expected output when everything is correctly configured:
 
 ---
 
+## Choose Your Agent Profile
+
+JarvisCore ships exactly two agent profiles. This is the first decision in every project:
+
+| | `AutoAgent` | `CustomAgent` |
+|---|---|---|
+| Who brings the logic | The framework: LLM reasoning, sandboxed code generation, self-repair | You: plain Python in `execute_task` |
+| You write | `role`, `capabilities`, `system_prompt` | The implementation |
+| Use for | Tasks you can describe: research, analysis, content, data extraction | Logic you can code: API workers, wrapping existing services, deterministic pipelines |
+| Guide | [AutoAgent guide](guides/autoagent.md) | [CustomAgent guide](guides/customagent.md) |
+
+Both run on the same mesh and mix freely in one system. Not sure? Start with `AutoAgent` below; switch any agent to `CustomAgent` later without touching the rest.
+
+---
+
 ## Your First Agent
 
 Create a file named `main.py`:
@@ -228,6 +243,23 @@ python main.py
 ```
 
 The agent will reason through the task using the OODA loop and return a structured response. Because no infrastructure is configured beyond the LLM key, all state is held in process memory and discarded when the script exits.
+
+The same agent as a `CustomAgent`, when you want to own the logic instead of describing the task:
+
+```python title="main.py (CustomAgent variant)"
+from jarviscore.profiles import CustomAgent
+
+
+class ResearcherAgent(CustomAgent):
+    role = "researcher"
+    capabilities = ["research"]
+
+    async def execute_task(self, task):
+        findings = await my_research_pipeline(task["task"])   # your code
+        return {"status": "success", "output": findings}
+```
+
+Everything else on this page works identically for both profiles.
 
 ---
 

--- a/jarviscore/docs/getting-started.md
+++ b/jarviscore/docs/getting-started.md
@@ -10,12 +10,12 @@ This guide takes you from a fresh Python environment to a running JarvisCore age
 
 ## Requirements
 
-JarvisCore requires Python 3.10 or later. No infrastructure is required to run a minimal agent — the first working example in this guide uses only an LLM API key.
+JarvisCore requires Python 3.10 or later. No infrastructure is required to run a minimal agent. The first working example in this guide uses only an LLM API key.
 
 **Optional: Docker** is required for two capabilities:
 
-- `jarviscore nexus up` — starts the local Nexus broker and gateway for OAuth2 credential management
-- `jarviscore-framework[browser]` — Playwright runs in a Docker-managed Chromium for browser automation
+- `jarviscore nexus up` starts the local Nexus broker and gateway for OAuth2 credential management
+- `jarviscore-framework[browser]` runs Playwright in a Docker-managed Chromium for browser automation
 
 If you are not using Nexus or browser automation, Docker is not needed.
 
@@ -64,7 +64,7 @@ To install optional extras for specific capabilities:
     ```bash
     pip install "jarviscore-framework[research]"
     ```
-    Full researcher stack — installs `browser` + `rag` + BeautifulSoup4. Everything `ResearcherSubAgent` needs for deep web research.
+    Full researcher stack: installs `browser` + `rag` + BeautifulSoup4. Everything `ResearcherSubAgent` needs for deep web research.
 
 === "Athena Memory"
     ```bash
@@ -88,7 +88,7 @@ To install optional extras for specific capabilities:
     ```bash
     pip install "jarviscore-framework[full]"
     ```
-    Installs every optional dependency — use for production deployments where you need all capabilities enabled.
+    Installs every optional dependency. Use for production deployments where you need all capabilities enabled.
 
 ---
 
@@ -103,7 +103,7 @@ jarviscore init
 This creates:
 
 ```
-.env.example        — environment variable template
+.env.example: environment variable template
 ```
 
 Copy the example to create your working configuration:
@@ -278,6 +278,17 @@ async def main():
 if __name__ == "__main__":
     asyncio.run(main())
 ```
+
+---
+
+## One Thing to Know: Two Ways to Run
+
+You will see two execution calls in these docs and it matters which one you reach for:
+
+- `mesh.run_task(agent=..., task=...)` runs one task on one agent and returns its result. Use it for single asks and for hand-rolled pipelines like the example above, where your own code decides what happens between steps.
+- `mesh.workflow(id, steps)` runs a declared list of steps as one traced unit: the framework handles ordering, dependencies, retries, and records the whole thing under a single workflow id. Use it the moment you have more than one step that belongs together.
+
+A useful rule: if you are passing one agent's output into another agent's prompt by hand, you probably want `workflow`. See the [Workflow DAGs guide](guides/workflows.md).
 
 ---
 

--- a/jarviscore/docs/getting-started.md
+++ b/jarviscore/docs/getting-started.md
@@ -281,14 +281,12 @@ if __name__ == "__main__":
 
 ---
 
-## One Thing to Know: Two Ways to Run
+## Two Ways to Run
 
-You will see two execution calls in these docs and it matters which one you reach for:
+- `mesh.run_task(agent=..., task=...)` runs one task on one agent. Use it for single asks and hand-rolled pipelines where your code decides what happens between steps.
+- `mesh.workflow(id, steps)` runs declared steps as one traced unit: ordering, dependencies, retries, and a single workflow id. Use it when steps belong together.
 
-- `mesh.run_task(agent=..., task=...)` runs one task on one agent and returns its result. Use it for single asks and for hand-rolled pipelines like the example above, where your own code decides what happens between steps.
-- `mesh.workflow(id, steps)` runs a declared list of steps as one traced unit: the framework handles ordering, dependencies, retries, and records the whole thing under a single workflow id. Use it the moment you have more than one step that belongs together.
-
-A useful rule: if you are passing one agent's output into another agent's prompt by hand, you probably want `workflow`. See the [Workflow DAGs guide](guides/workflows.md).
+Rule of thumb: passing one agent's output into another agent's prompt by hand means you want `workflow`. See [Workflow DAGs](guides/workflows.md).
 
 ---
 

--- a/jarviscore/docs/guides/autoagent.md
+++ b/jarviscore/docs/guides/autoagent.md
@@ -202,7 +202,7 @@ Use this for tasks where the whole job is the answer: analysis, classification, 
 
 ## Coder Sandbox
 
-When the Kernel routes a task to the `CoderSubAgent`, code executes inside `CoderSandbox` — a deliberately file-capable execution environment that is distinct from the `SandboxExecutor` used by other sub-agents.
+When the Kernel routes a task to the `CoderSubAgent`, code executes inside `CoderSandbox`: a deliberately file-capable execution environment that is distinct from the `SandboxExecutor` used by other sub-agents.
 
 `SandboxExecutor` (used by ResearcherSubAgent and CommunicatorSubAgent) blocks `open()`, `subprocess`, and filesystem access. `CoderSandbox` intentionally grants those capabilities, scoped to a controlled workspace directory.
 
@@ -211,7 +211,7 @@ Inside every execution, generated code receives these names in its namespace:
 | Name | Type | Description |
 |---|---|---|
 | `workspace` | `Path` | Project root directory. All file reads and writes are expected here. |
-| `output_dir` | `Path` | `workspace/output/` — the preferred write location for produced files. |
+| `output_dir` | `Path` | `workspace/output/`: the preferred write location for produced files. |
 | `blob_path(name)` | `Path` | Shorthand for `output_dir / name`. Creates parent directories. |
 | `bash(cmd)` | `BashExecutor` | Run allowed shell commands. Returns `{success, stdout, stderr, returncode}`. |
 | `git` | `GitHelper` | High-level git: `checkout_branch`, `add_all`, `commit`, `push`, `describe_pr`. |
@@ -222,7 +222,7 @@ The Coder can `import` any installed package from within the sandbox. The securi
 
 The bash allow-list covers: `git`, `pip`, `pip3`, `cp`, `mv`, `mkdir`, `rm`, `ls`, `cat`, `echo`, `touch`, `find`, `grep`, `sed`, `awk`, `pandoc`, `npm`, `npx`, `node`, `python`, `python3`, `curl`. Hard-blocked regardless: `sudo`, `rm -rf /`, `eval`, `curl | bash`, and pipe-to-shell patterns.
 
-The `CoderResult` output shape — what gets written to `result` by generated code and surfaced in `step["payload"]`:
+The `CoderResult` output shape: what gets written to `result` by generated code and surfaced in `step["payload"]`:
 
 ```python
 result = {
@@ -239,7 +239,7 @@ result = {
 Configure the workspace root and timeouts:
 
 ```bash title=".env"
-# Workspace directory — defaults to the process working directory
+# Workspace directory: defaults to the process working directory
 CODER_WORKSPACE=/path/to/your/project
 
 # Sandbox execution timeout in seconds (default: 300)
@@ -252,7 +252,7 @@ When writing system prompts for agents that route to the Coder, always tell the 
 
 ## Execution Budgets
 
-Every sub-agent dispatch runs against an `ExecutionLease` — a token, turn, and wall-clock budget specific to the sub-agent role. When the lease is exhausted, the Kernel stops the sub-agent and returns whatever has been produced so far.
+Every sub-agent dispatch runs against an `ExecutionLease`: a token, turn, and wall-clock budget specific to the sub-agent role. When the lease is exhausted, the Kernel stops the sub-agent and returns whatever has been produced so far.
 
 | Role | Thinking tokens | Action tokens | Total tokens | Wall clock | Turn fuse |
 |---|---|---|---|---|---|
@@ -263,7 +263,7 @@ Every sub-agent dispatch runs against an `ExecutionLease` — a token, turn, and
 
 The turn fuse is an emergency hard-stop. If a sub-agent reaches 32 turns without completing, the Kernel terminates it regardless of token budget. This prevents runaway loops on adversarial or ambiguous tasks.
 
-You do not configure lease budgets per-agent — they are role-level defaults. If a specific task consistently exhausts the budget, the right fix is usually to narrow the task scope (break it into smaller steps in the workflow DAG), not to increase the budget.
+You do not configure lease budgets per-agent: they are role-level defaults. If a specific task consistently exhausts the budget, the right fix is usually to narrow the task scope (break it into smaller steps in the workflow DAG), not to increase the budget.
 
 Token budget consumption appears in `step["metadata"]["tokens"]` on every workflow result:
 
@@ -281,7 +281,7 @@ print(step["metadata"]["tokens"])
 
 ## Model Routing
 
-JarvisCore routes each sub-agent dispatch to a capability tier — `nano`, `standard`, or `heavy` — based on the role and an optional per-step hint. Pass `complexity` in a workflow step to override the default for that dispatch:
+JarvisCore routes each sub-agent dispatch to a capability tier (`nano`, `standard`, or `heavy`) based on the role and an optional per-step hint. Pass `complexity` in a workflow step to override the default for that dispatch:
 
 ```python
 results = await mesh.workflow("task-001", [
@@ -290,7 +290,7 @@ results = await mesh.workflow("task-001", [
 ])
 ```
 
-When `complexity` is omitted, the role's built-in default applies — `communicator` defaults to `nano`, `researcher` and `browser` default to `standard`. See [Model Routing](../concepts/model-routing.md) for the full tier configuration, fallback chain, and provider compatibility reference.
+When `complexity` is omitted, the role's built-in default applies: `communicator` defaults to `nano`, `researcher` and `browser` default to `standard`. See [Model Routing](../concepts/model-routing.md) for the full tier configuration, fallback chain, and provider compatibility reference.
 
 ---
 
@@ -301,7 +301,7 @@ The Mesh injects infrastructure stores into every agent before `setup()` runs. T
 | Attribute | Available when |
 |---|---|
 | `self._redis_store` | `REDIS_URL` is set |
-| `self._blob_storage` | Always — falls back to local filesystem |
+| `self._blob_storage` | Always: falls back to local filesystem |
 | `self.mailbox` | `REDIS_URL` is set |
 
 ```python
@@ -330,9 +330,9 @@ prior = raw.get("output", raw) if isinstance(raw, dict) else {}
 
 ### Checkpointing
 
-Checkpointing happens automatically. After every OODA loop turn, the Kernel calls `UnifiedMemory.save_checkpoint()` which writes the current `KernelState` — all accumulated findings, tool history, and reasoning progress — to Redis under `checkpoint:{workflow_id}:{step_id}`. If the process crashes and the workflow restarts, the `WorkflowEngine` detects the existing checkpoint and resumes from that turn rather than restarting from scratch.
+Checkpointing happens automatically. After every OODA loop turn, the Kernel calls `UnifiedMemory.save_checkpoint()` which writes the current `KernelState` (all accumulated findings, tool history, and reasoning progress) to Redis under `checkpoint:{workflow_id}:{step_id}`. If the process crashes and the workflow restarts, the `WorkflowEngine` detects the existing checkpoint and resumes from that turn rather than restarting from scratch.
 
-You do not call `save_checkpoint()` or `load_checkpoint()` in application code. The framework manages this transparently when `REDIS_URL` is configured. Without Redis, there is no persistence and no crash recovery — the workflow starts from the beginning on failure.
+You do not call `save_checkpoint()` or `load_checkpoint()` in application code. The framework manages this transparently when `REDIS_URL` is configured. Without Redis, there is no persistence and no crash recovery: the workflow starts from the beginning on failure.
 
 ---
 
@@ -458,13 +458,13 @@ HITL_MAX_CONFIDENCE=0.8
 HITL_MIN_RISK_SCORE=0.7
 ```
 
-Per-agent escalation targets are configured in the agent profile YAML under `escalates_to`. See the [Agent Personas](../concepts/agent-personas.md) concept page for the full schema. For the full HITL API — `request()`, `wait()`, `check()`, `resolve()` — see the [HITL Escalation guide](hitl.md).
+Per-agent escalation targets are configured in the agent profile YAML under `escalates_to`. See the [Agent Personas](../concepts/agent-personas.md) concept page for the full schema. For the full HITL API (`request()`, `wait()`, `check()`, `resolve()`) see the [HITL Escalation guide](hitl.md).
 
 ---
 
 ## Production Example: Financial Pipeline
 
-The `financial_pipeline.py` example runs three AutoAgents sequentially — a market data fetcher, an analyst, and a report writer — with Redis crash recovery, UnifiedMemory episodic logging, and blob storage output.
+The `financial_pipeline.py` example runs three AutoAgents sequentially (a market data fetcher, an analyst, and a report writer) with Redis crash recovery, UnifiedMemory episodic logging, and blob storage output.
 
 ```bash
 docker compose -f docker-compose.infra.yml up -d
@@ -488,4 +488,4 @@ Running with the same `workflow_id` a second time skips already-completed steps.
 
 If a task returns a success status with `execution_time` under 10 milliseconds and a null payload, the generated code failed instantly before doing any real work. This almost always means `context` was not passed in the task dict, so the generated code raised a `NameError` on the first line that referenced it. Make sure every step dict includes a `"context"` key, even if empty.
 
-If code keeps failing after autonomous repairs, improve the system prompt. The LLM generates code from the prompt. Vague prompts produce fragile code — the more explicit you are about available tools, input format, and the exact shape of `result`, the fewer repairs are needed.
+If code keeps failing after autonomous repairs, improve the system prompt. The LLM generates code from the prompt. Vague prompts produce fragile code: the more explicit you are about available tools, input format, and the exact shape of `result`, the fewer repairs are needed.

--- a/jarviscore/docs/guides/chat.md
+++ b/jarviscore/docs/guides/chat.md
@@ -4,7 +4,7 @@ icon: material/chat-processing
 
 # Chat Endpoint
 
-JarvisCore agents are not just task executors — they can function as conversational interfaces. The `create_chat_router` factory produces a FastAPI router with a `POST /chat` endpoint and a real-time Server-Sent Events stream, letting you build a chat UI backed by any JarvisCore `AutoAgent` in minutes.
+JarvisCore agents are not just task executors: they can function as conversational interfaces. The `create_chat_router` factory produces a FastAPI router with a `POST /chat` endpoint and a real-time Server-Sent Events stream, letting you build a chat UI backed by any JarvisCore `AutoAgent` in minutes.
 
 ---
 
@@ -123,7 +123,7 @@ curl -X POST http://localhost:8000/api/v1/chat \
 
 ### `GET /api/v1/chat/stream/{workflow_id}`
 
-Real-time SSE stream of trace events for a workflow. Connect before or after the `POST /chat` call — missed events are replayed from Redis on connection.
+Real-time SSE stream of trace events for a workflow. Connect before or after the `POST /chat` call: missed events are replayed from Redis on connection.
 
 ```javascript title="Browser SSE client"
 const workflowId = "chat-a3f2b1";
@@ -163,7 +163,7 @@ es.onmessage = (e) => {
 | `tool_result` | `tool: str, result: str, success: bool, error: str\|null` | Tool result returned |
 | `llm_request` | `system_preview: str, user_preview: str` | LLM call dispatched |
 | `llm_response` | `content_preview: str, latency_ms: float` | LLM response received |
-| `step_complete` | `success: bool, summary: str` | Execution finished — read `answer` and `sources` from the POST response |
+| `step_complete` | `success: bool, summary: str` | Execution finished: read `answer` and `sources` from the POST response |
 | `error` | `message: str` | Something went wrong |
 | `timeout` | `message: str` | Stream timed out (default: 300 seconds) |
 
@@ -195,7 +195,7 @@ curl http://localhost:8000/api/v1/chat/history/chat-a3f2b1/step-1
 
 ## Multi-Turn Conversations
 
-Pass the same `workflow_id` across multiple `POST /chat` calls to give the Kernel a shared memory anchor. Each call generates its own `step_id` (a timestamp-based key), so the episodic ledger entries are separate. What persists across calls is the Athena and long-term memory context — the Kernel rehydrates that on each request using the same `workflow_id` as the lookup key.
+Pass the same `workflow_id` across multiple `POST /chat` calls to give the Kernel a shared memory anchor. Each call generates its own `step_id` (a timestamp-based key), so the episodic ledger entries are separate. What persists across calls is the Athena and long-term memory context: the Kernel rehydrates that on each request using the same `workflow_id` as the lookup key.
 
 In practice this means the agent can refer to what it learned in an earlier turn when Athena is configured. Without Athena, each call is stateless regardless of `workflow_id`.
 
@@ -208,7 +208,7 @@ client = httpx.Client(base_url="http://localhost:8000")
 r1 = client.post("/api/v1/chat", json={"message": "Tell me about transformer attention."})
 workflow_id = r1.json()["workflow_id"]
 
-# Turn 2 — same workflow_id; Kernel rehydrates shared memory context
+# Turn 2: same workflow_id; Kernel rehydrates shared memory context
 r2 = client.post("/api/v1/chat", json={
     "message": "How does that compare to state space models?",
     "workflow_id": workflow_id,
@@ -222,7 +222,7 @@ r2 = client.post("/api/v1/chat", json={
 
 ## Adding a System Prompt Per Request
 
-The `system_prompt` field in the request is passed directly to `kernel.execute()` as the system prompt for the Kernel's subagent dispatch. It replaces the subagent's default system prompt for that request. The AutoAgent class's own `system_prompt` attribute is not affected — this field is a per-request override, not an extension of it.
+The `system_prompt` field in the request is passed directly to `kernel.execute()` as the system prompt for the Kernel's subagent dispatch. It replaces the subagent's default system prompt for that request. The AutoAgent class's own `system_prompt` attribute is not affected: this field is a per-request override, not an extension of it.
 
 The `context` dict is injected into the agent's task context alongside the message:
 
@@ -238,6 +238,6 @@ httpx.post("/api/v1/chat", json={
 
 ## Further Reading
 
-- [FastAPI Integration](fastapi.md) — Full FastAPI setup with `JarvisLifespan` and `mesh.workflow()`
-- [Observability](observability.md) — How trace events are stored and what metrics are emitted
-- [AutoAgent Guide](autoagent.md) — The Kernel OODA loop that drives the chat endpoint
+- [FastAPI Integration](fastapi.md): Full FastAPI setup with `JarvisLifespan` and `mesh.workflow()`
+- [Observability](observability.md): How trace events are stored and what metrics are emitted
+- [AutoAgent Guide](autoagent.md): The Kernel OODA loop that drives the chat endpoint

--- a/jarviscore/docs/guides/custom-subagents.md
+++ b/jarviscore/docs/guides/custom-subagents.md
@@ -37,7 +37,7 @@ def register_tool(
     name: str,           # String the LLM emits in TOOL: <name>
     func: Callable,      # Async or sync callable
     description: str,    # Shown to LLM; include param schema
-    phase: str = "action",  # "action" or "thinking" — informational only
+    phase: str = "action",  # "action" or "thinking": informational only
 )
 ```
 
@@ -53,7 +53,7 @@ class DatabaseSubAgent(BaseSubAgent):
     SYSTEM_PROMPT = """
     You are a DATABASE QUERY SPECIALIST.
     Rules:
-    1. Only use SELECT — never INSERT, UPDATE, DELETE, or DROP.
+    1. Only use SELECT, never INSERT, UPDATE, DELETE, or DROP.
     2. Limit results to 100 rows unless the task says otherwise.
     3. Include the query and row count in your DONE summary.
     """
@@ -136,7 +136,7 @@ Called when the LLM emits `DONE`. Return `(True, "")` to allow, or `(False, "rea
 ```python
 def _can_complete(self, state, parsed) -> tuple:
     if not parsed.get("result", {}).get("rows"):
-        return False, "No rows returned — run a query before finishing."
+        return False, "No rows returned. Run a query before finishing."
     return True, ""
 ```
 

--- a/jarviscore/docs/guides/customagent.md
+++ b/jarviscore/docs/guides/customagent.md
@@ -4,7 +4,7 @@ icon: material/code-braces
 
 # CustomAgent Guide
 
-`CustomAgent` is JarvisCore's structured execution agent. You implement the handlers yourself, which gives you complete control over what happens when a message arrives. The framework provides the infrastructure layer — memory, peer communication, Nexus auth, mailbox, blob storage, and mesh connectivity — all injected automatically before your `setup()` runs.
+`CustomAgent` is JarvisCore's structured execution agent. You implement the handlers yourself, which gives you complete control over what happens when a message arrives. The framework provides the infrastructure layer (memory, peer communication, Nexus auth, mailbox, blob storage, and mesh connectivity) all injected automatically before your `setup()` runs.
 
 Use `CustomAgent` when the steps required to complete a task are known in advance, when you are wrapping an existing service or LangChain agent, when you need deterministic auditable execution, or when you want to build a long-running message-driven worker rather than a one-shot task executor.
 
@@ -12,7 +12,7 @@ Use `CustomAgent` when the steps required to complete a task are known in advanc
 
 ## The Core Interface
 
-`CustomAgent` is a message-driven agent. The primary method to implement is `on_peer_request()`, not `run()`. The `run()` method is the framework's internal listener loop — it receives P2P messages and dispatches them to your handlers. You do not override it.
+`CustomAgent` is a message-driven agent. The primary method to implement is `on_peer_request()`, not `run()`. The `run()` method is the framework's internal listener loop: it receives P2P messages and dispatches them to your handlers. You do not override it.
 
 ```python title="agents/analyst.py"
 from jarviscore import CustomAgent
@@ -41,7 +41,7 @@ The `msg` parameter is an `IncomingMessage` object. Its fields are:
 | `msg.sender` | Sender agent ID or role string |
 | `msg.data` | Payload dict |
 | `msg.type` | `MessageType.REQUEST` or `MessageType.NOTIFY` |
-| `msg.correlation_id` | For response matching — handled automatically |
+| `msg.correlation_id` | For response matching: handled automatically |
 
 Return a dict from `on_peer_request()` and the framework sends it back to the requester automatically (controlled by `auto_respond = True`, the default). Return `None` to skip sending a response.
 
@@ -65,7 +65,7 @@ Return a dict from `on_peer_request()` and the framework sends it back to the re
 
 ### setup
 
-Called once by the Mesh after instantiation. Override to initialise connections, load configuration, or perform one-time setup. Always call `await super().setup()` first — this connects the agent to memory tiers and the peer registry:
+Called once by the Mesh after instantiation. Override to initialise connections, load configuration, or perform one-time setup. Always call `await super().setup()` first: this connects the agent to memory tiers and the peer registry:
 
 ```python
 async def setup(self):
@@ -113,13 +113,13 @@ The Mesh injects these stores into every agent before `setup()` runs. All three 
 | Attribute | Type | Available when |
 |---|---|---|
 | `self._redis_store` | `RedisStore` | `REDIS_URL` is set |
-| `self._blob_storage` | `LocalBlobStorage` or `AzureBlobStorage` | Always — falls back to local filesystem |
+| `self._blob_storage` | `LocalBlobStorage` or `AzureBlobStorage` | Always: falls back to local filesystem |
 | `self.mailbox` | `MailboxManager` | `REDIS_URL` is set |
 
 ```python
 async def setup(self):
     await super().setup()
-    # All three already injected — use them immediately
+    # All three already injected: use them immediately
     self.memory = UnifiedMemory(
         workflow_id="wf-001", step_id=self.role,
         agent_id=self.role,
@@ -244,7 +244,7 @@ For the complete `PeerClient` API, see the [P2P Communication](../concepts/p2p.m
 
 ## Nexus Auth: requires_auth
 
-Set `requires_auth = True` on agents that call third-party services. The Mesh creates an `AuthenticationManager` backed by Nexus and injects it as `self._auth_manager` after `setup()` completes. The full OAuth flow — browser consent, token refresh — is handled automatically.
+Set `requires_auth = True` on agents that call third-party services. The Mesh creates an `AuthenticationManager` backed by Nexus and injects it as `self._auth_manager` after `setup()` completes. The full OAuth flow (browser consent, token refresh) is handled automatically.
 
 ```python
 class TechnicalAgent(CustomAgent):
@@ -264,13 +264,13 @@ class TechnicalAgent(CustomAgent):
         return {"status": "success", "output": result}
 ```
 
-`_auth_manager` is `None` when `NEXUS_GATEWAY_URL` is not set. Always check `if self._auth_manager:` before using it — this is the graceful degradation path for environments without Nexus configured.
+`_auth_manager` is `None` when `NEXUS_GATEWAY_URL` is not set. Always check `if self._auth_manager:` before using it: this is the graceful degradation path for environments without Nexus configured.
 
 ---
 
 ## Workflow Compatibility
 
-`CustomAgent` can participate in `mesh.workflow()` calls, not just P2P message loops. The `execute_task()` method is already implemented — it creates a synthetic `IncomingMessage` from the workflow step dict and delegates to `on_peer_request()`. You get workflow participation for free by implementing `on_peer_request()`.
+`CustomAgent` can participate in `mesh.workflow()` calls, not just P2P message loops. The `execute_task()` method is already implemented: it creates a synthetic `IncomingMessage` from the workflow step dict and delegates to `on_peer_request()`. You get workflow participation for free by implementing `on_peer_request()`.
 
 ```python
 results = await mesh.workflow("support-pipeline", [
@@ -410,7 +410,7 @@ class MCPAgent(CustomAgent):
 
 ## Production Examples
 
-The [Support Swarm example](../examples/support-swarm.md) shows four `CustomAgent` instances running in a single process with P2P messaging. A `GatewayAgent` reads incoming queries and routes them via mailbox to specialist agents — `TechnicalAgent` (with `requires_auth = True` for GitHub), `BillingAgent`, and `EscalationAgent`.
+The [Support Swarm example](../examples/support-swarm.md) shows four `CustomAgent` instances running in a single process with P2P messaging. A `GatewayAgent` reads incoming queries and routes them via mailbox to specialist agents: `TechnicalAgent` (with `requires_auth = True` for GitHub), `BillingAgent`, and `EscalationAgent`.
 
 ```bash
 docker compose -f docker-compose.infra.yml up -d
@@ -424,7 +424,7 @@ The [Content Pipeline example](../examples/content-pipeline.md) shows a `CustomA
 
 ## Scheduled Tasks
 
-JarvisCore does not include a built-in scheduler or cron primitive. Recurring tasks are implemented with `CustomAgent` and `asyncio` — the `run_forever()` loop is async, so you can add timed work directly inside the agent:
+JarvisCore does not include a built-in scheduler or cron primitive. Recurring tasks are implemented with `CustomAgent` and `asyncio`: the `run_forever()` loop is async, so you can add timed work directly inside the agent:
 
 ```python
 import asyncio
@@ -487,4 +487,4 @@ response = await self._peer_client.send("operator", {
 })
 ```
 
-JarvisCore provides the peer messaging infrastructure. You wire the human-facing interface — Slack, web dashboard, mobile app, or CLI.
+JarvisCore provides the peer messaging infrastructure. You wire the human-facing interface: Slack, web dashboard, mobile app, or CLI.

--- a/jarviscore/docs/guides/fastapi.md
+++ b/jarviscore/docs/guides/fastapi.md
@@ -4,7 +4,7 @@ icon: material/api
 
 # FastAPI Integration
 
-JarvisCore integrates with FastAPI through `JarvisLifespan` — a lifespan context manager that starts the Mesh on app startup, runs agent loops as background tasks, and shuts everything down cleanly when the server stops.
+JarvisCore integrates with FastAPI through `JarvisLifespan`: a lifespan context manager that starts the Mesh on app startup, runs agent loops as background tasks, and shuts everything down cleanly when the server stops.
 
 The integration reduces ~100 lines of boilerplate to 3.
 
@@ -151,7 +151,7 @@ class AnalystAgent(CustomAgent):
         return {"analysis": analysis, "confidence": 0.9}
 
     async def run(self, task: str = "", context: dict = None) -> dict:
-        """Receive loop — keeps the agent alive to handle peer messages."""
+        """Receive loop: keeps the agent alive to handle peer messages."""
         while not self.shutdown_requested:
             message = await self.peers.receive(timeout=5)
             if not message:
@@ -190,10 +190,10 @@ asyncio.run(main())
 ```
 
 ```bash
-# Terminal 1 — start the FastAPI server with embedded agents
+# Terminal 1: start the FastAPI server with embedded agents
 uvicorn app:app --host 0.0.0.0 --port 8000
 
-# Terminal 2 — join the mesh from a separate process
+# Terminal 2: join the mesh from a separate process
 python standalone_scout.py
 ```
 

--- a/jarviscore/docs/guides/hitl.md
+++ b/jarviscore/docs/guides/hitl.md
@@ -4,7 +4,7 @@ icon: material/account-supervisor
 
 # Human-in-the-Loop (HITL) Escalation
 
-JarvisCore agents are designed to operate autonomously. The Human-in-the-Loop (HITL) system exists for the narrow set of situations where a human decision is genuinely required — not for quality checks or uncertainty the agent should resolve itself.
+JarvisCore agents are designed to operate autonomously. The Human-in-the-Loop (HITL) system exists for the narrow set of situations where a human decision is genuinely required: not for quality checks or uncertainty the agent should resolve itself.
 
 This guide covers when to escalate, the complete `HITLQueue` API, how resolutions are delivered back to the agent, and how to wire up a review dashboard.
 
@@ -75,7 +75,7 @@ item_id = self.hitl.request(
 
 | Parameter | Type | Required | Description |
 |---|---|---|---|
-| `title` | `str` | Yes | Headline shown in the review list. Never truncated — keep it descriptive. |
+| `title` | `str` | Yes | Headline shown in the review list. Never truncated: keep it descriptive. |
 | `content` | `str` | Yes | Full details for the reviewer. Markdown is supported. Truncated to 2,000 characters. |
 | `urgency` | `str` | No | One of `"low"`, `"normal"`, `"high"`, `"critical"`. Default: `"normal"`. |
 | `category` | `str` | Yes | One of `"auth_required"`, `"data_required"`, `"critical_action"`. Any other value raises `ValueError`. |
@@ -170,7 +170,7 @@ class CampaignSenderAgent(CustomAgent):
         context = msg.data.get("context", {})
         campaign = await self.prepare_campaign(msg.data.get("task", ""))
 
-        # 1. Escalate — declare the irreversible action
+        # 1. Escalate: declare the irreversible action
         item_id = self.hitl.request(
             title=f"Approve email campaign: {campaign['name']}",
             content=(
@@ -255,6 +255,6 @@ The agent's `wait()` loop detects the status change on its next poll cycle.
 | `HITL_ENABLED` | `false` | Enable automatic Kernel escalation when confidence is below threshold |
 | `HITL_MAX_CONFIDENCE` | `0.8` | Confidence threshold below which the Kernel escalates to HITL |
 
-When `HITL_ENABLED=true`, the Kernel escalates automatically. When `HITL_ENABLED=false` (the default), HITL is still available to agents via `self.hitl.request()` — only the automatic Kernel escalation is disabled.
+When `HITL_ENABLED=true`, the Kernel escalates automatically. When `HITL_ENABLED=false` (the default), HITL is still available to agents via `self.hitl.request()`: only the automatic Kernel escalation is disabled.
 
-For testing HITL flows in unit tests without a running agent, see [Testing Agents — HITL flows](testing.md#testing-hitl-flows).
+For testing HITL flows in unit tests without a running agent, see [Testing Agents: HITL flows](testing.md#testing-hitl-flows).

--- a/jarviscore/docs/guides/index.md
+++ b/jarviscore/docs/guides/index.md
@@ -4,19 +4,19 @@ icon: material/book-open-page-variant
 
 # Guides
 
-Step-by-step implementation guides for building with JarvisCore — from your first AutoAgent to production deployments.
+Step-by-step implementation guides, from your first agent to production deployment.
 
 <div class="grid cards" markdown>
 
 -   :material-robot: **AutoAgent**
 
-    The fastest path to a working agent — just define role, capabilities, and system_prompt.
+    The framework brings the brain. Describe the task; the agent plans, generates code in a sandbox, and self-repairs. Use when you can describe the work but not code it.
 
     [Read more →](autoagent.md)
 
 -   :material-code-braces: **CustomAgent**
 
-    Full control over agent lifecycle, message handling, and tool execution.
+    You bring the brain. Plain Python in `execute_task`, deterministic control, same mesh. Use when you can code the logic.
 
     [Read more →](customagent.md)
 

--- a/jarviscore/docs/guides/integrations.md
+++ b/jarviscore/docs/guides/integrations.md
@@ -4,7 +4,7 @@ icon: material/connection
 
 # System Bundles & Integrations
 
-JarvisCore ships with **46 built-in system bundles** covering 237+ discrete, versioned atoms. Each atom is a self-contained, ready-to-use tool your agents can call directly — no wrapper code required. Bundles span communication, productivity, CRM, ERP, finance, HR, developer tools, content, advertising, storage, healthcare, and more.
+JarvisCore ships with **46 built-in system bundles** covering 237+ discrete, versioned atoms. Each atom is a self-contained, ready-to-use tool your agents can call directly: no wrapper code required. Bundles span communication, productivity, CRM, ERP, finance, HR, developer tools, content, advertising, storage, healthcare, and more.
 
 ---
 
@@ -20,14 +20,14 @@ When a task arrives, before generating any code the Kernel searches the registry
 Task: "Send a Slack notification to #ops"
   → Kernel Option A: semantic_search("Send a Slack notification")
   → Finds: slack_send_message (stage=verified, score=4.2)
-  → Injects code directly into sandbox — skips code generation entirely
+  → Injects code directly into sandbox, skips code generation entirely
 ```
 
 If the search finds a `verified` or `golden` match above the confidence threshold, the Kernel reuses it. If not, `CoderSubAgent` generates fresh code.
 
 ### What devs actually write
 
-An agent that calls Slack, Jira, and Notion needs nothing special — just a clear `system_prompt`:
+An agent that calls Slack, Jira, and Notion needs nothing special: just a clear `system_prompt`:
 
 ```python
 from jarviscore import AutoAgent
@@ -40,7 +40,7 @@ class OpsAgent(AutoAgent):
     """
 ```
 
-The Kernel auto-picks the right atom when the task matches. The `capabilities` field on an agent is **descriptive metadata** — it does not control which atoms are loaded.
+The Kernel auto-picks the right atom when the task matches. The `capabilities` field on an agent is **descriptive metadata**: it does not control which atoms are loaded.
 
 ### Seeding the registry
 
@@ -377,7 +377,7 @@ CRM contacts, deals, and pipeline management.
 ---
 
 #### Salesforce
-Enterprise CRM — leads, opportunities, contacts, and SOQL.
+Enterprise CRM: leads, opportunities, contacts, and SOQL.
 
 | Atom | Description |
 |---|---|
@@ -451,7 +451,7 @@ ERP records, customers, and financial data.
 ---
 
 #### Odoo
-Open-source ERP — leads, partners, and invoices.
+Open-source ERP: leads, partners, and invoices.
 
 | Atom | Description |
 |---|---|
@@ -547,7 +547,7 @@ Invoicing, clients, and expense tracking for SMBs.
 ---
 
 #### Zoho Books
-Cloud accounting — invoices, expenses, and contacts.
+Cloud accounting: invoices, expenses, and contacts.
 
 | Atom | Description |
 |---|---|

--- a/jarviscore/docs/guides/internet-search.md
+++ b/jarviscore/docs/guides/internet-search.md
@@ -6,13 +6,13 @@ icon: material/earth
 
 JarvisCore includes a built-in `InternetSearch` module used primarily by `ResearcherSubAgent`. It runs multiple search providers in parallel, deduplicates and ranks results by relevance and source trust, then returns a unified result list your agents can reason over.
 
-No configuration is required to get started — if you have `GEMINI_API_KEY` set, search is active immediately.
+No configuration is required to get started: if you have `GEMINI_API_KEY` set, search is active immediately.
 
 ---
 
 ## How it works
 
-When an agent triggers a search, the module fans out to all configured providers simultaneously, collects results, deduplicates by URL, and ranks them by a weighted trust score. All providers have circuit breakers — a failing provider is automatically bypassed after 8 consecutive failures and retried after 5 minutes.
+When an agent triggers a search, the module fans out to all configured providers simultaneously, collects results, deduplicates by URL, and ranks them by a weighted trust score. All providers have circuit breakers: a failing provider is automatically bypassed after 8 consecutive failures and retried after 5 minutes.
 
 ```
 Agent → InternetSearch.search(query)
@@ -37,7 +37,7 @@ Agent → InternetSearch.search(query)
 
 Uses the Gemini API with Google Search grounding enabled. The model queries Google Search in real time and returns structured web results alongside a synthesised summary grounded in those sources.
 
-**Required:** one of the following —
+**Required:** one of the following:
 
 | Variable | Description |
 |---|---|
@@ -63,7 +63,7 @@ Serper calls the Google Search API via [serper.dev](https://serper.dev). It adds
 
 | Variable | Default | Description |
 |---|---|---|
-| `SERPER_API_KEY` | — | API key from [serper.dev](https://serper.dev). Provider is skipped if unset. |
+| `SERPER_API_KEY` |: | API key from [serper.dev](https://serper.dev). Provider is skipped if unset. |
 
 Serper results score slightly lower than Google Grounded Search in the ranking (1.2 vs 1.4) because they don't carry grounding metadata or synthesised summaries.
 
@@ -71,7 +71,7 @@ Serper results score slightly lower than Google Grounded Search in the ranking (
 
 ### SearXNG <span class="jc-badge jc-badge-optional">Optional</span> <span class="jc-badge jc-badge-free">Self-hosted</span>
 
-SearXNG is a self-hosted, privacy-respecting metasearch engine that aggregates results from Google, Bing, and dozens of other engines — without API keys. It is always attempted unless you point `SEARXNG_INSTANCE_URL` at a non-responsive host, in which case the circuit breaker takes it offline.
+SearXNG is a self-hosted, privacy-respecting metasearch engine that aggregates results from Google, Bing, and dozens of other engines: without API keys. It is always attempted unless you point `SEARXNG_INSTANCE_URL` at a non-responsive host, in which case the circuit breaker takes it offline.
 
 | Variable | Default | Description |
 |---|---|---|
@@ -89,7 +89,7 @@ docker run -d \
 > [!IMPORTANT]
 > SearXNG's JSON format must be enabled. Add `- json` under `search.formats` in `settings.yml`, or pass the env var shown above.
 
-If SearXNG is not running, the connection fails silently and the circuit breaker skips it — no error reaches your agent.
+If SearXNG is not running, the connection fails silently and the circuit breaker skips it: no error reaches your agent.
 
 ---
 
@@ -97,8 +97,8 @@ If SearXNG is not running, the connection fails silently and the circuit breaker
 
 Both are always active. They use free public APIs with no authentication.
 
-- **arXiv** — searches academic preprints via `export.arxiv.org`. Best for research-heavy queries.
-- **Crossref** — searches published academic papers via `api.crossref.org`. Returns DOI links.
+- **arXiv**: searches academic preprints via `export.arxiv.org`. Best for research-heavy queries.
+- **Crossref**: searches published academic papers via `api.crossref.org`. Returns DOI links.
 
 These providers score lower by default (0.9 and 0.8) because they are domain-specific. Use `exclude_providers` to skip them for non-academic tasks.
 
@@ -106,14 +106,14 @@ These providers score lower by default (0.9 and 0.8) because they are domain-spe
 
 ### Wikipedia <span class="jc-badge jc-badge-free">No config needed</span>
 
-Always active. Uses the Wikipedia search API. Scores lowest (0.6) — useful as a broad fallback but not a primary signal for real-time queries.
+Always active. Uses the Wikipedia search API. Scores lowest (0.6): useful as a broad fallback but not a primary signal for real-time queries.
 
 ---
 
 ## Configuration summary
 
 ```bash
-# .env — minimum for search to work (also needed for agents)
+# .env: minimum for search to work (also needed for agents)
 GEMINI_API_KEY=AIza...
 
 # Optional: add Serper for dual Google-source coverage
@@ -144,13 +144,13 @@ results = await search.search(
 )
 ```
 
-This prevents wasted network calls — the provider is skipped entirely, not just filtered from results.
+This prevents wasted network calls: the provider is skipped entirely, not just filtered from results.
 
 ---
 
 ## Browser escalation (SPAs and paywalled content)
 
-When HTTP extraction returns empty content — common for single-page applications and some paywalled sites — the module can escalate to a headless browser. This is an opt-in extra:
+When HTTP extraction returns empty content (common for single-page applications and some paywalled sites) the module can escalate to a headless browser. This is an opt-in extra:
 
 ```bash
 pip install "jarviscore[browser]"
@@ -159,7 +159,7 @@ pip install "jarviscore[browser]"
 | Variable | Default | Description |
 |---|---|---|
 | `BROWSER_HEADLESS` | `true` | Run browser in headless mode |
-| `BROWSER_CONTROL_URL` | — | CDP endpoint for remote browser (e.g. Browserless, Playwright server) |
+| `BROWSER_CONTROL_URL` |: | CDP endpoint for remote browser (e.g. Browserless, Playwright server) |
 
 ---
 
@@ -180,7 +180,7 @@ Once a provider's breaker opens, it is skipped entirely until the recovery windo
 
 | Scenario | Recommendation |
 |---|---|
-| **Getting started** | Just `GEMINI_API_KEY` — Google Grounded Search alone is sufficient |
+| **Getting started** | Just `GEMINI_API_KEY`: Google Grounded Search alone is sufficient |
 | **High-volume research agents** | Add `SERPER_API_KEY` to reduce Gemini quota usage |
 | **Privacy-sensitive deployments** | Add self-hosted SearXNG, exclude `google_grounded` and `serper` |
 | **Academic / scientific research** | Keep arXiv and Crossref enabled (they are by default) |

--- a/jarviscore/docs/guides/knowledge-base.md
+++ b/jarviscore/docs/guides/knowledge-base.md
@@ -34,15 +34,15 @@ The agent doesn't change. You don't modify system prompts. The RAG layer is plum
 
 ## Installation
 
-RAG dependencies are optional — install the `rag` extra:
+RAG dependencies are optional: install the `rag` extra:
 
 ```bash
 pip install "jarviscore[rag]"
 ```
 
 This installs:
-- `sentence-transformers` — local embedding generation (no API key required)
-- `faiss-cpu` — FAISS vector store
+- `sentence-transformers`: local embedding generation (no API key required)
+- `faiss-cpu`: FAISS vector store
 
 ---
 
@@ -72,14 +72,14 @@ print(result)
 # {"status": "success", "documents": 2, "chunks": 47}
 ```
 
-`ingest_documents()` chunks each document into overlapping segments, embeds them, and adds them to the FAISS index. The index is persisted to disk immediately — you only need to ingest once.
+`ingest_documents()` chunks each document into overlapping segments, embeds them, and adds them to the FAISS index. The index is persisted to disk immediately: you only need to ingest once.
 
 ### Document format
 
 | Key | Required | Description |
 |---|---|---|
 | `content` | Yes | The document text (markdown, plain text, extracted PDF, etc.) |
-| `source` | Yes | A stable identifier — used for citation and deduplication |
+| `source` | Yes | A stable identifier: used for citation and deduplication |
 | `metadata` | No | Arbitrary dict stored alongside each chunk (author, date, topic, etc.) |
 
 ---
@@ -161,7 +161,7 @@ For large wikis, split by page and ingest each page as a separate document. The 
 
 ## Keeping the Index Fresh
 
-The FAISS index accumulates documents — there is no automatic deduplication by `source`. If you re-ingest the same source, you get duplicate chunks. Manage this by deleting and rebuilding the index when your source documents change:
+The FAISS index accumulates documents: there is no automatic deduplication by `source`. If you re-ingest the same source, you get duplicate chunks. Manage this by deleting and rebuilding the index when your source documents change:
 
 ```bash
 rm ~/.jarviscore/rag/faiss.index
@@ -183,7 +183,7 @@ print(rag.stats())
 ## Configuration
 
 ```bash title=".env"
-# Embedding model (default: all-MiniLM-L6-v2 — fast, 384-dim)
+# Embedding model (default: all-MiniLM-L6-v2: fast, 384-dim)
 RAG_EMBED_MODEL=all-MiniLM-L6-v2
 
 # Use a larger model for higher recall quality (slower)
@@ -205,7 +205,7 @@ RAG_CHUNK_OVERLAP=200
 | Variable | Default | Description |
 |---|---|---|
 | `RAG_EMBED_MODEL` | `all-MiniLM-L6-v2` | Sentence-transformers model name or HuggingFace ID |
-| `RAG_EMBED_MODEL_PATH` | — | Path to a local model directory |
+| `RAG_EMBED_MODEL_PATH` |: | Path to a local model directory |
 | `RAG_INDEX_PATH` | `~/.jarviscore/rag/faiss.index` | FAISS index file location |
 | `RAG_META_PATH` | `~/.jarviscore/rag/faiss_meta.json` | Chunk metadata sidecar |
 | `RAG_TOP_K` | `5` | Number of chunks returned per query |
@@ -216,6 +216,6 @@ RAG_CHUNK_OVERLAP=200
 
 ## Further Reading
 
-- [Internet Search](internet-search.md) — Web search providers that ResearcherSubAgent runs alongside RAG
-- [AutoAgent Guide](autoagent.md) — How ResearcherSubAgent fits into the OODA loop
-- [Integrations](integrations.md) — Atoms and system bundles that extend what agents can do
+- [Internet Search](internet-search.md): Web search providers that ResearcherSubAgent runs alongside RAG
+- [AutoAgent Guide](autoagent.md): How ResearcherSubAgent fits into the OODA loop
+- [Integrations](integrations.md): Atoms and system bundles that extend what agents can do

--- a/jarviscore/docs/guides/migration.md
+++ b/jarviscore/docs/guides/migration.md
@@ -119,7 +119,7 @@ asyncio.run(main())
 ```
 
 **Key differences:**
-- `Task(context=[...])` → `"depends_on": [...]` in the step dict. Prior outputs are injected automatically — no manual context passing needed.
+- `Task(context=[...])` → `"depends_on": [...]` in the step dict. Prior outputs are injected automatically: no manual context passing needed.
 - `Agent(role=..., goal=..., backstory=...)` → one `system_prompt` string that covers all three. Be explicit about `result` shape.
 - `Crew(process=Process.sequential)` → implicit via `depends_on`. Steps without dependencies run in parallel automatically.
 
@@ -142,7 +142,7 @@ researcher = Agent(
 
 **JarvisCore:**
 
-Internet search is built in — `ResearcherSubAgent` runs multi-provider search automatically when the agent routes to it. No `tools=[]` argument needed.
+Internet search is built in: `ResearcherSubAgent` runs multi-provider search automatically when the agent routes to it. No `tools=[]` argument needed.
 
 For custom tools, write an atom function and register it:
 
@@ -182,9 +182,9 @@ Some CrewAI patterns map to a different primitive in JarvisCore rather than a di
 
 | CrewAI pattern | How JarvisCore does it |
 |---|---|
-| `Process.hierarchical` — manager agent auto-routes tasks | An `AutoAgent` orchestrator sends peer messages with `await self._peer_client.send(...)`. You control routing logic explicitly in Python — no hidden manager. |
-| `Agent(allow_delegation=True)` | All `AutoAgent` instances can delegate to peers via the mesh peer tool — delegation is on by default, not opt-in. |
-| Built-in `FileReadTool`, `DirectoryReadTool` | Write an atom function — 5 lines of Python, registered once, available to all agents. No wrapper class needed. |
+| `Process.hierarchical` (manager agent auto-routes tasks | An `AutoAgent` orchestrator sends peer messages with `await self._peer_client.send(...)`. You control routing logic explicitly in Python) no hidden manager. |
+| `Agent(allow_delegation=True)` | All `AutoAgent` instances can delegate to peers via the mesh peer tool: delegation is on by default, not opt-in. |
+| Built-in `FileReadTool`, `DirectoryReadTool` | Write an atom function: 5 lines of Python, registered once, available to all agents. No wrapper class needed. |
 | `Crew(planning=True)` | Set `goal_oriented = True` on the `AutoAgent`. The Kernel runs a planning phase before execution. |
 
 ---
@@ -206,7 +206,7 @@ Some CrewAI patterns map to a different primitive in JarvisCore rather than a di
 | `app = graph.compile()` | `await mesh.start()` | Mesh compiles and starts all agents |
 | `app.invoke(input)` | `await mesh.workflow(id, steps)` | Returns list of step results |
 | `app.stream(input)` | Chat SSE stream via `create_chat_router` | `GET /chat/stream/{workflow_id}` |
-| Checkpointer | Automatic — Redis `step_output:wf:step` | Crash-safe by default when Redis is set |
+| Checkpointer | Automatic: Redis `step_output:wf:step` | Crash-safe by default when Redis is set |
 | `ToolNode` | `SystemBundle` + `Registry` | Atoms are plain functions in a bundle class |
 | `HumanNode` | `self.hitl.request()` in agent code | HITL escalation with async wait |
 
@@ -297,7 +297,7 @@ from jarviscore.context.truth import TruthContext, TruthFact, Evidence
 # Initialise shared truth store for a workflow
 truth = TruthContext()
 
-# Agent A writes a fact — assign directly to truth.facts
+# Agent A writes a fact: assign directly to truth.facts
 truth.facts["competitors"] = TruthFact(
     value=["CompanyX", "CompanyY"],
     confidence=0.9,
@@ -342,7 +342,7 @@ class EvaluatorAgent(CustomAgent):
     async def on_peer_request(self, msg) -> dict:
         result = await self._evaluate(msg.data["content"])
         if result["confidence"] < 0.7:
-            # Escalate to HITL — human reviews and responds
+            # Escalate to HITL: human reviews and responds
             await self.hitl.request(
                 question="Please review this output",
                 context=result,
@@ -361,15 +361,15 @@ Conditional routing is expressed as agent logic in `on_peer_request()`. This giv
 
 ### Architectural Differences from LangGraph
 
-LangGraph is a graph execution engine — JarvisCore is an agent runtime. The mental model shifts from "nodes and edges" to "agents and steps". Some patterns have direct equivalents under different names; a few reflect a genuinely different philosophy:
+LangGraph is a graph execution engine: JarvisCore is an agent runtime. The mental model shifts from "nodes and edges" to "agents and steps". Some patterns have direct equivalents under different names; a few reflect a genuinely different philosophy:
 
 | LangGraph pattern | How JarvisCore does it |
 |---|---|
 | Typed `State` schema enforced across all nodes | `TruthContext` provides typed, evidence-backed facts shared across agents. Per-agent schema enforcement sits in the system prompt and result contract. |
-| Built-in graph visualisation | No built-in DAG visualiser. The observability dashboard shows live execution traces, OODA loop thoughts, tool calls, and token usage — richer than a static graph. |
+| Built-in graph visualisation | No built-in DAG visualiser. The observability dashboard shows live execution traces, OODA loop thoughts, tool calls, and token usage: richer than a static graph. |
 | `interrupt_before` / `interrupt_after` hooks | `CustomAgent.on_peer_request()` with pre/post logic, or HITL escalation via `self.hitl.request()`. |
-| Studio (LangSmith graph UI) | JarvisCore Observability — trace events to Redis + JSONL, Prometheus metrics, and the `GET /chat/stream` SSE feed for live agent reasoning. |
-| `Pregel` parallel execution model | Steps without shared `depends_on` dependencies run concurrently automatically — no explicit parallel primitives needed. |
+| Studio (LangSmith graph UI) | JarvisCore Observability: trace events to Redis + JSONL, Prometheus metrics, and the `GET /chat/stream` SSE feed for live agent reasoning. |
+| `Pregel` parallel execution model | Steps without shared `depends_on` dependencies run concurrently automatically: no explicit parallel primitives needed. |
 
 ---
 
@@ -378,18 +378,18 @@ LangGraph is a graph execution engine — JarvisCore is an agent runtime. The me
 - [ ] Replace `Agent(role=..., goal=..., backstory=...)` with an `AutoAgent` subclass with `system_prompt`
 - [ ] Replace `Task(description=..., expected_output=...)` with a step dict and explicit `result` variable in the system prompt
 - [ ] Replace `context=[prior_task]` / `add_edge()` with `"depends_on": ["step_id"]`
-- [ ] Remove manual state passing — prior step outputs are injected automatically via `depends_on`
+- [ ] Remove manual state passing: prior step outputs are injected automatically via `depends_on`
 - [ ] Replace `Tool` classes with atom functions in a `SystemBundle`
-- [ ] Set `REDIS_URL` in your environment — enables crash-safe execution, mailboxes, and memory
-- [ ] Remove `LLM(model=...)` from agent constructors — configure with `TASK_MODEL_STANDARD=` in `.env`
+- [ ] Set `REDIS_URL` in your environment: enables crash-safe execution, mailboxes, and memory
+- [ ] Remove `LLM(model=...)` from agent constructors: configure with `TASK_MODEL_STANDARD=` in `.env`
 - [ ] Add `GEMINI_API_KEY` (or `ANTHROPIC_API_KEY` / `OPENAI_API_KEY`) to `.env`
 
 ---
 
 ## Further Reading
 
-- [AutoAgent Guide](autoagent.md) — Full AutoAgent API
-- [CustomAgent Guide](customagent.md) — For deterministic, scripted agents
-- [Workflow DAGs](workflows.md) — `depends_on`, parallelism, crash recovery
-- [System Prompts](system-prompts.md) — How to write effective system prompts
-- [Getting Started](../getting-started.md) — Install and run your first agent in 5 minutes
+- [AutoAgent Guide](autoagent.md): Full AutoAgent API
+- [CustomAgent Guide](customagent.md): For deterministic, scripted agents
+- [Workflow DAGs](workflows.md): `depends_on`, parallelism, crash recovery
+- [System Prompts](system-prompts.md): How to write effective system prompts
+- [Getting Started](../getting-started.md): Install and run your first agent in 5 minutes

--- a/jarviscore/docs/guides/nexus.md
+++ b/jarviscore/docs/guides/nexus.md
@@ -14,7 +14,7 @@ Nexus is JarvisCore's credential management system and an [open-source framework
 ## How It Works
 
 1. You register a provider's credentials once using `jarviscore nexus register`.
-2. Credentials are written to `~/.jarviscore/nexus.enc` — an AES-256-GCM encrypted file keyed to your machine.
+2. Credentials are written to `~/.jarviscore/nexus.enc`: an AES-256-GCM encrypted file keyed to your machine.
 3. When an agent calls a registered provider, the `NexusLocalStore` retrieves and decrypts the credentials at call time and passes them to the provider's atom function.
 4. Agent code never sees the raw credentials.
 
@@ -62,7 +62,7 @@ stripe     api_key     sk_l****     2026-05-01
 
 Credentials are stored in `~/.jarviscore/nexus.enc`:
 
-- **Encryption:** AES-256-GCM (authenticated encryption — integrity + confidentiality)
+- **Encryption:** AES-256-GCM (authenticated encryption: integrity + confidentiality)
 - **Key derivation:** PBKDF2-HMAC-SHA256, 260,000 iterations (OWASP 2024 recommendation)
 - **Salt:** Per-machine, generated once and stored at `~/.jarviscore/.salt`. Never changes.
 - **Secret input:** `NEXUS_SECRET` env var if set; falls back to machine UUID (MAC address).
@@ -80,7 +80,7 @@ Without `NEXUS_SECRET`, the key is derived from the machine's hardware UUID. Cre
 
 ## Using Nexus in Agent Code
 
-The `NexusLocalStore` is accessed via `jarviscore.nexus.store.get_store()`. In normal usage you do not call it directly — provider atom functions receive `auth_info` automatically. For custom integrations, you can retrieve credentials as follows:
+The `NexusLocalStore` is accessed via `jarviscore.nexus.store.get_store()`. In normal usage you do not call it directly: provider atom functions receive `auth_info` automatically. For custom integrations, you can retrieve credentials as follows:
 
 ```python
 from jarviscore.nexus.store import get_store
@@ -118,12 +118,12 @@ auth_info = store.build_auth_info("github")
 The local encrypted store handles credentials for single-developer and small team use. For multi-user deployments where agents act on behalf of individual users (each with their own OAuth tokens), the **Nexus Gateway** provides full OAuth flow management.
 
 > [!NOTE]
-> **The two modes are not mutually exclusive — the CLI chooses automatically.**
-> When you run `jarviscore nexus register`, the CLI checks whether `NEXUS_GATEWAY_URL` is set and reachable. If it is, credentials are registered with the gateway. If it is not set, or if the gateway is unreachable, credentials are written to the local store (`~/.jarviscore/nexus.enc`) and a warning is printed. You can start without a gateway and migrate to one later — the local store keeps working regardless.
+> **The two modes are not mutually exclusive: the CLI chooses automatically.**
+> When you run `jarviscore nexus register`, the CLI checks whether `NEXUS_GATEWAY_URL` is set and reachable. If it is, credentials are registered with the gateway. If it is not set, or if the gateway is unreachable, credentials are written to the local store (`~/.jarviscore/nexus.enc`) and a warning is printed. You can start without a gateway and migrate to one later: the local store keeps working regardless.
 
 
 
-The gateway is managed entirely via the `jarviscore` CLI — no separate install required. It runs as a Docker-composed stack. Set it up once per environment:
+The gateway is managed entirely via the `jarviscore` CLI: no separate install required. It runs as a Docker-composed stack. Set it up once per environment:
 
 ```bash
 jarviscore nexus init
@@ -151,7 +151,7 @@ jarviscore nexus status
 
 ## Gateway API Contract
 
-When `NEXUS_GATEWAY_URL` is set, the CLI registers providers by calling the Gateway directly. You should not need to call this manually — `jarviscore nexus register` handles it — but the contract is documented here for completeness.
+When `NEXUS_GATEWAY_URL` is set, the CLI registers providers by calling the Gateway directly. You should not need to call this manually (`jarviscore nexus register` handles it) but the contract is documented here for completeness.
 
 **Register a provider:** `POST /v1/providers`
 
@@ -198,7 +198,7 @@ The payload must wrap all fields in a `profile` object and use `name` (not `prov
 **Check gateway health:** `GET /health`
 
 > [!NOTE]
-> All examples assume `http://localhost:8090` — the default local Docker stack started by `jarviscore nexus init`. Substitute your own Gateway URL in production. **Do not point developers at a third-party hosted gateway** — each team runs their own Nexus stack.
+> All examples assume `http://localhost:8090` (the default local Docker stack started by `jarviscore nexus init`. Substitute your own Gateway URL in production. **Do not point developers at a third-party hosted gateway**) each team runs their own Nexus stack.
 
 ---
 

--- a/jarviscore/docs/guides/observability.md
+++ b/jarviscore/docs/guides/observability.md
@@ -4,14 +4,14 @@ icon: material/chart-line
 
 # Observability & Telemetry
 
-JarvisCore ships with a built-in, two-layer observability system. Every agent turn, tool call, LLM request, mailbox message, and HITL event is captured automatically — no instrumentation required in your agent code.
+JarvisCore ships with a built-in, two-layer observability system. Every agent turn, tool call, LLM request, mailbox message, and HITL event is captured automatically: no instrumentation required in your agent code.
 
 The two layers serve different purposes:
 
 | Layer | What it does | Where data goes |
 |---|---|---|
-| **Structured Tracing** (`TraceManager`) | Records *what happened* — the full execution narrative | Redis List (persistent), Redis PubSub (real-time), JSONL (compliance fallback) |
-| **Operational Metrics** (`metrics.py`) | Records *how it performed* — counters, histograms, and gauges | Prometheus (scrape endpoint on port 9090) |
+| **Structured Tracing** (`TraceManager`) | Records *what happened*: the full execution narrative | Redis List (persistent), Redis PubSub (real-time), JSONL (compliance fallback) |
+| **Operational Metrics** (`metrics.py`) | Records *how it performed*: counters, histograms, and gauges | Prometheus (scrape endpoint on port 9090) |
 
 Both layers are **non-blocking by design**. If Redis is unavailable, tracing falls back to JSONL. If `prometheus-client` is not installed, metrics become silent no-ops. Neither failure will crash your agent.
 
@@ -29,7 +29,7 @@ from jarviscore.telemetry import TraceManager
 tracer = TraceManager(
     workflow_id="wf-abc123",
     step_id="step-001",
-    redis_store=redis_store,   # optional — omit to use JSONL-only mode
+    redis_store=redis_store,   # optional: omit to use JSONL-only mode
     trace_dir="traces",        # directory for JSONL fallback files
 )
 ```
@@ -54,7 +54,7 @@ Subscribe from a dashboard, alerting system, or log aggregator to receive events
 ```
 Path: {trace_dir}/{workflow_id}_{step_id}.jsonl
 ```
-Written even when Redis is unavailable. Each line is a self-contained JSON event — parseable with any standard tooling.
+Written even when Redis is unavailable. Each line is a self-contained JSON event: parseable with any standard tooling.
 
 ### Trace Event Shape
 
@@ -134,12 +134,12 @@ All event types are defined in `TraceEventType` (a typed `str` enum). The full s
 The kernel handles all standard events automatically. If you are building a custom subagent or tool, you can emit custom events directly:
 
 ```python
-# Convenience methods — the recommended approach
+# Convenience methods: the recommended approach
 tracer.log_tool_start("my_custom_tool", params={"key": "value"})
 tracer.log_tool_result("my_custom_tool", result="Done")
 tracer.log_thinking("Evaluating whether the output meets the acceptance criteria")
 
-# Raw event — for custom types not covered by convenience methods
+# Raw event: for custom types not covered by convenience methods
 tracer.log_event("my_custom_event", data={"detail": "something happened"})
 ```
 
@@ -177,7 +177,7 @@ cat traces/*.jsonl | jq 'select(.type == "llm_response") | .data.latency_ms' | a
 
 ### Installation
 
-Prometheus metrics require the `prometheus-client` package. Without it, all metric calls are silent no-ops — your agent runs normally but no metrics are collected.
+Prometheus metrics require the `prometheus-client` package. Without it, all metric calls are silent no-ops: your agent runs normally but no metrics are collected.
 
 ```bash
 pip install "jarviscore-framework[prometheus]"
@@ -213,8 +213,8 @@ Metrics are then available at `http://localhost:9090/metrics` for Prometheus to 
 |---|---|---|---|
 | `jarviscore_workflow_steps_total` | Counter | `status` | Steps processed by outcome |
 | `jarviscore_step_execution_duration_seconds` | Histogram | `status` | Step duration in seconds |
-| `jarviscore_active_workflows` | Gauge | — | Currently running workflows |
-| `jarviscore_active_steps` | Gauge | — | Currently executing steps |
+| `jarviscore_active_workflows` | Gauge |: | Currently running workflows |
+| `jarviscore_active_steps` | Gauge |: | Currently executing steps |
 
 #### Event Metrics
 
@@ -298,7 +298,7 @@ Use `prometheus-remote-write` or the Grafana Agent to forward metrics directly w
 
 ### Splunk / ELK
 
-The JSONL trace files are the simplest integration point. Point a Filebeat or Splunk Universal Forwarder at the `traces/` directory — each line is already structured JSON, with `workflow_id`, `step_id`, `timestamp`, and `type` as top-level fields for indexing.
+The JSONL trace files are the simplest integration point. Point a Filebeat or Splunk Universal Forwarder at the `traces/` directory: each line is already structured JSON, with `workflow_id`, `step_id`, `timestamp`, and `type` as top-level fields for indexing.
 
 ---
 
@@ -312,4 +312,4 @@ JarvisCore observability works in three modes:
 | **JSONL-only** | No Redis | Traces written to JSONL files only; no real-time stream |
 | **Local dev** | No Redis, no `prometheus-client` | JSONL traces only; metrics are silent no-ops |
 
-No configuration flag is needed — the system detects what is available at runtime and degrades gracefully.
+No configuration flag is needed: the system detects what is available at runtime and degrades gracefully.

--- a/jarviscore/docs/guides/production.md
+++ b/jarviscore/docs/guides/production.md
@@ -357,7 +357,7 @@ For non-containerised deployments, use a process supervisor to keep agents runni
 ```ini
 # /etc/systemd/system/my-agent.service
 [Unit]
-Description=JarvisCore Agent — my-agent
+Description=JarvisCore Agent (my-agent)
 After=network.target redis.service
 
 [Service]
@@ -384,13 +384,13 @@ JarvisCore's P2P layer uses a SWIM-based gossip protocol for peer discovery and 
 Bind port and bind host are per-process settings. They cannot be set once in a shared `.env` file because every node needs a different port. Set them at process launch:
 
 ```bash
-# Node 1 — the seed node that other nodes join through
+# Node 1: the seed node that other nodes join through
 JARVISCORE_BIND_HOST=0.0.0.0 \
 JARVISCORE_BIND_PORT=7946 \
 JARVISCORE_NODE_NAME=researcher-01 \
 python researcher.py
 
-# Node 2 — joins the cluster through the seed node
+# Node 2: joins the cluster through the seed node
 JARVISCORE_BIND_HOST=0.0.0.0 \
 JARVISCORE_BIND_PORT=7947 \
 JARVISCORE_NODE_NAME=coder-01 \

--- a/jarviscore/docs/guides/system-prompts.md
+++ b/jarviscore/docs/guides/system-prompts.md
@@ -23,7 +23,7 @@ When the Kernel starts an OODA loop turn, it assembles a full context bundle:
 [Athena Context]         ← Semantic memory from prior sessions (if configured)
 ```
 
-The base system prompt sits between the profile block and the runtime context. It is the part you control at the class level. The Kernel prepends the profile block — the system prompt should never repeat what the profile block already defines (role, expertise, SOPs).
+The base system prompt sits between the profile block and the runtime context. It is the part you control at the class level. The Kernel prepends the profile block: the system prompt should never repeat what the profile block already defines (role, expertise, SOPs).
 
 ---
 
@@ -31,9 +31,9 @@ The base system prompt sits between the profile block and the runtime context. I
 
 Three things are required in every AutoAgent system prompt:
 
-1. **What the agent is** — role identity in one sentence
-2. **What `result` must contain** — exact variable name and structure
-3. **What to do when something fails** — error handling instruction
+1. **What the agent is**: role identity in one sentence
+2. **What `result` must contain**: exact variable name and structure
+3. **What to do when something fails**: error handling instruction
 
 ```python
 system_prompt = """
@@ -61,13 +61,13 @@ Missing any of these three creates predictable failure modes: vague identity →
 The Kernel always reads from a Python variable named `result` in the sandbox. It does not infer output from print statements, return values, or side effects. The system prompt must explicitly instruct the agent to assign its output to `result`.
 
 ```python
-# ✅ Correct — result is assigned
+# ✅ Correct: result is assigned
 result = {"summary": "...", "items": [...]}
 
-# ❌ Wrong — the Kernel will not find this
+# ❌ Wrong: the Kernel will not find this
 print(json.dumps({"summary": "..."}))
 
-# ❌ Wrong — function return values are not captured
+# ❌ Wrong: function return values are not captured
 def get_summary():
     return {"summary": "..."}
 ```
@@ -131,7 +131,7 @@ Final output stored in `result` as:
     "recommendation": str
   }
 
-If a research step finds no data, note the gap and continue — do not abort.
+If a research step finds no data, note the gap and continue. Do not abort.
 """
 ```
 
@@ -168,10 +168,10 @@ Setting `default_kernel_role = "communicator"` tells the Kernel and Planner the 
 
 ## Using Agent Profiles for Domain Intelligence
 
-The system prompt is for task-level instructions. Domain intelligence — who the agent is, what it knows, what its standing procedures are — belongs in an `AgentProfile` YAML file:
+The system prompt is for task-level instructions. Domain intelligence (who the agent is, what it knows, what its standing procedures are) belongs in an `AgentProfile` YAML file:
 
 ```yaml title="profiles/researcher.yaml"
-role: "Researcher — Data Intelligence Agent"
+role: "Researcher, Data Intelligence Agent"
 default_kernel_role: researcher
 
 expertise:
@@ -202,7 +202,7 @@ escalates_to:
 JARVISCORE_PROFILES_DIR=/your-app/profiles/agents
 ```
 
-The profile block is prepended automatically. The system prompt only needs task-level instructions — no need to repeat the agent's role or expertise.
+The profile block is prepended automatically. The system prompt only needs task-level instructions: no need to repeat the agent's role or expertise.
 
 ---
 
@@ -210,7 +210,7 @@ The profile block is prepended automatically. The system prompt only needs task-
 
 ### Vague identity
 ```python
-# ❌ Too vague — the Kernel doesn't know which sub-agent to route to
+# ❌ Too vague: the Kernel doesn't know which sub-agent to route to
 system_prompt = "You are a helpful AI assistant."
 
 # ✅ Specific identity tells the Kernel exactly what to do
@@ -219,7 +219,7 @@ system_prompt = "You are a Python code reviewer. Analyse pull request diffs and 
 
 ### Missing `result` assignment
 ```python
-# ❌ Result not stored — step["payload"] will be None
+# ❌ Result not stored: step["payload"] will be None
 system_prompt = "Fetch and summarise the top 5 news stories."
 
 # ✅ Explicit output contract
@@ -231,12 +231,12 @@ Store in `result` as a list of {"title": str, "summary": str, "url": str}.
 
 ### Injecting prior step data manually
 ```python
-# ❌ Never do this — the WorkflowEngine injects prior steps automatically
+# ❌ Never do this: the WorkflowEngine injects prior steps automatically
 system_prompt = """
 You are an analyst. Access previous step data via context.get('fetch', {}).
 """
 
-# ✅ Just declare depends_on — prior step outputs appear automatically
+# ✅ Just declare depends_on: prior step outputs appear automatically
 results = await mesh.workflow("pipeline", [
     {"id": "fetch", "agent": "fetcher", "task": "Fetch data"},
     {"id": "analyse", "agent": "analyst", "task": "Analyse the data", "depends_on": ["fetch"]},
@@ -252,7 +252,7 @@ SOP 2: Cross-reference at least two sources
 ...
 """
 
-# ✅ SOPs belong in the AgentProfile YAML — hot-reloadable, versionable
+# ✅ SOPs belong in the AgentProfile YAML: hot-reloadable, versionable
 ```
 
 ---
@@ -265,9 +265,9 @@ A battle-tested template for production `AutoAgent` deployments:
 system_prompt = """
 You are a [ROLE] specialising in [DOMAIN].
 
-[AVAILABLE TOOLS — list any system bundle methods the agent can call]
+[AVAILABLE TOOLS: list any system bundle methods the agent can call]
 
-[DATA SOURCES — API endpoints, authentication notes]
+[DATA SOURCES: API endpoints, authentication notes]
 
 Your output must be stored in `result` as:
   {
@@ -275,9 +275,9 @@ Your output must be stored in `result` as:
     ...
   }
 
-[EDGE CASE HANDLING — what to do when data is missing, API fails, etc.]
+[EDGE CASE HANDLING: what to do when data is missing, API fails, etc.]
 
-[QUALITY CONSTRAINTS — max length, format requirements, citation rules]
+[QUALITY CONSTRAINTS: max length, format requirements, citation rules]
 """
 ```
 
@@ -287,6 +287,6 @@ Apply this template for every new agent. The more precisely you fill each sectio
 
 ## Further Reading
 
-- [AutoAgent Guide](autoagent.md) — How the Kernel uses the system prompt in the OODA loop
-- [Agent Personas](../concepts/agent-personas.md) — Full AgentProfile YAML schema and profile loading
-- [Workflow DAGs](workflows.md) — How depends_on replaces manual context injection in system prompts
+- [AutoAgent Guide](autoagent.md): How the Kernel uses the system prompt in the OODA loop
+- [Agent Personas](../concepts/agent-personas.md): Full AgentProfile YAML schema and profile loading
+- [Workflow DAGs](workflows.md): How depends_on replaces manual context injection in system prompts

--- a/jarviscore/docs/guides/testing.md
+++ b/jarviscore/docs/guides/testing.md
@@ -101,7 +101,7 @@ client.reset()
 
 ## MockBlobStorage
 
-In-memory blob storage. All data lives in a dict — no filesystem access required.
+In-memory blob storage. All data lives in a dict: no filesystem access required.
 
 ```python
 from jarviscore.testing import MockBlobStorage
@@ -130,7 +130,7 @@ storage.clear()
 
 ## MockRedisContextStore
 
-Backed by `fakeredis` — provides a real Redis-compatible API without a running server. All `RedisContextStore` methods work identically.
+Backed by `fakeredis`: provides a real Redis-compatible API without a running server. All `RedisContextStore` methods work identically.
 
 ```python
 from jarviscore.testing import MockRedisContextStore
@@ -173,7 +173,7 @@ When the queue is exhausted, `MockLLMClient` returns `{"content": "DONE: no more
 
 ## ExampleMockLLMClient
 
-A higher-level mock that interprets message content and **validates tool names against the `tools` parameter** before returning a tool-use response. Use it when testing agents that call `chat_with_tools()` — it prevents mock deadlocks caused by returning a tool that is not in scope for the current turn.
+A higher-level mock that interprets message content and **validates tool names against the `tools` parameter** before returning a tool-use response. Use it when testing agents that call `chat_with_tools()`: it prevents mock deadlocks caused by returning a tool that is not in scope for the current turn.
 
 ```python
 from jarviscore.testing import ExampleMockLLMClient
@@ -195,7 +195,7 @@ response = llm.chat_with_tools(
 # → {"type": "text", "content": "Mock analysis: ..."}
 ```
 
-**Tool routing logic** — `chat_with_tools()` inspects the user message and available tool names:
+**Tool routing logic**: `chat_with_tools()` inspects the user message and available tool names:
 
 | Message contains | Tool in scope | Returns |
 |-----------------|---------------|---------|
@@ -206,7 +206,7 @@ response = llm.chat_with_tools(
 
 **`continue_with_tool_result()`** always returns a text response summarising the tool result.
 
-**`chat()`** returns a short mock string — use it for agents that call the simple chat path rather than tool use.
+**`chat()`** returns a short mock string: use it for agents that call the simple chat path rather than tool use.
 
 ```python
 result = llm.chat("Summarise this report")

--- a/jarviscore/docs/guides/workflows.md
+++ b/jarviscore/docs/guides/workflows.md
@@ -4,7 +4,7 @@ icon: material/sitemap
 
 # Workflow DAGs
 
-JarvisCore's `WorkflowBuilder` lets you compose multi-agent workflows as Directed Acyclic Graphs (DAGs). Each step is assigned to a specific agent role, steps declare their dependencies, and the framework executes them in topological order — parallelising independent steps automatically.
+JarvisCore's `WorkflowBuilder` lets you compose multi-agent workflows as Directed Acyclic Graphs (DAGs). Each step is assigned to a specific agent role, steps declare their dependencies, and the framework executes them in topological order: parallelising independent steps automatically.
 
 This guide covers the full `WorkflowBuilder` API, the result reference syntax for chaining step outputs, Redis-backed persistence, and production patterns.
 

--- a/jarviscore/docs/index.md
+++ b/jarviscore/docs/index.md
@@ -8,7 +8,7 @@ icon: material/home
 
 # Agents that survive production
 
-Most frameworks get you a demo. JarvisCore gets you an operator: agents that run unattended for weeks, remember what happened last month, fail loudly instead of silently, and leave a flight record you can actually read. We know because we run our own agents on it, with real budgets and real consequences, and every hardening release comes from those scars.
+Most frameworks get you a demo. JarvisCore gets you an operator: agents that run unattended for weeks, remember last month, fail loudly, and leave a flight record you can read. We run our own agents on it with real budgets, and every hardening release comes from those scars.
 
 <div class="jc-cta-text" markdown>
 [Get started](getting-started.md) [Why JarvisCore](#why-jarviscore) [Reference](reference/configuration.md)
@@ -41,20 +41,20 @@ Most frameworks get you a demo. JarvisCore gets you an operator: agents that run
 
 ## Why JarvisCore
 
-Agent frameworks fail in the same three places. We built against all three, because our own agents hit them first.
+Agent frameworks fail in the same three places. We built against all three.
 
-**Your agent should never lie to itself.** Context windows fill up, and most frameworks quietly cut things out: the oldest turns, the middle of a tool result, half of a step summary. The agent then reasons confidently from evidence it does not know is missing. JarvisCore has a standing rule: truncation is not compression, it is lossiness. Anything clipped is labeled as clipped, originals are archived with a retrieval path, and summaries say what they summarize. Your agent knows what it knows.
+**Your agent should never lie to itself.** When context fills up, most frameworks quietly drop things: old turns, the middle of a tool result, half a summary. The agent then reasons from evidence it does not know is missing. Our rule: truncation is lossiness, not compression. Clips are labeled, originals are archived with a retrieval path, summaries say what they summarize.
 
-**Failures must be loud.** An autonomous agent that fails silently is a liability you discover at the worst moment. Steps that fail say so, evaluators see full evidence before passing a verdict, partial work survives a failed goal instead of vanishing, and rate-limit storms are absorbed with jittered backoff instead of crashing the loop. When something breaks, the record shows you exactly where.
+**Failures must be loud.** Failed steps say so. Evaluators see full evidence before passing a verdict. Partial work survives a failed goal. Rate-limit storms are absorbed with jittered backoff instead of crashing the loop. When something breaks, the record shows where.
 
-**Autonomy is a spectrum, not a slider.** JarvisCore ships exactly two agent profiles. CustomAgent is a thin infrastructure shell where you bring the brain and keep deterministic control. AutoAgent is the full cognitive stack: task classification, typed routing, specialist sub-agents on an observe-orient-decide-act loop, code generation with sandboxed execution and self-repair, and a registry where verified work graduates for reuse. Pick your point on the spectrum per agent, not per framework.
+**Autonomy is a spectrum.** Two profiles, nothing in between. CustomAgent is a thin infrastructure shell: you bring the brain, you keep deterministic control. AutoAgent is the full cognitive stack: classification, typed routing, specialist sub-agents, sandboxed code generation with self-repair, and a registry where verified work graduates for reuse. Pick your point per agent, not per framework.
 
-And underneath those positions sit structural choices no glue layer gives you:
+Underneath sit structural choices no glue layer gives you:
 
-- **A self-organising mesh, not a supervisor.** Agents find each other over the SWIM gossip protocol with ZMQ transport. There is no central orchestrator to die: nodes join, fail, and rejoin, and the mesh reorganises. The same PeerClient code runs in one process or across a fleet of machines.
-- **Memory that compounds.** Set one URL and every agent gains a fourth memory tier through Athena MemOS: cross-session, semantic, and consolidated over time, so the agent you run in week six is working from what it learned in week one. No wiring code. Without it, the three in-process tiers still carry working, episodic, and long-term context.
-- **Agents that write their own integrations.** When AutoAgent needs capability it does not have, it writes the code, runs it in a sandbox, repairs it until it passes, and files it in a registry where it graduates from candidate to verified to golden. Your agents do not just consume a tool catalog. They grow one.
-- **Zero-trust credentials.** With Nexus, agents call third-party APIs without ever seeing a raw secret. Tokens live outside agent reasoning entirely, so a prompt injection cannot exfiltrate what the agent never had.
+- **Self-organising mesh.** Agents discover each other over SWIM gossip with ZMQ transport. No central orchestrator to die. The same PeerClient code runs in one process or across a fleet.
+- **Memory that compounds.** Set `ATHENA_URL` and every agent gains a fourth memory tier: cross-session, semantic, consolidated over time. The agent you run in week six works from what it learned in week one. Without it, three in-process tiers still cover working, episodic, and long-term context.
+- **Agents that write their own integrations.** When AutoAgent lacks a capability, it writes the code, runs it in a sandbox, repairs it until it passes, and files it in a registry: candidate, verified, golden. Your agents grow a tool catalog instead of consuming one.
+- **Zero-trust credentials.** With Nexus, agents never see a raw secret. Prompt injection cannot exfiltrate what the agent never had.
 
 ---
 

--- a/jarviscore/docs/index.md
+++ b/jarviscore/docs/index.md
@@ -49,6 +49,13 @@ Agent frameworks fail in the same three places. We built against all three, beca
 
 **Autonomy is a spectrum, not a slider.** JarvisCore ships exactly two agent profiles. CustomAgent is a thin infrastructure shell where you bring the brain and keep deterministic control. AutoAgent is the full cognitive stack: task classification, typed routing, specialist sub-agents on an observe-orient-decide-act loop, code generation with sandboxed execution and self-repair, and a registry where verified work graduates for reuse. Pick your point on the spectrum per agent, not per framework.
 
+And underneath those positions sit structural choices no glue layer gives you:
+
+- **A self-organising mesh, not a supervisor.** Agents find each other over the SWIM gossip protocol with ZMQ transport. There is no central orchestrator to die: nodes join, fail, and rejoin, and the mesh reorganises. The same PeerClient code runs in one process or across a fleet of machines.
+- **Memory that compounds.** Set one URL and every agent gains a fourth memory tier through Athena MemOS: cross-session, semantic, and consolidated over time, so the agent you run in week six is working from what it learned in week one. No wiring code. Without it, the three in-process tiers still carry working, episodic, and long-term context.
+- **Agents that write their own integrations.** When AutoAgent needs capability it does not have, it writes the code, runs it in a sandbox, repairs it until it passes, and files it in a registry where it graduates from candidate to verified to golden. Your agents do not just consume a tool catalog. They grow one.
+- **Zero-trust credentials.** With Nexus, agents call third-party APIs without ever seeing a raw secret. Tokens live outside agent reasoning entirely, so a prompt injection cannot exfiltrate what the agent never had.
+
 ---
 
 ## What JarvisCore provides
@@ -67,15 +74,15 @@ Agent frameworks fail in the same three places. We built against all three, beca
 
 ### Four-tier memory
 
-Working scratchpad → episodic ledger → LLM-compressed long-term summaries → optional cross-session semantic memory via Athena MemOS. Context that survives restarts, scales across steps.
+Working scratchpad, episodic ledger, LLM-compressed long-term summaries, and optional cross-session semantic memory via Athena MemOS. Wired into AutoAgent automatically when `ATHENA_URL` is set. Context that survives restarts and compounds across weeks.
 </div>
 
 <div class="jc-card" markdown>
 <span class="jc-card-label">Communication</span>
 
-### Peer-to-peer mesh
+### Self-organising mesh
 
-Agents discover and message each other via a `PeerClient` API. Routing, request-response, and broadcast work identically on a single process or across distributed machines.
+Agents discover and message each other via a `PeerClient` API over SWIM gossip and ZMQ. No central orchestrator to die: nodes join, fail, and rejoin. Identical code on a single process or across distributed machines.
 </div>
 
 <div class="jc-card" markdown>

--- a/jarviscore/docs/index.md
+++ b/jarviscore/docs/index.md
@@ -8,7 +8,7 @@ icon: material/home
 
 # Agents that survive production
 
-Most frameworks get you a demo. JarvisCore gets you an operator: agents that run unattended for weeks, remember last month, fail loudly, and leave a flight record you can read. We run our own agents on it with real budgets, and every hardening release comes from those scars.
+Most frameworks get you a demo. JarvisCore gets you an operator: agents that run unattended for weeks, remember last month, fail loudly, and leave a flight record you can read. We run our own agents on it, with real budgets. Every hardening release comes from those scars.
 
 <div class="jc-cta-text" markdown>
 [Get started](getting-started.md) [Why JarvisCore](#why-jarviscore) [Reference](reference/configuration.md)
@@ -41,20 +41,12 @@ Most frameworks get you a demo. JarvisCore gets you an operator: agents that run
 
 ## Why JarvisCore
 
-Agent frameworks fail in the same three places. We built against all three.
+Built by running our own agents unattended, with real budgets. Four rules fell out of that, and they are enforced in code, not promised in prose:
 
-**Your agent should never lie to itself.** When context fills up, most frameworks quietly drop things: old turns, the middle of a tool result, half a summary. The agent then reasons from evidence it does not know is missing. Our rule: truncation is lossiness, not compression. Clips are labeled, originals are archived with a retrieval path, summaries say what they summarize.
-
-**Failures must be loud.** Failed steps say so. Evaluators see full evidence before passing a verdict. Partial work survives a failed goal. Rate-limit storms are absorbed with jittered backoff instead of crashing the loop. When something breaks, the record shows where.
-
-**Autonomy is a spectrum.** Two profiles, nothing in between. CustomAgent is a thin infrastructure shell: you bring the brain, you keep deterministic control. AutoAgent is the full cognitive stack: classification, typed routing, specialist sub-agents, sandboxed code generation with self-repair, and a registry where verified work graduates for reuse. Pick your point per agent, not per framework.
-
-Underneath sit structural choices no glue layer gives you:
-
-- **Self-organising mesh.** Agents discover each other over SWIM gossip with ZMQ transport. No central orchestrator to die. The same PeerClient code runs in one process or across a fleet.
-- **Memory that compounds.** Set `ATHENA_URL` and every agent gains a fourth memory tier: cross-session, semantic, consolidated over time. The agent you run in week six works from what it learned in week one. Without it, three in-process tiers still cover working, episodic, and long-term context.
-- **Agents that write their own integrations.** When AutoAgent lacks a capability, it writes the code, runs it in a sandbox, repairs it until it passes, and files it in a registry: candidate, verified, golden. Your agents grow a tool catalog instead of consuming one.
-- **Zero-trust credentials.** With Nexus, agents never see a raw secret. Prompt injection cannot exfiltrate what the agent never had.
+- **Honest context.** Nothing is truncated silently. Clips are labeled, originals archived, summaries say what they summarize.
+- **Loud failures.** Failed steps say so. Partial work survives. Rate-limit storms are absorbed, not crashed on.
+- **Two profiles, no mushy middle.** `CustomAgent`: you bring the brain. `AutoAgent`: the full cognitive stack. It writes its own integrations, repairs them in a sandbox, and banks verified work for reuse.
+- **No single point of death.** Agents coordinate over a SWIM gossip mesh. Memory compounds across sessions via Athena. Credentials stay out of agent reasoning via Nexus.
 
 ---
 

--- a/jarviscore/docs/index.md
+++ b/jarviscore/docs/index.md
@@ -6,12 +6,12 @@ icon: material/home
 
 <img src="assets/combo-brand.svg" class="jc-hero-logo" alt="JarvisCore Logo" />
 
-# Build autonomous multi-agent systems
+# Agents that survive production
 
-JarvisCore is a Python framework for production multi-agent AI. Peer-to-peer coordination, composable memory, 46 service integrations, and full observability — from a single agent to a fleet.
+Most frameworks get you a demo. JarvisCore gets you an operator: agents that run unattended for weeks, remember what happened last month, fail loudly instead of silently, and leave a flight record you can actually read. We know because we run our own agents on it, with real budgets and real consequences, and every hardening release comes from those scars.
 
 <div class="jc-cta-text" markdown>
-[Get started](getting-started.md) [Reference](reference/configuration.md) [View Changelog](CHANGELOG.md)
+[Get started](getting-started.md) [Why JarvisCore](#why-jarviscore) [Reference](reference/configuration.md)
 </div>
 
 </div>
@@ -20,22 +20,34 @@ JarvisCore is a Python framework for production multi-agent AI. Peer-to-peer coo
 
 <div class="jc-stats" markdown>
 <div class="jc-stat" markdown>
+<span class="jc-stat-value">1 key</span>
+<span class="jc-stat-label">To First Agent</span>
+</div>
+<div class="jc-stat" markdown>
+<span class="jc-stat-value">0</span>
+<span class="jc-stat-label">Silent Truncations</span>
+</div>
+<div class="jc-stat" markdown>
+<span class="jc-stat-value">24/7</span>
+<span class="jc-stat-label">Unattended Operation</span>
+</div>
+<div class="jc-stat" markdown>
 <span class="jc-stat-value">46</span>
 <span class="jc-stat-label">Service Integrations</span>
 </div>
-<div class="jc-stat" markdown>
-<span class="jc-stat-value">237+</span>
-<span class="jc-stat-label">Prebuilt Actions</span>
 </div>
-<div class="jc-stat" markdown>
-<span class="jc-stat-value">4-tier</span>
-<span class="jc-stat-label">Agent Memory</span>
-</div>
-<div class="jc-stat" markdown>
-<span class="jc-stat-value">P2P</span>
-<span class="jc-stat-label">Agent Mesh</span>
-</div>
-</div>
+
+---
+
+## Why JarvisCore
+
+Agent frameworks fail in the same three places. We built against all three, because our own agents hit them first.
+
+**Your agent should never lie to itself.** Context windows fill up, and most frameworks quietly cut things out: the oldest turns, the middle of a tool result, half of a step summary. The agent then reasons confidently from evidence it does not know is missing. JarvisCore has a standing rule: truncation is not compression, it is lossiness. Anything clipped is labeled as clipped, originals are archived with a retrieval path, and summaries say what they summarize. Your agent knows what it knows.
+
+**Failures must be loud.** An autonomous agent that fails silently is a liability you discover at the worst moment. Steps that fail say so, evaluators see full evidence before passing a verdict, partial work survives a failed goal instead of vanishing, and rate-limit storms are absorbed with jittered backoff instead of crashing the loop. When something breaks, the record shows you exactly where.
+
+**Autonomy is a spectrum, not a slider.** JarvisCore ships exactly two agent profiles. CustomAgent is a thin infrastructure shell where you bring the brain and keep deterministic control. AutoAgent is the full cognitive stack: task classification, typed routing, specialist sub-agents on an observe-orient-decide-act loop, code generation with sandboxed execution and self-repair, and a registry where verified work graduates for reuse. Pick your point on the spectrum per agent, not per framework.
 
 ---
 
@@ -47,7 +59,7 @@ JarvisCore is a Python framework for production multi-agent AI. Peer-to-peer coo
 
 ### Two execution models
 
-`AutoAgent` runs a full OODA loop internally — observe, orient, decide, act. `CustomAgent` exposes the execution loop directly for deterministic control. Both share the same infrastructure.
+`AutoAgent` runs a full cognitive loop internally: observe, orient, decide, act. `CustomAgent` exposes the execution loop directly for deterministic control. Both share the same infrastructure.
 </div>
 
 <div class="jc-card" markdown>
@@ -71,7 +83,7 @@ Agents discover and message each other via a `PeerClient` API. Routing, request-
 
 ### 46 service integrations
 
-Slack, GitHub, Zoom, SAP, NetSuite, MS Graph, Salesforce, and 40 more. 237+ prebuilt actions your agents can call directly — no glue code, no auth wiring.
+Slack, GitHub, Zoom, SAP, NetSuite, MS Graph, Salesforce, and 40 more. 237+ prebuilt actions your agents can call directly. No glue code, no auth wiring.
 
 [Browse integrations →](guides/integrations.md)
 </div>
@@ -81,7 +93,7 @@ Slack, GitHub, Zoom, SAP, NetSuite, MS Graph, Salesforce, and 40 more. 237+ preb
 
 ### Nexus credential layer
 
-Agents call third-party APIs without ever touching raw credentials. OAuth2, API keys, and basic auth — all managed by Nexus and kept out of agent reasoning.
+Agents call third-party APIs without ever touching raw credentials. OAuth2, API keys, and basic auth are all managed by Nexus and kept out of agent reasoning.
 
 [Nexus guide →](guides/nexus.md)
 </div>
@@ -149,20 +161,20 @@ asyncio.run(main())
 
 If you are new to JarvisCore, read in this order:
 
-1. [Getting Started](getting-started.md) — install, configure, and run your first agent
-2. [Architecture Overview](concepts/architecture.md) — the mental model for how the framework fits together
-3. [Agents](concepts/agents.md) — what an agent is, its identity and lifecycle
-4. [Language Models](concepts/language-models.md) — how JarvisCore uses multiple LLMs simultaneously
-5. [Memory](concepts/memory.md) — how agents maintain and recover context
-6. [Agent Personas](concepts/agent-personas.md) — how profiles shape autonomous behaviour
+1. [Getting Started](getting-started.md): install, configure, and run your first agent
+2. [Architecture Overview](concepts/architecture.md): the mental model for how the framework fits together
+3. [Agents](concepts/agents.md): what an agent is, its identity and lifecycle
+4. [Language Models](concepts/language-models.md): how JarvisCore uses multiple LLMs simultaneously
+5. [Memory](concepts/memory.md): how agents maintain and recover context
+6. [Agent Personas](concepts/agent-personas.md): how profiles shape autonomous behaviour
 
 If you are evaluating for a specific use case:
 
-- [AutoAgent Guide](guides/autoagent.md) — autonomous reasoning agents
-- [CustomAgent Guide](guides/customagent.md) — deterministic worker agents
-- [System Bundles & Integrations](guides/integrations.md) — the full atom catalog
-- [Configuration Reference](reference/configuration.md) — all environment variables
-- [JarvisCore Enterprise](infrastructure/enterprise.md) — managed deployment and SLAs
+- [AutoAgent Guide](guides/autoagent.md): autonomous reasoning agents
+- [CustomAgent Guide](guides/customagent.md): deterministic worker agents
+- [System Bundles & Integrations](guides/integrations.md): the full atom catalog
+- [Configuration Reference](reference/configuration.md): all environment variables
+- [JarvisCore Enterprise](infrastructure/enterprise.md): managed deployment and SLAs
 
 ---
 
@@ -170,10 +182,10 @@ If you are evaluating for a specific use case:
 
 | | |
 |---|---|
-| **Reference** | Full API surface, configuration keys, and CLI flags — [view reference](reference/configuration.md) |
-| **Source** | Browse the code, open issues, and submit PRs — [GitHub](https://github.com/Prescott-Data/jarviscore-framework){ target="_blank" rel="noopener" } |
-| **Community** | Questions, showcases, and early feature previews — [Discord](https://discord.gg/jarviscore){ target="_blank" rel="noopener" } |
-| **Blog** | Engineering deep-dives and architecture walkthroughs — [read the blog](https://developers.prescottdata.io/blog){ target="_blank" rel="noopener" } |
+| **Reference** | Full API surface, configuration keys, and CLI flags: [view reference](reference/configuration.md) |
+| **Source** | Browse the code, open issues, and submit PRs: [GitHub](https://github.com/Prescott-Data/jarviscore-framework){ target="_blank" rel="noopener" } |
+| **Community** | Questions, showcases, and early feature previews: [Discord](https://discord.gg/jarviscore){ target="_blank" rel="noopener" } |
+| **Blog** | Engineering deep-dives and architecture walkthroughs: [read the blog](https://developers.prescottdata.io/blog){ target="_blank" rel="noopener" } |
 
 ---
 

--- a/jarviscore/docs/index.md
+++ b/jarviscore/docs/index.md
@@ -1,5 +1,7 @@
 ---
 icon: material/home
+title: Python Multi-Agent AI Framework for Production
+description: Open source Python framework for building autonomous multi-agent AI systems. Peer-to-peer agent orchestration, persistent agent memory, zero-trust credentials, and full observability.
 ---
 
 <div class="jc-hero" markdown>
@@ -8,33 +10,12 @@ icon: material/home
 
 # Agents that survive production
 
-Most frameworks get you a demo. JarvisCore gets you an operator: agents that run unattended for weeks, remember last month, fail loudly, and leave a flight record you can read. We run our own agents on it, with real budgets. Every hardening release comes from those scars.
+JarvisCore is an open source Python framework for building autonomous multi-agent AI systems. Most agent frameworks get you a demo; JarvisCore gets you an operator: agents that run unattended for weeks, remember last month, fail loudly, and leave a flight record you can read. We run our own agents on it, with real budgets. Every hardening release comes from those scars.
 
 <div class="jc-cta-text" markdown>
 [Get started](getting-started.md) [Why JarvisCore](#why-jarviscore) [Reference](reference/configuration.md)
 </div>
 
-</div>
-
----
-
-<div class="jc-stats" markdown>
-<div class="jc-stat" markdown>
-<span class="jc-stat-value">1 key</span>
-<span class="jc-stat-label">To First Agent</span>
-</div>
-<div class="jc-stat" markdown>
-<span class="jc-stat-value">0</span>
-<span class="jc-stat-label">Silent Truncations</span>
-</div>
-<div class="jc-stat" markdown>
-<span class="jc-stat-value">24/7</span>
-<span class="jc-stat-label">Unattended Operation</span>
-</div>
-<div class="jc-stat" markdown>
-<span class="jc-stat-value">46</span>
-<span class="jc-stat-label">Service Integrations</span>
-</div>
 </div>
 
 ---
@@ -47,6 +28,8 @@ Built by running our own agents unattended, with real budgets. Four rules fell o
 - **Loud failures.** Failed steps say so. Partial work survives. Rate-limit storms are absorbed, not crashed on.
 - **Two profiles, no mushy middle.** `CustomAgent`: you bring the brain. `AutoAgent`: the full cognitive stack. It writes its own integrations, repairs them in a sandbox, and banks verified work for reuse.
 - **No single point of death.** Agents coordinate over a SWIM gossip mesh. Memory compounds across sessions via Athena. Credentials stay out of agent reasoning via Nexus.
+
+Here is what those rules buy you in practice.
 
 ---
 
@@ -64,7 +47,7 @@ Built by running our own agents unattended, with real budgets. Four rules fell o
 <div class="jc-card" markdown>
 <span class="jc-card-label">Memory</span>
 
-### Four-tier memory
+### Four-tier agent memory
 
 Working scratchpad, episodic ledger, LLM-compressed long-term summaries, and optional cross-session semantic memory via Athena MemOS. Wired into AutoAgent automatically when `ATHENA_URL` is set. Context that survives restarts and compounds across weeks.
 </div>
@@ -72,7 +55,7 @@ Working scratchpad, episodic ledger, LLM-compressed long-term summaries, and opt
 <div class="jc-card" markdown>
 <span class="jc-card-label">Communication</span>
 
-### Self-organising mesh
+### Self-organising agent mesh
 
 Agents discover and message each other via a `PeerClient` API over SWIM gossip and ZMQ. No central orchestrator to die: nodes join, fail, and rejoin. Identical code on a single process or across distributed machines.
 </div>
@@ -121,6 +104,8 @@ Every agent turn, tool call, and LLM request is traced automatically. Redis PubS
 ---
 
 ## Quickstart
+
+One LLM provider key is the only required configuration. Install, initialise, and run your first autonomous agent:
 
 ```bash title="Install & initialise"
 pip install jarviscore-framework

--- a/jarviscore/docs/infrastructure/enterprise.md
+++ b/jarviscore/docs/infrastructure/enterprise.md
@@ -4,9 +4,9 @@ icon: material/office-building
 
 # JarvisCore Enterprise
 
-JarvisCore is open source under Apache 2.0. You can self-host it, run it on any cloud, and operate it entirely on your own infrastructure — forever, for free.
+JarvisCore is open source under Apache 2.0. You can self-host it, run it on any cloud, and operate it entirely on your own infrastructure: forever, for free.
 
-**JarvisCore Enterprise** is a managed deployment service. Prescott Data runs, operates, and supports the full JarvisCore stack on your behalf — the same way MongoDB Atlas runs MongoDB or Redis Cloud runs Redis. Your team builds agent systems; we handle the infrastructure that runs them.
+**JarvisCore Enterprise** is a managed deployment service. Prescott Data runs, operates, and supports the full JarvisCore stack on your behalf: the same way MongoDB Atlas runs MongoDB or Redis Cloud runs Redis. Your team builds agent systems; we handle the infrastructure that runs them.
 
 ---
 
@@ -16,15 +16,15 @@ JarvisCore is open source under Apache 2.0. You can self-host it, run it on any 
 |---|---|---|
 | **Who runs it** | You | Prescott Data |
 | **Deployment** | Self-managed | Fully managed |
-| **Licensing** | Apache 2.0 — free | Commercial agreement |
-| **Uptime SLA** | — | 99.9% guaranteed |
+| **Licensing** | Apache 2.0: free | Commercial agreement |
+| **Uptime SLA** |: | 99.9% guaranteed |
 | **Support** | Community (GitHub Issues) | Dedicated engineering + SLA |
 | **Security hardening** | Framework defaults | Enterprise-grade (see below) |
 | **Data isolation** | You configure it | Enforced at the infrastructure layer |
 | **Backup & DR** | You configure it | Automated, cross-region, RPO < 1h |
 | **Agent governance** | None | Policy engine, rate limits, allow/deny lists |
 | **LLM flexibility** | Any provider via config | Bring-your-own LLM, on-prem model support |
-| **Professional services** | — | Onboarding, architecture review, migrations |
+| **Professional services** |: | Onboarding, architecture review, migrations |
 
 ---
 
@@ -32,7 +32,7 @@ JarvisCore is open source under Apache 2.0. You can self-host it, run it on any 
 
 ### Managed Deployment
 
-Prescott Data provisions, configures, and operates the complete JarvisCore stack — agents, mesh, Redis, blob storage, and observability — on your chosen cloud (AWS, Azure, GCP) or in your private network.
+Prescott Data provisions, configures, and operates the complete JarvisCore stack (agents, mesh, Redis, blob storage, and observability) on your chosen cloud (AWS, Azure, GCP) or in your private network.
 
 - Zero-ops onboarding: your team connects to a running system, not a setup guide
 - Automated patching, dependency upgrades, and rollbacks
@@ -72,7 +72,7 @@ Enterprise deployments carry a **99.9% monthly uptime SLA** (≤ 43.8 minutes un
 | Measurement window | Calendar month, per region |
 | SLA credit | Pro-rated service credit if missed |
 | Exclusions | Scheduled maintenance (pre-announced ≥ 48h), force majeure, customer-caused outages |
-| Status page | Provided — real-time and historical incident data |
+| Status page | Provided: real-time and historical incident data |
 
 Full SLA terms are included in the commercial agreement.
 
@@ -87,7 +87,7 @@ Full SLA terms are included in the commercial agreement.
 | **Backup frequency** | Continuous (Redis AOF + hourly snapshots) |
 | **Backup retention** | 30 days rolling |
 | **Cross-region replication** | Available on Professional and Enterprise plans |
-| **Failover** | Automated — no manual intervention required |
+| **Failover** | Automated: no manual intervention required |
 
 Backups are encrypted with your tenant key and stored in isolated, access-controlled storage separate from the primary deployment.
 
@@ -111,7 +111,7 @@ Enterprise enforces strict separation at every layer for multi-tenant deployment
 - Workspace-level partitioning: each tenant's agents, workflows, and memory are fully separated
 - Network isolation: no shared data paths between tenants
 - Per-tenant encryption keys
-- Redis namespaces and blob storage prefixes enforced at the platform layer — not in application code
+- Redis namespaces and blob storage prefixes enforced at the platform layer: not in application code
 - Verified isolation documentation available as part of the security review pack
 
 ---
@@ -120,12 +120,12 @@ Enterprise enforces strict separation at every layer for multi-tenant deployment
 
 Enterprise adds a platform-level policy engine that sits above your agent code. This gives platform and security teams controls that don't require modifying agent implementations.
 
-- **Rate limiting** — per-agent, per-workflow, and per-tenant request caps with configurable burst allowances
-- **Capability allow/deny lists** — restrict which tools, APIs, and data sources each agent role can access
-- **LLM provider policy** — enforce which LLM providers and model versions agents may use; block unapproved models
-- **Output filtering** — platform-level PII redaction and content policy enforcement on all agent outputs before they leave the mesh
-- **Workflow approval gates** — require human sign-off before specific workflow steps execute in production
-- **Cost guardrails** — per-workspace LLM token budget with configurable alerting and hard caps
+- **Rate limiting**: per-agent, per-workflow, and per-tenant request caps with configurable burst allowances
+- **Capability allow/deny lists**: restrict which tools, APIs, and data sources each agent role can access
+- **LLM provider policy**: enforce which LLM providers and model versions agents may use; block unapproved models
+- **Output filtering**: platform-level PII redaction and content policy enforcement on all agent outputs before they leave the mesh
+- **Workflow approval gates**: require human sign-off before specific workflow steps execute in production
+- **Cost guardrails**: per-workspace LLM token budget with configurable alerting and hard caps
 
 ---
 
@@ -134,9 +134,9 @@ Enterprise adds a platform-level policy engine that sits above your agent code. 
 Enterprise does not lock you into a single AI provider. You bring the models your team has approved.
 
 - Use any LLM via the existing JarvisCore provider config (OpenAI, Anthropic, Mistral, Cohere, and others)
-- **Bring-your-own-model** — connect to on-premises or VPC-hosted models (Ollama, vLLM, Azure OpenAI private endpoint)
-- Per-agent model routing — different agent roles can use different models and providers
-- Model fallback chains — if a primary provider is unavailable, agents fail over to a configured backup automatically
+- **Bring-your-own-model**: connect to on-premises or VPC-hosted models (Ollama, vLLM, Azure OpenAI private endpoint)
+- Per-agent model routing: different agent roles can use different models and providers
+- Model fallback chains: if a primary provider is unavailable, agents fail over to a configured backup automatically
 - All LLM calls are logged, attributable, and subject to your governance policy
 
 ---
@@ -154,7 +154,7 @@ Enterprise does not lock you into a single AI provider. You bring the models you
 
 ### Observability & Tracing
 
-- OpenTelemetry export — metrics, traces, and logs — to your existing stack (Datadog, Grafana, Splunk, and others)
+- OpenTelemetry export (metrics, traces, and logs) to your existing stack (Datadog, Grafana, Splunk, and others)
 - SIEM-ready audit streams with tamper-evident event records
 - Long-retention, searchable workflow traces with replay tooling
 - Prometheus metrics aggregated across all nodes and exportable to your monitoring platform
@@ -190,7 +190,7 @@ All paid plans include a named support engineer and a dedicated Slack or Teams c
 
 ## Pricing Model
 
-JarvisCore Enterprise is priced on a **subscription basis** — a flat annual fee based on deployment size (number of active agents and workflow volume), not per-seat or per-API-call. This means your costs are predictable as you scale agent usage, and you don't get billed every time an agent completes a workflow step.
+JarvisCore Enterprise is priced on a **subscription basis**: a flat annual fee based on deployment size (number of active agents and workflow volume), not per-seat or per-API-call. This means your costs are predictable as you scale agent usage, and you don't get billed every time an agent completes a workflow step.
 
 Pricing is scoped per engagement. Factors include:
 
@@ -213,15 +213,15 @@ Enterprise is the right choice when any of these apply:
 - **You have compliance requirements.** SOC 2, GDPR, HIPAA, or internal data governance policies require audited, isolated, documented deployments that pass security review.
 - **You need a guaranteed uptime SLA.** Your agent workflows are in the critical path of production systems and cannot tolerate unplanned downtime.
 - **You operate at multi-tenant scale.** Multiple business units or customers need strict data separation without the cost of running completely separate deployments.
-- **You need a support SLA.** When a production incident happens, you need a guaranteed response time and an engineer who knows your deployment — not a GitHub issue queue.
+- **You need a support SLA.** When a production incident happens, you need a guaranteed response time and an engineer who knows your deployment: not a GitHub issue queue.
 - **You need model and vendor governance.** Your organisation requires policy controls over which LLMs agents can call, with auditable records of every call.
 
 ---
 
 ## How Teams Typically Adopt
 
-1. **Build on JarvisCore OSS.** Every framework primitive — agents, memory, orchestration, HITL, Nexus — is available and unrestricted. Validate your architecture on your own infrastructure first.
-2. **Move to Enterprise** when operational overhead, compliance requirements, or uptime SLAs become the constraint — not the framework's capabilities.
+1. **Build on JarvisCore OSS.** Every framework primitive (agents, memory, orchestration, HITL, Nexus) is available and unrestricted. Validate your architecture on your own infrastructure first.
+2. **Move to Enterprise** when operational overhead, compliance requirements, or uptime SLAs become the constraint: not the framework's capabilities.
 3. Onboarding typically takes **1–2 weeks** from a signed agreement to a fully running managed environment.
 
 ---
@@ -245,6 +245,6 @@ Request the pack via the email below and reference "security review" in your sub
 
 **Email:** jarviscore-enterprise@prescottdata.io
 
-Include your cloud provider preference, approximate agent count, and any specific compliance framework requirements in your first message — it helps us prepare the right materials and route your enquiry to the right team.
+Include your cloud provider preference, approximate agent count, and any specific compliance framework requirements in your first message: it helps us prepare the right materials and route your enquiry to the right team.
 
 We respond to all enterprise enquiries within **one business day**.

--- a/jarviscore/docs/reference/agent-api.md
+++ b/jarviscore/docs/reference/agent-api.md
@@ -201,7 +201,7 @@ Mesh(config: Optional[Dict[str, Any]] = None)
 | `checkpoint_interval` | `int` | `1` | Save workflow checkpoints every N steps |
 | `max_parallel` | `int` | `5` | Maximum parallel step execution |
 
-The Mesh auto-detects available infrastructure at `start()` time. Do not pass `mode=` — that argument is deprecated and has no effect.
+The Mesh auto-detects available infrastructure at `start()` time. Do not pass `mode=`: that argument is deprecated and has no effect.
 
 ### Methods
 
@@ -327,14 +327,14 @@ def create_jarvis_app(
 ) -> FastAPI
 ```
 
-Convenience wrapper for single-agent deployments. Creates a `FastAPI` app with `JarvisLifespan` pre-configured. The Mesh auto-detects its operational mode from available infrastructure at startup — no `mode` argument is accepted. For multi-agent deployments or more control, use `JarvisLifespan` directly.
+Convenience wrapper for single-agent deployments. Creates a `FastAPI` app with `JarvisLifespan` pre-configured. The Mesh auto-detects its operational mode from available infrastructure at startup: no `mode` argument is accepted. For multi-agent deployments or more control, use `JarvisLifespan` directly.
 
 ---
 
 ## Further Reading
 
-- [AutoAgent guide](../guides/autoagent.md) — usage walkthrough with examples
-- [CustomAgent guide](../guides/customagent.md) — usage walkthrough with examples
-- [Planning](../concepts/planning.md) — goal-oriented mode for `AutoAgent`
-- [Configuration Reference](configuration.md) — all environment variables
-- [Chat API Reference](chat-api.md) — HTTP chat endpoint contract
+- [AutoAgent guide](../guides/autoagent.md): usage walkthrough with examples
+- [CustomAgent guide](../guides/customagent.md): usage walkthrough with examples
+- [Planning](../concepts/planning.md): goal-oriented mode for `AutoAgent`
+- [Configuration Reference](configuration.md): all environment variables
+- [Chat API Reference](chat-api.md): HTTP chat endpoint contract

--- a/jarviscore/docs/reference/chat-api.md
+++ b/jarviscore/docs/reference/chat-api.md
@@ -15,7 +15,7 @@ app.include_router(
 )
 ```
 
-The `kernel` argument must be a `jarviscore.kernel.kernel.Kernel` instance. The router is stateless — the same Kernel can be shared across multiple router mounts or agent instances.
+The `kernel` argument must be a `jarviscore.kernel.kernel.Kernel` instance. The router is stateless: the same Kernel can be shared across multiple router mounts or agent instances.
 
 ---
 
@@ -63,7 +63,7 @@ Trace events stream in real time on `GET /chat/stream/{workflow_id}` while the P
 
 | Field | Type | Required | Default | Description |
 |---|---|---|---|---|
-| `message` | `str` | Yes | — | Natural language task or question |
+| `message` | `str` | Yes |: | Natural language task or question |
 | `workflow_id` | `str` | No | auto-generated (`chat_<12hex>`) | Workflow identifier; supply your own to correlate with the SSE stream |
 | `agent_id` | `str` | No | `"chat"` | Agent identity passed to the Kernel |
 | `system_prompt` | `str` | No | `""` | System prompt prepended to the Kernel call |
@@ -89,7 +89,7 @@ HTTP 200 on success. HTTP 500 with `{"error": "...", "workflow_id": "..."}` on K
 |---|---|---|
 | `workflow_id` | `str` | Workflow identifier (use this to open the SSE stream) |
 | `step_id` | `str` | Step identifier, formatted as `step_<unix_timestamp>` |
-| `status` | `str` | `"success"`, `"failure"`, or `"yield"` — taken directly from `output.status` |
+| `status` | `str` | `"success"`, `"failure"`, or `"yield"`: taken directly from `output.status` |
 | `answer` | `str` | Final answer text. Taken from `output.summary`, falling back to `str(output.payload)[:2000]` |
 | `sources` | `List[dict]` | Citation sources extracted from researcher output. Each entry is `{"title": "...", "url": "...", "source": "..."}`. Capped at 10 entries |
 | `tokens` | `dict` | Token usage from `output.metadata["tokens"]`. Keys depend on the provider |
@@ -189,6 +189,6 @@ Requires Redis to be configured. Events are read from the trace files in the `tr
 
 ## Further Reading
 
-- [Chat Endpoint guide](../guides/chat.md) — integration walkthrough with full examples
-- [Configuration Reference](configuration.md) — `REDIS_URL` required for live SSE streaming
-- [Model Routing](../concepts/model-routing.md) — how the Kernel classifies and routes chat messages
+- [Chat Endpoint guide](../guides/chat.md): integration walkthrough with full examples
+- [Configuration Reference](configuration.md): `REDIS_URL` required for live SSE streaming
+- [Model Routing](../concepts/model-routing.md): how the Kernel classifies and routes chat messages

--- a/jarviscore/docs/reference/cli.md
+++ b/jarviscore/docs/reference/cli.md
@@ -241,7 +241,7 @@ Example output:
 
 ```
 ════════════════════════════════════════════════════════════════════════
-  JarvisCore Memory — Status
+  JarvisCore Memory Status
 ════════════════════════════════════════════════════════════════════════
   Athena MemOS  http://localhost:8080  [ok]
     Redis: ok
@@ -300,11 +300,11 @@ jarviscore atom test --bundle <bundle> --mode <dry-run|integration> [options]
 | `--bundle` | Bundle name to test (e.g. `slack`, `github`, `stripe`) |
 | `--atom` | Test a single atom instead of the whole bundle |
 | `--mode` | `dry-run` (default) or `integration` |
-| `--connection-id` | Nexus connection handle — required for `integration` mode |
+| `--connection-id` | Nexus connection handle: required for `integration` mode |
 | `--nexus-url` | Gateway URL (defaults to `NEXUS_GATEWAY_URL` or `http://localhost:8090`) |
-| `--all` | Test every atom across all bundles — `dry-run` only |
+| `--all` | Test every atom across all bundles: `dry-run` only |
 
-**Dry-run mode** — structural checks only, no network required:
+**Dry-run mode**: structural checks only, no network required:
 
 ```bash
 # Check all atoms in the slack bundle
@@ -330,7 +330,7 @@ Dry-run validates:
 | Return statement | At least one `return` with a value |
 | Forbidden usage | No `subprocess`, `pickle`, `ctypes`, `eval`, `exec` |
 
-**Integration mode** — passes dry-run, then verifies a Nexus `connection_id` resolves:
+**Integration mode**: passes dry-run, then verifies a Nexus `connection_id` resolves:
 
 ```bash
 jarviscore atom test \
@@ -339,7 +339,7 @@ jarviscore atom test \
     --mode integration
 ```
 
-The integration check does not call the provider API — it confirms the Nexus Gateway is reachable and the `connection_id` resolves to a token payload. API behaviour must be verified manually.
+The integration check does not call the provider API: it confirms the Nexus Gateway is reachable and the `connection_id` resolves to a token payload. API behaviour must be verified manually.
 
 !!! note "Gateway required for integration mode"
     `--mode integration` requires `NEXUS_GATEWAY_URL` to be set and the Nexus stack to be running. Use `jarviscore nexus status` to confirm the gateway is healthy first.
@@ -373,4 +373,4 @@ jarviscore/integrations/atoms
 46 bundles  ·  237 atoms total
 ```
 
-See [Testing Atoms](../guides/testing-atoms.md) for the full workflow — from writing a new atom to promoting it to `verified`.
+See [Testing Atoms](../guides/testing-atoms.md) for the full workflow: from writing a new atom to promoting it to `verified`.

--- a/jarviscore/docs/reference/configuration.md
+++ b/jarviscore/docs/reference/configuration.md
@@ -16,31 +16,31 @@ Configure exactly one LLM provider. JarvisCore auto-detects the active provider 
 
     | Variable | Required | Default | Description |
     |---|---|---|---|
-    | `CLAUDE_API_KEY` | Yes | — | API key starting with `sk-ant-` |
+    | `CLAUDE_API_KEY` | Yes | (none) | API key starting with `sk-ant-` |
     | `CLAUDE_MODEL` | No | `claude-sonnet-4` | Model name |
 
 === "Google Gemini"
 
     | Variable | Required | Default | Description |
     |---|---|---|---|
-    | `GEMINI_API_KEY` | Yes | — | API key starting with `AIza` |
+    | `GEMINI_API_KEY` | Yes | (none) | API key starting with `AIza` |
     | `GEMINI_MODEL` | No | `gemini-2.0-flash` | Model name |
 
 === "Azure OpenAI"
 
     | Variable | Required | Default | Description |
     |---|---|---|---|
-    | `AZURE_API_KEY` | Yes | — | Azure OpenAI API key |
-    | `AZURE_ENDPOINT` | Yes | — | Resource endpoint, e.g. `https://your-resource.openai.azure.com/` |
-    | `AZURE_DEPLOYMENT` | Yes | — | Deployment name, e.g. `gpt-4o` |
+    | `AZURE_API_KEY` | Yes | (none) | Azure OpenAI API key |
+    | `AZURE_ENDPOINT` | Yes | (none) | Resource endpoint, e.g. `https://your-resource.openai.azure.com/` |
+    | `AZURE_DEPLOYMENT` | Yes | (none) | Deployment name, e.g. `gpt-4o` |
     | `AZURE_API_VERSION` | No | `2024-02-15-preview` | API version string |
 
 === "Local / vLLM"
 
     | Variable | Required | Default | Description |
     |---|---|---|---|
-    | `LLM_ENDPOINT` | Yes | — | OpenAI-compatible endpoint URL |
-    | `LLM_MODEL` | Yes | — | Model name as expected by the endpoint |
+    | `LLM_ENDPOINT` | Yes | (none) | OpenAI-compatible endpoint URL |
+    | `LLM_MODEL` | Yes | (none) | Model name as expected by the endpoint |
 
 ---
 
@@ -93,10 +93,10 @@ Without Redis, JarvisCore runs in in-process mode: workflows execute locally, ma
 
 | Variable | Default | Description |
 |---|---|---|
-| `REDIS_URL` | — | Full connection URL; takes precedence over host/port variables. Example: `redis://host:6379/0` |
+| `REDIS_URL` | (none) | Full connection URL; takes precedence over host/port variables. Example: `redis://host:6379/0` |
 | `REDIS_HOST` | `localhost` | Used when `REDIS_URL` is not set |
 | `REDIS_PORT` | `6379` | Used when `REDIS_URL` is not set |
-| `REDIS_PASSWORD` | — | Authentication password |
+| `REDIS_PASSWORD` | (none) | Authentication password |
 | `REDIS_DB` | `0` | Database number |
 | `REDIS_CONTEXT_TTL_DAYS` | `7` | Number of days to retain agent context keys |
 
@@ -114,7 +114,7 @@ Athena provides three-tier persistent memory (STM, MTM, and LTM graph) that span
 
 | Variable | Default | Description |
 |---|---|---|
-| `ATHENA_URL` | — | Athena API base URL, e.g. `http://localhost:8080` |
+| `ATHENA_URL` | (none) | Athena API base URL, e.g. `http://localhost:8080` |
 | `ATHENA_TENANT_ID` | `default` | Tenant namespace for memory isolation across teams or environments |
 | `ATHENA_HTTP_TIMEOUT` | `10.0` | Seconds before an Athena HTTP call times out. Increase if your Athena instance is remote or under load. |
 | `ATHENA_SESSION_TTL_DAYS` | `30` | How long a session ID is cached in Redis before Athena re-issues it. |
@@ -142,7 +142,7 @@ Blob storage is used by agents to persist large outputs (reports, datasets, gene
 |---|---|---|
 | `STORAGE_BACKEND` | `local` | `local` or `azure` |
 | `STORAGE_BASE_PATH` | `./blob_storage` | Base directory path for the local backend |
-| `AZURE_STORAGE_CONNECTION_STRING` | — | Required when `STORAGE_BACKEND=azure` |
+| `AZURE_STORAGE_CONNECTION_STRING` | (none) | Required when `STORAGE_BACKEND=azure` |
 
 For Azure:
 
@@ -159,7 +159,7 @@ AZURE_STORAGE_CONNECTION_STRING=DefaultEndpointsProtocol=https;AccountName=...
 
 ## Search
 
-JarvisCore runs multiple search providers in parallel and merges results. All providers have circuit breakers — a failing provider is skipped automatically. See the [Internet Search guide](../guides/internet-search.md) for provider details, ranking logic, and usage patterns.
+JarvisCore runs multiple search providers in parallel and merges results. All providers have circuit breakers: a failing provider is skipped automatically. See the [Internet Search guide](../guides/internet-search.md) for provider details, ranking logic, and usage patterns.
 
 ### Google Grounded Search <span class="jc-badge jc-badge-primary">Primary</span>
 
@@ -169,14 +169,14 @@ Active automatically when `GEMINI_API_KEY` is set (which is already required for
 |---|---|---|
 | `GEMINI_GROUNDING_API_KEY` | `GEMINI_API_KEY` | Override the key used specifically for grounded search |
 | `GEMINI_GROUNDING_MODEL` | `gemini-2.5-flash` | Gemini model used for grounded search |
-| `GOOGLE_CLOUD_PROJECT` | — | Vertex AI path (alternative to API key) |
+| `GOOGLE_CLOUD_PROJECT` | (none) | Vertex AI path (alternative to API key) |
 | `GOOGLE_CLOUD_LOCATION` | `global` | GCP location for Vertex AI |
 
 ### Serper <span class="jc-badge jc-badge-optional">Optional</span>
 
 | Variable | Default | Description |
 |---|---|---|
-| `SERPER_API_KEY` | — | API key from [serper.dev](https://serper.dev). Provider is skipped if unset. |
+| `SERPER_API_KEY` | (none) | API key from [serper.dev](https://serper.dev). Provider is skipped if unset. |
 
 ### SearXNG <span class="jc-badge jc-badge-optional">Optional</span> <span class="jc-badge jc-badge-free">Self-hosted</span>
 
@@ -215,8 +215,8 @@ Required only when agents call third-party services (GitHub, Slack, Jira, Stripe
 
 | Variable | Default | Description |
 |---|---|---|
-| `NEXUS_GATEWAY_URL` | — | Gateway URL, e.g. `http://localhost:8090` |
-| `NEXUS_BROKER_URL` | — | Broker URL, e.g. `http://localhost:8080`. Used by dashboard and SDK to POST credentials directly to the Broker's `/auth/capture-credential` endpoint for non-OAuth providers. |
+| `NEXUS_GATEWAY_URL` | (none) | Gateway URL, e.g. `http://localhost:8090` |
+| `NEXUS_BROKER_URL` | (none) | Broker URL, e.g. `http://localhost:8080`. Used by dashboard and SDK to POST credentials directly to the Broker's `/auth/capture-credential` endpoint for non-OAuth providers. |
 | `NEXUS_RETURN_URL` | `http://localhost:8000/oauth/callback` | OAuth callback URL; the Nexus broker redirects here after consent. |
 | `NEXUS_DEFAULT_USER_ID` | `jarviscore-agent` | User identity passed to Nexus for credential lookups. |
 | `AUTH_STRATEGY_CACHE_TTL` | `300` | Seconds before the resolved auth strategy is re-fetched from the Gateway. |
@@ -245,7 +245,7 @@ Enables multi-node agent discovery and message routing using the SWIM gossip pro
 | `P2P_ENABLED` | `false` | Activates the SWIM coordinator and ZMQ transport |
 | `JC_SWIM_HOST` | `0.0.0.0` | Bind address; `0.0.0.0` listens on all interfaces |
 | `JC_SWIM_PORT` | `7946` | SWIM gossip port; must be unique per node on the same machine |
-| `JC_SEED_NODES` | — | Comma-separated list of seed node addresses, e.g. `10.0.0.1:7946,10.0.0.2:7946` |
+| `JC_SEED_NODES` | (none) | Comma-separated list of seed node addresses, e.g. `10.0.0.1:7946,10.0.0.2:7946` |
 
 !!! warning "Port uniqueness"
     `JC_SWIM_PORT` must be different for each node running on the same machine. The ZMQ data port is set automatically to `JC_SWIM_PORT + 1000`.

--- a/jarviscore/docs/reference/index.md
+++ b/jarviscore/docs/reference/index.md
@@ -42,6 +42,6 @@ Complete API reference, configuration options, CLI commands, and troubleshooting
 
     Release history, version notes, and upgrade guides.
 
-    [Read more →](../CHANGELOG.md)
+    [Read more →](../changelog.md)
 
 </div>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
 site_name: JarvisCore
-site_description: Orchestrate multi-agent systems with peer-to-peer coordination, unified memory, and built-in auth.
+site_description: Open source Python framework for building autonomous multi-agent AI systems in production. Peer-to-peer agent orchestration, persistent memory, zero-trust auth, and full observability.
 site_url: https://jarviscore.developers.prescottdata.io/
 repo_url: https://github.com/Prescott-Data/jarviscore-framework
 repo_name: Prescott-Data/jarviscore-framework


### PR DESCRIPTION
## What

Rewrites the doc-site landing page and tightens getting-started, so the value proposition and differentiation land in the first screen instead of paragraph six.

## Landing page

- Hero now states the position only we can honestly take: "Agents that survive production", backed by the fact that we operate our own agents unattended on this framework and every hardening release traces to those incidents.
- New "Why JarvisCore" section carries the three differentiators as plain claims a reader can test against the code:
  1. Honest context: truncation is lossiness; clips are labeled, originals archived, summaries say what they summarize.
  2. Loud failures: failed steps say so, evaluators see full evidence, partial work survives failed goals, rate-limit storms are absorbed.
  3. Two profiles, no mushy middle: CustomAgent infrastructure shell vs the full AutoAgent cognitive stack.
- Stats row leads with what a first-time visitor cares about (one key to first agent, zero silent truncations, unattended operation) before ecosystem counts.

## Getting started

The docs used `mesh.run_task` in one place and `mesh.workflow` in another without saying which to reach for. New "Two Ways to Run" section states the rule plainly: `run_task` for single asks and hand-rolled pipelines, `workflow` the moment steps belong together.

## House style

No em dashes remain on either page.
