### PR TITLE
feat: local memory tier - agents remember without infrastructure

### DIFF
--- a/jarviscore/memory/local_memory.py
+++ b/jarviscore/memory/local_memory.py
@@ -1,0 +1,211 @@
+"""
+LocalMemory: the zero-infrastructure cross-session memory tier.
+
+Same surface as AthenaMemory, backed by a single SQLite file. No Go
+stack, no Docker, no Redis. Set ATHENA_URL and the kernel upgrades to
+Athena MemOS with no code changes; until then, agents still remember
+across restarts.
+
+Persistence is deliberate and loud: the location is announced once at
+init (default ./.jarviscore/memory.db, override with
+JARVISCORE_MEMORY_PATH, disable with JARVISCORE_MEMORY_PATH=off).
+
+Search is keyword-overlap ranking, not embeddings. It is honest about
+that: results carry match_type="keyword" so callers and readers never
+mistake it for semantic recall.
+"""
+
+import asyncio
+import contextlib
+import json
+import logging
+import os
+import sqlite3
+import time
+import uuid
+from pathlib import Path
+from typing import Any, Dict, Iterator, List, Optional
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_PATH = os.path.join(".jarviscore", "memory.db")
+
+_SCHEMA = """
+CREATE TABLE IF NOT EXISTS sessions (
+    session_id TEXT PRIMARY KEY,
+    agent_id   TEXT NOT NULL,
+    created_at REAL NOT NULL,
+    metadata   TEXT NOT NULL DEFAULT '{}'
+);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_sessions_agent ON sessions(agent_id);
+CREATE TABLE IF NOT EXISTS events (
+    id         INTEGER PRIMARY KEY AUTOINCREMENT,
+    session_id TEXT NOT NULL,
+    role       TEXT NOT NULL,
+    type       TEXT NOT NULL,
+    content    TEXT NOT NULL,
+    metadata   TEXT NOT NULL DEFAULT '{}',
+    created_at REAL NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_events_session ON events(session_id, id);
+"""
+
+
+class LocalMemory:
+    """Cross-session agent memory in one SQLite file. AthenaMemory-compatible."""
+
+    def __init__(self, agent_id: str, session_id: str, db_path: str) -> None:
+        self._agent_id = agent_id
+        self._session_id = session_id
+        self._db_path = db_path
+
+    # ── Factory ──────────────────────────────────────────────────────────────
+
+    @classmethod
+    async def create(
+        cls,
+        agent_id: str,
+        db_path: Optional[str] = None,
+        metadata: Optional[Dict[str, str]] = None,
+    ) -> "LocalMemory":
+        """Create or reuse the durable session for this agent."""
+        path = db_path or os.environ.get("JARVISCORE_MEMORY_PATH") or DEFAULT_PATH
+        Path(path).parent.mkdir(parents=True, exist_ok=True)
+
+        def _init() -> str:
+            with cls._connect(path) as conn:
+                conn.executescript(_SCHEMA)
+                row = conn.execute(
+                    "SELECT session_id FROM sessions WHERE agent_id = ?", (agent_id,)
+                ).fetchone()
+                if row:
+                    return row[0]
+                session_id = f"local-{uuid.uuid4().hex[:12]}"
+                conn.execute(
+                    "INSERT INTO sessions (session_id, agent_id, created_at, metadata) "
+                    "VALUES (?, ?, ?, ?)",
+                    (session_id, agent_id, time.time(), json.dumps(metadata or {})),
+                )
+                return session_id
+
+        session_id = await asyncio.to_thread(_init)
+        logger.info(
+            "[LocalMemory] ready: agent=%s session=%s path=%s "
+            "(set ATHENA_URL for cross-session semantic memory)",
+            agent_id, session_id, path,
+        )
+        return cls(agent_id=agent_id, session_id=session_id, db_path=path)
+
+    @staticmethod
+    @contextlib.contextmanager
+    def _connect(path: str) -> Iterator[sqlite3.Connection]:
+        """Commit on success, roll back on error, always close."""
+        conn = sqlite3.connect(path, timeout=10.0)
+        try:
+            conn.execute("PRAGMA journal_mode=WAL")
+            with conn:
+                yield conn
+        finally:
+            conn.close()
+
+    # ── Write helpers (AthenaMemory surface) ─────────────────────────────────
+
+    async def record_thought(
+        self, content: str, metadata: Optional[Dict[str, str]] = None
+    ) -> None:
+        await self._store("agent", "thought", content, metadata)
+
+    async def record_action(
+        self, content: str, metadata: Optional[Dict[str, str]] = None
+    ) -> None:
+        await self._store("agent", "action", content, metadata)
+
+    async def record_observation(
+        self, content: str, metadata: Optional[Dict[str, str]] = None
+    ) -> None:
+        await self._store("agent", "observation", content, metadata)
+
+    async def _store(
+        self, role: str, type_: str, content: str, metadata: Optional[Dict[str, str]]
+    ) -> None:
+        meta = json.dumps({"agent_id": self._agent_id, **(metadata or {})})
+
+        def _write() -> None:
+            with self._connect(self._db_path) as conn:
+                conn.execute(
+                    "INSERT INTO events (session_id, role, type, content, metadata, created_at) "
+                    "VALUES (?, ?, ?, ?, ?, ?)",
+                    (self._session_id, role, type_, content, meta, time.time()),
+                )
+
+        await asyncio.to_thread(_write)
+
+    # ── Read helpers (AthenaMemory surface) ──────────────────────────────────
+
+    async def get_memory_context(self, limit: int = 20) -> Dict[str, Any]:
+        """Recent events, shaped like Athena's context payload.
+
+        mtm_chains is always empty: consolidation is Athena's job, and
+        pretending otherwise here would be a lie.
+        """
+
+        def _read() -> List[Dict[str, Any]]:
+            with self._connect(self._db_path) as conn:
+                rows = conn.execute(
+                    "SELECT role, type, content, metadata, created_at FROM events "
+                    "WHERE session_id = ? ORDER BY id DESC LIMIT ?",
+                    (self._session_id, limit),
+                ).fetchall()
+            return [
+                {
+                    "role": r[0], "type": r[1], "content": r[2],
+                    "metadata": json.loads(r[3]), "created_at": r[4],
+                }
+                for r in reversed(rows)
+            ]
+
+        events = await asyncio.to_thread(_read)
+        return {"stm_events": events, "mtm_chains": [], "heat_score": 0.0}
+
+    async def search(self, query: str, limit: int = 5) -> List[Dict[str, Any]]:
+        """Keyword-overlap search. Labeled as such: this is not semantic recall."""
+        terms = {t for t in query.lower().split() if len(t) > 2}
+        if not terms:
+            return []
+
+        def _read() -> List[Dict[str, Any]]:
+            with self._connect(self._db_path) as conn:
+                rows = conn.execute(
+                    "SELECT content, type, created_at FROM events "
+                    "WHERE session_id = ? ORDER BY id DESC LIMIT 2000",
+                    (self._session_id,),
+                ).fetchall()
+            scored = []
+            for content, type_, created_at in rows:
+                words = set(content.lower().split())
+                overlap = len(terms & words)
+                if overlap:
+                    scored.append(
+                        {
+                            "content": content,
+                            "type": type_,
+                            "created_at": created_at,
+                            "similarity_score": overlap / len(terms),
+                            "match_type": "keyword",
+                        }
+                    )
+            scored.sort(key=lambda x: x["similarity_score"], reverse=True)
+            return scored[:limit]
+
+        return await asyncio.to_thread(_read)
+
+    async def get_heat(self) -> Dict[str, Any]:
+        return {"heat_score": 0.0, "backend": "local"}
+
+    @property
+    def session_id(self) -> str:
+        return self._session_id
+
+    @property
+    def agent_id(self) -> str:
+        return self._agent_id

