### PR TITLE
fix: jarviscore init works from a fresh clone and starts minimal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,8 +45,8 @@ htmlcov/
 .dmypy.json
 dmypy.json
 
-# Event store data (local dev)
-data/
+# Event store data (local dev): root only. jarviscore/data/ is packaged source
+/data/
 *.jsonl
 
 # Environment variables

--- a/jarviscore/cli/scaffold.py
+++ b/jarviscore/cli/scaffold.py
@@ -29,19 +29,20 @@ def get_data_path() -> Path:
         return Path(jarviscore.data.__file__).parent
 
 
-def copy_env_example(dest_dir: Path, force: bool = False) -> bool:
+def copy_env_example(dest_dir: Path, force: bool = False, full: bool = False) -> bool:
     """
-    Copy .env.example to destination directory.
+    Copy the env template to the destination directory.
 
     Args:
         dest_dir: Destination directory
         force: Overwrite if exists
+        full: Copy the complete reference template instead of the minimal one
 
     Returns:
         True if copied, False if skipped
     """
     data_path = get_data_path()
-    src = data_path / '.env.example'
+    src = data_path / ('.env.example' if full else '.env.minimal')
     dest = dest_dir / '.env.example'
 
     if not src.exists():
@@ -53,7 +54,8 @@ def copy_env_example(dest_dir: Path, force: bool = False) -> bool:
         return False
 
     shutil.copy2(src, dest)
-    print(f"✓ Created {dest.name}")
+    label = 'full reference' if full else 'minimal; run with --full for every option'
+    print(f"✓ Created {dest.name} ({label})")
     return True
 
 
@@ -77,7 +79,7 @@ def copy_examples(dest_dir: Path, force: bool = False) -> bool:
         return False
 
     if dest.exists() and not force:
-        print(f"⚠ examples/ directory already exists (use --force to overwrite)")
+        print("⚠ examples/ directory already exists (use --force to overwrite)")
         return False
 
     if dest.exists() and force:
