### PR TITLE
memory: init pulls the published Athena image, no clone required

### DIFF
--- a/jarviscore/cli/memory.py
+++ b/jarviscore/cli/memory.py
@@ -21,6 +21,7 @@ import asyncio
 import json
 import os
 import sys
+from pathlib import Path
 from typing import Optional
 
 
@@ -111,7 +112,7 @@ async def cmd_context(args: argparse.Namespace) -> None:
         _err("ATHENA_URL is not set. Run 'jarviscore memory up' for setup instructions.")
         sys.exit(1)
 
-    from jarviscore.memory import get_athena_client, AthenaMemory
+    from jarviscore.memory import get_athena_client
 
     client = get_athena_client()
     if not client:
@@ -275,17 +276,21 @@ def _pick_llm_key() -> tuple[str, str]:
     return "gemini", "", "gemini-2.0-flash"
 
 
-def cmd_init(_args: argparse.Namespace) -> None:
+def cmd_init(args: argparse.Namespace) -> None:
     """
     One-command Athena setup — same philosophy as 'jarviscore nexus init'.
 
-    1. Find the Athena source repo (~/athena or ATHENA_DIR)
-    2. Pick an LLM API key from the existing environment
-    3. Build + start all 7 services via docker compose
-    4. Wait for Athena to be healthy (up to 90s — Milvus is slow)
-    5. Write ATHENA_URL to the project .env
+    1. Pick an LLM API key from the existing environment
+    2. Pull + start all 7 services via docker compose
+       (--from-source builds Athena from a local clone instead)
+    3. Wait for Athena to be healthy (up to 90s — Milvus is slow)
+    4. Write ATHENA_URL to the project .env
     """
-    import shutil, subprocess, time, urllib.request, urllib.error
+    import shutil
+    import subprocess
+    import time
+    import urllib.error
+    import urllib.request
 
     _banner("JarvisCore — Athena MemOS Init", "═")
 
@@ -293,47 +298,57 @@ def cmd_init(_args: argparse.Namespace) -> None:
         _err("Docker not found. Install Docker Desktop: https://www.docker.com/products/docker-desktop")
         sys.exit(1)
 
-    # 1. Find Athena source
-    athena_dir = _find_athena_repo()
-    if not athena_dir:
-        _err("Athena source repo not found.")
-        print()
-        print("  Clone the Athena repo first:")
-        print("    git clone https://github.com/Prescott-Data/athena ~/athena")
-        print()
-        print("  Or set ATHENA_DIR to point at an existing clone:")
-        print("    export ATHENA_DIR=/path/to/athena")
-        print()
-        print("  Then re-run:  jarviscore memory init")
-        print()
-        sys.exit(1)
+    from_source = bool(getattr(args, "from_source", False))
+    athena_dir = None
+    if from_source:
+        athena_dir = _find_athena_repo()
+        if not athena_dir:
+            _err("--from-source needs an Athena clone.")
+            print()
+            print("  Clone the Athena repo first:")
+            print("    git clone https://github.com/Prescott-Data/athena ~/athena")
+            print()
+            print("  Or set ATHENA_DIR to point at an existing clone:")
+            print("    export ATHENA_DIR=/path/to/athena")
+            print()
+            sys.exit(1)
+        print(f"  ✅  Athena source: {athena_dir}")
+    else:
+        print("  ✅  Athena image: ghcr.io/prescott-data/athena:latest")
 
-    print(f"  ✅  Athena source: {athena_dir}")
-
-    # 2. Pick LLM key
+    # LLM key
     provider, llm_key, model = _pick_llm_key()
     if not llm_key:
         _err("No LLM API key found. Set one of: GEMINI_API_KEY, OPENAI_API_KEY, ANTHROPIC_API_KEY")
         sys.exit(1)
     print(f"  ✅  LLM: {provider} / {model}")
 
-    # 3. Prepare env for compose
+    # Prepare env for compose
     env = {
         **os.environ,
-        "ATHENA_BUILD_CONTEXT": str(athena_dir),
         "ATHENA_LLM_API_KEY":   llm_key,
         "ATHENA_LLM_PROVIDER":  provider,
         "ATHENA_LLM_MODEL":     model,
     }
+    compose_cmd = ["docker", "compose", "-f", None, "up", "-d"]
+    if from_source:
+        env["ATHENA_BUILD_CONTEXT"] = str(athena_dir)
+        env["ATHENA_IMAGE"] = "athena-memos:local"
+        compose_cmd.append("--build")
 
     compose = _compose_file()
+    compose_cmd[3] = str(compose)
+    env["ATHENA_MONGO_INIT"] = str(compose.parent / "init-mongo.js")
     print(f"  ✅  Compose file: {compose}")
     print()
-    print("  Building Athena from source (first build takes ~2 min)...")
+    if from_source:
+        print("  Building Athena from source (first build takes ~2 min)...")
+    else:
+        print("  Pulling images and starting the stack (first pull takes ~2 min)...")
     print()
 
     result = subprocess.run(
-        ["docker", "compose", "-f", str(compose), "up", "-d", "--build"],
+        compose_cmd,
         env=env,
         text=True,
     )