--- a/jarviscore/memory/unified.py
+++ b/jarviscore/memory/unified.py
@@ -12,6 +12,7 @@ Tier availability:
   neither               → all writes are no-ops (pure in-memory run)
 """
 import logging
+import os
 import time
 from typing import Any, Dict, Optional
 
@@ -69,18 +70,23 @@ class UnifiedMemory:
             if (redis_store and blob_storage) else None
         )
 
-        # ── Tier 4: Athena MemOS (optional) ──────────────────────────────────
-        # AthenaMemory bridges this session to Athena's STM/MTM/LTM pipeline.
-        # Created lazily via AthenaMemory.create() (async) the first time
-        # get_athena_memory() is awaited. Stored after first creation.
+        # ── Tier 4: cross-session memory (Athena MemOS or local SQLite) ─────
+        # Athena when ATHENA_URL is configured; otherwise a local SQLite file
+        # so agents remember across restarts with zero infrastructure.
+        # Disable entirely with JARVISCORE_MEMORY_PATH=off. Created lazily on
+        # first awaited access.
         self._athena_client = athena_client              # the HTTP client
-        self._athena_memory = None                       # AthenaMemory instance (set lazily)
+        self._athena_memory = None                       # tier-4 instance (set lazily)
+        self._tier4_disabled = (
+            athena_client is None
+            and os.environ.get("JARVISCORE_MEMORY_PATH", "").lower() == "off"
+        )
 
         tiers = [
             "scratchpad" if self.working else None,
             "episodic" if self.episodic else None,
             "ltm" if self.ltm else None,
-            "athena" if athena_client else None,
+            "athena" if athena_client else (None if self._tier4_disabled else "local"),
         ]
         active = [t for t in tiers if t]
         logger.info(
@@ -89,11 +95,19 @@ class UnifiedMemory:
         )
 
     async def _get_athena_memory(self):
-        """Lazy init: create AthenaMemory on first access. Thread-safe for async."""
+        """Lazy init of the tier-4 backend: Athena when configured, local otherwise."""
         if self._athena_memory is not None:
             return self._athena_memory
-        if self._athena_client is None:
+        if self._tier4_disabled:
             return None
+        if self._athena_client is None:
+            try:
+                from .local_memory import LocalMemory
+                self._athena_memory = await LocalMemory.create(agent_id=self._agent)
+            except Exception as exc:
+                logger.warning("[UnifiedMemory] local memory init failed (non-fatal): %s", exc)
+                self._tier4_disabled = True   # do not retry on every turn
+            return self._athena_memory
         try:
             from .athena_memory import AthenaMemory
             self._athena_memory = await AthenaMemory.create(
@@ -104,6 +118,7 @@ class UnifiedMemory:
         except Exception as exc:
             logger.warning("[UnifiedMemory] Athena init failed (non-fatal): %s", exc)
             self._athena_client = None   # disable so we don't retry on every turn
+            self._tier4_disabled = True
         return self._athena_memory
 
 

--- a/tests/test_local_memory.py
+++ b/tests/test_local_memory.py
@@ -1,0 +1,95 @@
+"""Tests for LocalMemory: the zero-infrastructure tier-4 backend."""
+
+import asyncio
+
+import pytest
+
+from jarviscore.memory.local_memory import LocalMemory
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+@pytest.fixture
+def db(tmp_path):
+    return str(tmp_path / "memory.db")
+
+
+def test_session_survives_restart(db):
+    async def scenario():
+        first = await LocalMemory.create("researcher", db_path=db)
+        await first.record_thought("btc looked bearish on H4")
+        # simulate a process restart: brand-new instance, same file
+        second = await LocalMemory.create("researcher", db_path=db)
+        assert second.session_id == first.session_id
+        ctx = await second.get_memory_context()
+        return ctx
+
+    ctx = _run(scenario())
+    assert len(ctx["stm_events"]) == 1
+    assert "bearish" in ctx["stm_events"][0]["content"]
+    assert ctx["mtm_chains"] == []          # consolidation is Athena's job
+
+
+def test_agents_get_isolated_sessions(db):
+    async def scenario():
+        a = await LocalMemory.create("scout", db_path=db)
+        b = await LocalMemory.create("analyst", db_path=db)
+        await a.record_action("scouted example.com")
+        return a, b, await b.get_memory_context()
+
+    a, b, b_ctx = _run(scenario())
+    assert a.session_id != b.session_id
+    assert b_ctx["stm_events"] == []
+
+
+def test_event_types_and_order(db):
+    async def scenario():
+        m = await LocalMemory.create("worker", db_path=db)
+        await m.record_thought("plan the report")
+        await m.record_action("wrote section one")
+        await m.record_observation("section one approved")
+        return await m.get_memory_context()
+
+    ctx = _run(scenario())
+    types = [e["type"] for e in ctx["stm_events"]]
+    assert types == ["thought", "action", "observation"]   # chronological
+
+
+def test_search_is_keyword_ranked_and_labeled(db):
+    async def scenario():
+        m = await LocalMemory.create("worker", db_path=db)
+        await m.record_thought("vector databases comparison for retrieval")
+        await m.record_thought("lunch options near the office")
+        return await m.search("vector retrieval comparison")
+
+    results = _run(scenario())
+    assert results
+    assert "vector" in results[0]["content"]
+    assert results[0]["match_type"] == "keyword"    # honest about not being semantic
+    assert 0 < results[0]["similarity_score"] <= 1
+
+
+def test_unified_memory_falls_back_to_local(tmp_path, monkeypatch):
+    from jarviscore.memory.unified import UnifiedMemory
+
+    monkeypatch.setenv("JARVISCORE_MEMORY_PATH", str(tmp_path / "m.db"))
+    um = UnifiedMemory(
+        workflow_id="wf", step_id="s1", agent_id="researcher",
+        redis_store=None, blob_storage=None, athena_client=None,
+    )
+    tier4 = _run(um._get_athena_memory())
+    assert tier4 is not None
+    assert type(tier4).__name__ == "LocalMemory"
+
+
+def test_tier4_off_switch(monkeypatch):
+    from jarviscore.memory.unified import UnifiedMemory
+
+    monkeypatch.setenv("JARVISCORE_MEMORY_PATH", "off")
+    um = UnifiedMemory(
+        workflow_id="wf", step_id="s1", agent_id="researcher",
+        redis_store=None, blob_storage=None, athena_client=None,
+    )
+    assert _run(um._get_athena_memory()) is None


### PR DESCRIPTION
Tier-4 memory previously required deploying Athena MemOS before an agent could remember anything across restarts. LocalMemory closes the gap: the AthenaMemory surface backed by one SQLite file, chosen automatically by UnifiedMemory's tier-4 resolver when ATHENA_URL is not configured. Kernel and call sites unchanged; upgrading to Athena is one env var.

Deliberate choices:
- Persist by default, loudly: `./.jarviscore/memory.db`, announced once at init. Override `JARVISCORE_MEMORY_PATH`, disable with `JARVISCORE_MEMORY_PATH=off`.
- Honest about limits: search is keyword-overlap and labeled `match_type=keyword`; `mtm_chains` stays empty because consolidation is Athena's job.
- Per-agent session isolation, stable session ids across restarts, WAL, connections closed via context manager, writes off the event loop.

6 new tests; the 122 memory-adjacent tests pass unchanged.