@@ -138,6 +140,11 @@ def main():
         help='Also copy example agent files'
     )
     parser.add_argument(
+        '--full',
+        action='store_true',
+        help='Write the complete configuration reference instead of the minimal template'
+    )
+    parser.add_argument(
         '--force',
         action='store_true',
         help='Overwrite existing files'
@@ -159,7 +166,7 @@ def main():
     dest_dir.mkdir(parents=True, exist_ok=True)
 
     # Copy files
-    env_created = copy_env_example(dest_dir, args.force)
+    env_created = copy_env_example(dest_dir, args.force, full=args.full)
 
     examples_created = False
     if args.examples:

--- a/jarviscore/data/.env.example
+++ b/jarviscore/data/.env.example
@@ -1,0 +1,129 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# JarvisCore .env.example
+#
+# Copy this file to .env and fill in the values for your setup.
+# Only ONE LLM provider is required to get started.
+# All other settings are optional and have sensible defaults.
+#
+# Quick start:
+#   cp .env.example .env
+#   # Fill in ONE of the LLM sections below
+#   python -m jarviscore.cli check --validate-llm
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+# ═══════════════════════════════════════════════════════════════
+# LLM PROVIDERS  (configure at least one)
+# ═══════════════════════════════════════════════════════════════
+
+# ── Option A: Azure OpenAI ───────────────────────────────────
+# AZURE_API_KEY=your-azure-openai-key
+# AZURE_ENDPOINT=https://your-resource.openai.azure.com/
+# AZURE_DEPLOYMENT=gpt-4o                  # your deployment name
+# AZURE_API_VERSION=2024-02-15-preview
+
+# ── Option B: Anthropic Claude ──────────────────────────────
+# CLAUDE_API_KEY=sk-ant-...
+# CLAUDE_MODEL=claude-sonnet-4             # or claude-opus-4
+
+# ── Option C: Google Gemini ──────────────────────────────────
+# GEMINI_API_KEY=AIza...
+# GEMINI_MODEL=gemini-2.0-flash
+
+# ── Option D: Local / vLLM ───────────────────────────────────
+# LLM_ENDPOINT=http://localhost:8000       # OpenAI-compatible endpoint
+# LLM_MODEL=your-model-name
+
+
+# ═══════════════════════════════════════════════════════════════
+# MODEL ROUTING  (optional — multi-tier routing)
+# ═══════════════════════════════════════════════════════════════
+# Override per-complexity tier. Falls back to AZURE_DEPLOYMENT / CLAUDE_MODEL
+# if not set. Pass complexity= in workflow tasks to use these.
+#
+# TASK_MODEL_NANO=gpt-4o-mini             # fast, cheap — classify / summarise
+# TASK_MODEL_STANDARD=gpt-4o             # general tasks (default tier)
+# TASK_MODEL_HEAVY=gpt-4o                # deep reasoning, long context
+# CODING_MODEL=gpt-4o                    # code generation (coder subagent)
+
+
+# ═══════════════════════════════════════════════════════════════
+# REDIS  (optional — enables distributed workflows + durable state)
+# ═══════════════════════════════════════════════════════════════
+# Without Redis, JarvisCore runs in-process with local routing.
+# With Redis, agents share state, mailboxes, and telemetry across processes.
+#
+# REDIS_URL=redis://localhost:6379/0      # takes precedence over host/port
+# REDIS_HOST=localhost
+# REDIS_PORT=6379
+# REDIS_PASSWORD=
+# REDIS_DB=0
+
+
+# ═══════════════════════════════════════════════════════════════
+# MEMORY / ATHENA  (optional — persistent cross-session memory)
+# ═══════════════════════════════════════════════════════════════
+# Athena is the full three-tier memory backend (STM → MTM → LTM graph).
+# When not set, agents use Redis-only episodic memory (good for most cases).
+#
+# ATHENA_URL=http://localhost:8080
+# ATHENA_TENANT_ID=default
+
+
+# ═══════════════════════════════════════════════════════════════
+# SEARCH  (optional — enables internet search for ResearcherSubAgent)
+# ═══════════════════════════════════════════════════════════════
+# Gemini Grounded Search is the primary provider (set GEMINI_API_KEY above).
+# Serper is a secondary fallback via serper.dev.
+#
+# SERPER_API_KEY=your-serper-key
+
+
+# ═══════════════════════════════════════════════════════════════
+# BROWSER  (optional — enables web automation via BrowserSubAgent)
+# ═══════════════════════════════════════════════════════════════
+# Requires: pip install jarviscore-framework[browser]
+# and: playwright install chromium
+#
+# BROWSER_ENABLED=false
+# BROWSER_HEADLESS=true
+
+
+# ═══════════════════════════════════════════════════════════════
+# NEXUS AUTH  (optional — enables OAuth + credential management)
+# ═══════════════════════════════════════════════════════════════
+# Required only when agents need to call third-party services (GitHub,
+# Jira, Slack, etc.) via the Nexus credential gateway.
+#
+# NEXUS_GATEWAY_URL=http://localhost:7070
+# NEXUS_RETURN_URL=http://localhost:8000/oauth/callback
+
+
+# ═══════════════════════════════════════════════════════════════
+# P2P / SWIM  (optional — multi-node agent mesh)
+# ═══════════════════════════════════════════════════════════════
+# Enables the SWIM gossip protocol + ZMQ transport so agents on
+# separate machines can discover and communicate with each other.
+# Requires Redis (above). Each node must have a unique JC_SWIM_PORT.
+#
+# P2P_ENABLED=false
+# JC_SWIM_HOST=0.0.0.0          # bind address (0.0.0.0 = all interfaces)
+# JC_SWIM_PORT=7946              # unique per node — ZMQ port = this + 1000
+# JC_SEED_NODES=192.168.1.10:7946,192.168.1.11:7946   # peer addresses
+
+
+# ═══════════════════════════════════════════════════════════════
+# KERNEL TUNING  (optional — advanced)
+# ═══════════════════════════════════════════════════════════════
+# KERNEL_MAX_TURNS=30
+# SANDBOX_MODE=local                      # "local" or "remote"
+# HITL_ENABLED=false
+# HITL_MAX_CONFIDENCE=0.8
+# MAX_GOAL_STEPS=10                       # step ceiling for goal_oriented agents
+# MAX_REPLAN_ATTEMPTS=3                   # max replanning cycles before failure
+
+
+# ═══════════════════════════════════════════════════════════════
+# LOGGING
+# ═══════════════════════════════════════════════════════════════
+# LOG_LEVEL=INFO                          # DEBUG | INFO | WARNING | ERROR

--- a/jarviscore/data/.env.minimal
+++ b/jarviscore/data/.env.minimal
@@ -1,0 +1,35 @@
+# JarvisCore configuration
+# Copy to .env and set ONE provider. Everything else is optional.
+# Full reference: jarviscore init --full, or docs: reference/configuration.md
+
+# --- Pick one LLM provider ---------------------------------------
+
+# Anthropic Claude
+# CLAUDE_API_KEY=your-anthropic-api-key
+# CLAUDE_MODEL=claude-sonnet-4
+
+# Azure OpenAI
+# AZURE_API_KEY=your-azure-openai-key
+# AZURE_ENDPOINT=https://your-resource.openai.azure.com
+# AZURE_DEPLOYMENT=gpt-4o
+
+# Google Gemini
+# GEMINI_API_KEY=your-gemini-api-key
+# GEMINI_MODEL=gemini-2.0-flash
+
+# vLLM / local
+# LLM_ENDPOINT=http://localhost:8000
+# LLM_MODEL=Qwen/Qwen2.5-Coder-32B-Instruct
+
+# --- Common optional add-ons -------------------------------------
+
+# Redis: distributed workflows, cross-session state, peer routing
+# REDIS_URL=redis://localhost:6379
+
+# Athena MemOS: cross-session semantic memory (memory tier 4)
+# ATHENA_URL=http://localhost:8080
+
+# P2P mesh across machines (pip install "jarviscore-framework[p2p]")
+# P2P_ENABLED=true
+
+# Verify your setup: jarviscore check --validate-llm

--- a/jarviscore/data/__init__.py
+++ b/jarviscore/data/__init__.py
@@ -1,0 +1,2 @@
+# JarvisCore data package
+# Provides bundled resources: .env.example, quickstart templates.

--- a/tests/test_cli_scaffold.py
+++ b/tests/test_cli_scaffold.py
@@ -1,0 +1,51 @@
+"""Tests for jarviscore init: minimal-first env scaffolding."""
+
+from pathlib import Path
+
+from jarviscore.cli.scaffold import copy_env_example, get_data_path
+
+
+def test_packaged_templates_exist_and_are_tracked():
+    data = get_data_path()
+    assert (data / ".env.minimal").exists()
+    assert (data / ".env.example").exists()
+
+
+def test_default_init_writes_the_minimal_template(tmp_path):
+    assert copy_env_example(tmp_path, force=False) is True
+    content = (tmp_path / ".env.example").read_text()
+    lines = content.splitlines()
+    assert len(lines) < 50, f"minimal template grew to {len(lines)} lines"
+    for provider_key in ("CLAUDE_API_KEY", "AZURE_API_KEY", "GEMINI_API_KEY", "LLM_ENDPOINT"):
+        assert provider_key in content
+    assert "--full" in content       # points at the full reference
+
+
+def test_full_flag_writes_the_complete_reference(tmp_path):
+    assert copy_env_example(tmp_path, force=False, full=True) is True
+    content = (tmp_path / ".env.example").read_text()
+    assert len(content.splitlines()) > 100
+    assert "P2P" in content
+
+
+def test_existing_file_is_not_overwritten_without_force(tmp_path):
+    (tmp_path / ".env.example").write_text("mine")
+    assert copy_env_example(tmp_path, force=False) is False
+    assert (tmp_path / ".env.example").read_text() == "mine"
+    assert copy_env_example(tmp_path, force=True) is True
+    assert (tmp_path / ".env.example").read_text() != "mine"
+
+
+def test_minimal_template_has_no_em_dashes():
+    data = get_data_path()
+    assert "\u2014" not in (data / ".env.minimal").read_text()
+
+
+def test_templates_resolve_from_repo_checkout():
+    # get_data_path must resolve inside the source tree so fresh clones work
+    data = get_data_path()
+    assert (data / "__init__.py").exists(), (
+        "jarviscore/data is missing from the checkout: the directory was "
+        "gitignored by an unanchored 'data/' pattern"
+    )
+    assert Path(str(data)).name == "data"


### PR DESCRIPTION
Two problems, one root cause surfaced while splitting the env template.

**Fresh-clone bug.** An unanchored `data/` in .gitignore (meant for the local event store) also ignored `jarviscore/data/`. The packaged `.env.example` and the data package `__init__` were never tracked, so on a fresh clone `jarviscore init` prints "Source file not found", and `data/examples` (declared in package-data) silently never ships in wheels built from clean checkouts. The pattern is now anchored to the repo root and `jarviscore/data/` is tracked.

**Minimal-first init.** `jarviscore init` now writes a 35-line template: pick one provider, three common add-ons (Redis, Athena, P2P), and a pointer to the full reference. `jarviscore init --full` writes the complete reference as before.

**Known drift, out of scope:** the repo-root `.env.example` (221 lines) and the packaged one (129 lines) have diverged; consolidation is a follow-up issue.

6 tests in `tests/test_cli_scaffold.py`. Smoke-tested both paths from an empty directory.