### PR TITLE
fix: import jarviscore is silent - stop swim-p2p announcing on stdout

### DIFF
--- a/jarviscore/p2p/__init__.py
+++ b/jarviscore/p2p/__init__.py
@@ -9,13 +9,23 @@ Wraps swim_p2p library for distributed agent coordination:
 - PeerClient for direct agent-to-agent communication
 """
 
-from .coordinator import P2PCoordinator
-from .swim_manager import SWIMThreadManager
 from .keepalive import P2PKeepaliveManager, CircuitState
 from .broadcaster import StepOutputBroadcaster, StepExecutionResult
 from .peer_client import PeerClient
 from .peer_tool import PeerTool
 from .messages import PeerInfo, IncomingMessage, MessageType
+
+_LAZY = {"P2PCoordinator": ".coordinator", "SWIMThreadManager": ".swim_manager"}
+
+
+def __getattr__(name):
+    # swim-p2p prints to stdout at import; load it only when P2P is actually used
+    if name in _LAZY:
+        import importlib
+
+        module = importlib.import_module(_LAZY[name], __name__)
+        return getattr(module, name)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 __all__ = [
     'P2PCoordinator',

--- a/jarviscore/p2p/swim_manager.py
+++ b/jarviscore/p2p/swim_manager.py
@@ -7,19 +7,24 @@ Adapted from an earlier internal agent codebase/src/swim_thread_manager.py
 - Kept core functionality identical
 """
 import asyncio
+import contextlib
+import io
 import logging
 import threading
-import time
 from typing import Optional
 
-from swim.transport.hybrid import HybridTransport
-from swim.protocol.node import Node
-from swim.config import get_config as get_swim_config, validate_config as validate_swim_config
-from swim.events.dispatcher import EventDispatcher
-from swim.integration.agent import ZMQAgentIntegration
-from swim.main import SWIMZMQBridge, parse_address as swim_parse_address
+# swim-p2p announces itself on stdout at import; a library must stay quiet
+with contextlib.redirect_stdout(io.StringIO()) as _swim_import_noise:
+    from swim.transport.hybrid import HybridTransport
+    from swim.protocol.node import Node
+    from swim.config import get_config as get_swim_config, validate_config as validate_swim_config
+    from swim.events.dispatcher import EventDispatcher
+    from swim.integration.agent import ZMQAgentIntegration
+    from swim.main import SWIMZMQBridge, parse_address as swim_parse_address
 
 logger = logging.getLogger(__name__)
+if _swim_import_noise.getvalue():
+    logger.debug("swim-p2p import output: %s", _swim_import_noise.getvalue().strip())
 
 
 class SWIMThreadManager:

--- a/tests/test_import_hygiene.py
+++ b/tests/test_import_hygiene.py
@@ -1,0 +1,37 @@
+"""Import hygiene: a library must not write to stdout when imported."""
+
+import subprocess
+import sys
+
+
+def test_importing_jarviscore_prints_nothing():
+    proc = subprocess.run(
+        [sys.executable, "-c", "import jarviscore"],
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    assert proc.returncode == 0, proc.stderr
+    assert proc.stdout == "", f"import jarviscore wrote to stdout: {proc.stdout!r}"
+
+
+def test_p2p_lazy_exports_still_resolve():
+    from jarviscore.p2p import PeerClient  # eager, swim-free
+
+    assert PeerClient.__name__ == "PeerClient"
+
+    import jarviscore.p2p as p2p
+
+    coordinator = p2p.P2PCoordinator  # lazy, loads swim on first touch
+    manager = p2p.SWIMThreadManager
+    assert coordinator.__name__ == "P2PCoordinator"
+    assert manager.__name__ == "SWIMThreadManager"
+
+
+def test_p2p_unknown_attribute_raises():
+    import pytest
+
+    import jarviscore.p2p as p2p
+
+    with pytest.raises(AttributeError):
+        p2p.DoesNotExist


### PR DESCRIPTION
Plain `import jarviscore` printed four 'module loaded' lines from swim-p2p's import-time print() calls, in every first script, demo, and captured pipeline. P2P is an optional extra and now loads lazily (PEP 562) on first touch of P2PCoordinator or SWIMThreadManager; swim's import chatter is captured and forwarded to debug logging at the one real import site. Regression test runs `import jarviscore` in a subprocess and asserts empty stdout. The 10 failures in the p2p test selection reproduce identically on pristine main and are unrelated.