@@ -368,7 +383,7 @@ def cmd_init(_args: argparse.Namespace) -> None:
         env_file.write_text(env_text)
         print(f"  ✅  Wrote ATHENA_URL={athena_url} to {env_file}")
     else:
-        print(f"  ✅  ATHENA_URL already set")
+        print("  ✅  ATHENA_URL already set")
 
     print()
     _banner("Athena is live!", "─")
@@ -383,9 +398,6 @@ def cmd_init(_args: argparse.Namespace) -> None:
   Once an agent runs, inspect its memory:
     jarviscore memory context --agent <agent-name>
     jarviscore memory search  --agent <agent-name> --query "market research"
-
-  When a pre-built Docker image is available, swap to:
-    jarviscore memory pull     # (coming soon)
 """)
 
 
@@ -399,7 +411,12 @@ def run(argv: Optional[list] = None) -> None:
     sub = parser.add_subparsers(dest="command", required=True)
 
     # init
-    sub.add_parser("init", help="First-time setup: build + start Athena stack (run once)")
+    p_init = sub.add_parser("init", help="First-time setup: pull + start the Athena stack (run once)")
+    p_init.add_argument(
+        "--from-source",
+        action="store_true",
+        help="Build Athena from a local clone (~/athena or ATHENA_DIR) instead of pulling the image",
+    )
 
     # status
     sub.add_parser("status", help="Health check all memory tiers")
@@ -415,8 +432,8 @@ def run(argv: Optional[list] = None) -> None:
     p_srch.add_argument("--query", required=True, help="Natural language query")
     p_srch.add_argument("--limit", type=int, default=5, help="Max results")
 
-    # up
-    sub.add_parser("up", help="Instructions to start Athena locally")
+    # up (alias for init: kept because docs and error messages reference it)
+    sub.add_parser("up", help="Start the Athena stack (alias for init)")
 
     args = parser.parse_args(argv)
 
@@ -429,7 +446,10 @@ def run(argv: Optional[list] = None) -> None:
     elif args.command == "search":
         asyncio.run(cmd_search(args))
     elif args.command == "up":
-        cmd_up(args)
+        # pre-existing bug: cmd_up never existed, so 'memory up' crashed with
+        # NameError. init is idempotent (compose up), so alias it.
+        args.from_source = False
+        cmd_init(args)
 
 
 if __name__ == "__main__":

--- a/jarviscore/docs/reference/cli.md
+++ b/jarviscore/docs/reference/cli.md
@@ -200,34 +200,42 @@ Manages the Athena MemOS memory infrastructure.
 
 ### memory init
 
-Builds and starts the Athena Docker stack from source. Run this once per environment.
+Pulls the published Athena image and starts the Docker stack. Run this once per environment.
 
 ```bash
 jarviscore memory init
 ```
 
-Before running this command, clone the Athena repository:
+Contributors working on Athena itself can build from a local clone:
 
 ```bash
 git clone https://github.com/Prescott-Data/athena ~/athena
+jarviscore memory init --from-source
 ```
 
-If your Athena clone is in a non-standard location, set `ATHENA_DIR`:
+With `--from-source`, a non-standard clone location is set with `ATHENA_DIR`:
 
 ```bash
-ATHENA_DIR=/path/to/athena jarviscore memory init
+ATHENA_DIR=/path/to/athena jarviscore memory init --from-source
 ```
 
 The `init` command:
 
-1. Locates the Athena source repository.
-2. Detects an LLM API key from the environment (Gemini, then Anthropic, then OpenAI).
-3. Builds all Athena services with `docker compose up -d --build`.
-4. Waits up to 90 seconds for the health endpoint at `http://localhost:8080/api/v1/health` to return `ok`.
-5. Writes `ATHENA_URL=http://localhost:8080` to the project `.env` file.
+1. Detects an LLM API key from the environment (Gemini, then Anthropic, then OpenAI).
+2. Starts all Athena services with `docker compose up -d`.
+3. Waits up to 90 seconds for the health endpoint at `http://localhost:8080/api/v1/health` to return `ok`.
+4. Writes `ATHENA_URL=http://localhost:8080` to the project `.env` file.
 
-!!! note "First-build duration"
-    The initial build takes approximately two minutes because Milvus is compiled from source. Subsequent starts use Docker layer caching and complete in under 10 seconds.
+!!! note "First-start duration"
+    The first run takes about two minutes to pull images. Subsequent starts complete in under 10 seconds.
+
+### memory up
+
+Alias for `memory init`. Starting the stack is idempotent: services already running are left untouched.
+
+```bash
+jarviscore memory up
+```
 
 ### memory status
 

--- a/jarviscore/memory/_data/docker-compose.athena.yml
+++ b/jarviscore/memory/_data/docker-compose.athena.yml
@@ -9,11 +9,9 @@
 #   jarviscore memory init
 #
 # Or manually:
-#   ATHENA_BUILD_CONTEXT=/path/to/athena \
-#   docker compose -f docker-compose.athena.yml up -d --build
+#   docker compose -f docker-compose.athena.yml up -d
 #
 # Required environment variables (set by `jarviscore memory init`):
-#   ATHENA_BUILD_CONTEXT   — absolute path to the athena repo clone
 #   ATHENA_LLM_API_KEY     — Gemini / OpenAI API key for MTM summarisation
 #
 # ── ARCHITECTURE ─────────────────────────────────────────────────────────────
@@ -25,14 +23,11 @@
 #   minio          (:9000)  — Milvus blob store
 #   arangodb       (:8529)  — LTM knowledge graph
 #
-# ── NO PUBLISHED IMAGE YET ───────────────────────────────────────────────────
-# Athena is built from source using the local repo clone.
-# Once ghcr.io/prescott-data/athena:latest is published, swap:
-#   image: ghcr.io/prescott-data/athena:latest
-# for:
-#   build:
-#     context: ${ATHENA_BUILD_CONTEXT}
-#     dockerfile: Dockerfile
+# ── IMAGE SOURCE ─────────────────────────────────────────────────────────────
+# Pulls ghcr.io/prescott-data/athena by default. Contributors hacking on
+# Athena itself can build from a local clone instead:
+#   ATHENA_IMAGE=athena-memos:local ATHENA_BUILD_CONTEXT=/path/to/athena \
+#     docker compose -f docker-compose.athena.yml up -d --build
 # ─────────────────────────────────────────────────────────────────────────────
 
 version: "3.9"
@@ -40,10 +35,7 @@ version: "3.9"
 services:
   # ── Athena Memory Server ────────────────────────────────────────────────────
   athena:
-    build:
-      context: ${ATHENA_BUILD_CONTEXT:?Run 'jarviscore memory init' or set ATHENA_BUILD_CONTEXT}
-      dockerfile: Dockerfile
-    image: athena-memos:local
+    image: ${ATHENA_IMAGE:-ghcr.io/prescott-data/athena:latest}
     container_name: athena
     ports:
       - "8080:8080"
@@ -143,7 +135,7 @@ services:
       MONGO_INITDB_DATABASE: memory_os
     volumes:
       - athena_mongodb_data:/data/db
-      - ${ATHENA_BUILD_CONTEXT:-.}/mongo-init/init-mongo.js:/docker-entrypoint-initdb.d/init-mongo.js:ro
+      - ${ATHENA_MONGO_INIT:-./init-mongo.js}:/docker-entrypoint-initdb.d/init-mongo.js:ro
     networks:
       - athena_net
     restart: unless-stopped

--- a/jarviscore/memory/_data/init-mongo.js
+++ b/jarviscore/memory/_data/init-mongo.js
@@ -1,0 +1,11 @@
+db = db.getSiblingDB('admin');
+db.auth('admin', 'admin123');
+
+db = db.getSiblingDB('memory_os_e2e');
+db.createCollection('dialogue_pages');
+
+db.createUser({
+  user: 'e2e_user',
+  pwd: 'e2e_password_2024',
+  roles: [{ role: 'readWrite', db: 'memory_os_e2e' }],
+});

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -129,6 +129,7 @@ jarviscore = [
     "nexus/_data/001_initial_schema.sql",
     # Athena MemOS local-stack compose — bundled for same reason
     "memory/_data/docker-compose.athena.yml",
+    "memory/_data/init-mongo.js",
 ]
 
 [tool.pytest.ini_options]


### PR DESCRIPTION
memory: init pulls the published Athena image, no clone required

jarviscore memory init required cloning the Athena repo and compiling
its Go server from source before an agent could write its first
long-term memory. Athena PR #17 publishes
ghcr.io/prescott-data/athena; this PR makes init consume it.

- compose: the athena service is image-first
  (ATHENA_IMAGE, default ghcr.io/prescott-data/athena:latest).
  Contributors hacking on Athena build from a clone with
  ATHENA_IMAGE=athena-memos:local ATHENA_BUILD_CONTEXT=... --build.
- mongo init script is bundled in the package (was mounted from the
  source clone, the second hidden source dependency); init passes its
  explicit path to compose.
- cmd_init: no repo discovery on the default path. --from-source
  restores the old build flow for contributors.
- Fixed pre-existing bugs ruff surfaced in this file: Path was never
  imported (init crashed with NameError before doing anything) and
  'memory up' dispatched to cmd_up which does not exist (NameError).
  up is now an alias for init, which is idempotent.

New developer path, in full:
    pip install jarviscore-framework
    jarviscore memory init          # docker + an LLM key you already have
    # ATHENA_URL written to .env; agents now remember across sessions

Merge order: after Prescott-Data/athena#17 publishes the image.
Validated: compose config parses; init --help and module import clean.
