### PR TITLE
feat: teach AI editors jarviscore - skill, installer, llms.txt

### DIFF
--- a/jarviscore/cli/scaffold.py
+++ b/jarviscore/cli/scaffold.py
@@ -77,7 +77,7 @@ def copy_examples(dest_dir: Path, force: bool = False) -> bool:
         return False
 
     if dest.exists() and not force:
-        print(f"⚠ examples/ directory already exists (use --force to overwrite)")
+        print("⚠ examples/ directory already exists (use --force to overwrite)")
         return False
 
     if dest.exists() and force:
@@ -127,6 +127,37 @@ def print_next_steps(env_created: bool, examples_created: bool):
     print()
 
 
+def copy_skill(dest_dir: Path, force: bool = False) -> bool:
+    """
+    Install the JarvisCore skill for AI coding editors.
+
+    Writes SKILL.md to the two locations editors discover today:
+    .github/skills/jarviscore/ (GitHub Copilot) and
+    .claude/skills/jarviscore/ (Claude Code). Cursor and other tools
+    that read AGENTS.md can reference either copy.
+    """
+    try:
+        from importlib import resources
+        src = Path(str(resources.files('jarviscore'))) / 'skills' / 'jarviscore' / 'SKILL.md'
+    except Exception:
+        src = Path(__file__).parent.parent / 'skills' / 'jarviscore' / 'SKILL.md'
+    if not src.exists():
+        print(f"✗ Skill file not found: {src}")
+        return False
+
+    wrote = False
+    for editor_dir in ('.github', '.claude'):
+        dest = dest_dir / editor_dir / 'skills' / 'jarviscore' / 'SKILL.md'
+        if dest.exists() and not force:
+            print(f"⚠ {dest.relative_to(dest_dir)} already exists (use --force to overwrite)")
+            continue
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(src, dest)
+        print(f"✓ Installed {dest.relative_to(dest_dir)}")
+        wrote = True
+    return wrote
+
+
 def main():
     """CLI entry point."""
     parser = argparse.ArgumentParser(
@@ -136,6 +167,11 @@ def main():
         '--examples',
         action='store_true',
         help='Also copy example agent files'
+    )
+    parser.add_argument(
+        '--skill',
+        action='store_true',
+        help='Install the JarvisCore skill for AI editors (Copilot, Claude Code)'
     )
     parser.add_argument(
         '--force',
@@ -165,8 +201,12 @@ def main():
     if args.examples:
         examples_created = copy_examples(dest_dir, args.force)
 
+    skill_created = False
+    if args.skill:
+        skill_created = copy_skill(dest_dir, args.force)
+
     # Summary
-    if env_created or examples_created:
+    if env_created or examples_created or skill_created:
         print_next_steps(env_created, examples_created)
         sys.exit(0)
     else:

--- a/jarviscore/docs/guides/ai-editors.md
+++ b/jarviscore/docs/guides/ai-editors.md
@@ -1,0 +1,46 @@
+---
+icon: material/robot-happy
+title: AI Editor Setup - Copilot, Claude Code, Cursor
+description: Teach your AI coding editor JarvisCore. Install the JarvisCore skill for GitHub Copilot and Claude Code, wire up Cursor with AGENTS.md, and point any tool at llms.txt.
+---
+
+# AI Editor Setup
+
+Your AI coding editor writes better JarvisCore code when it knows the framework. JarvisCore ships that knowledge as a skill: correct API contracts, the profile decision rule, configuration essentials, and the mistakes we see most, maintained in the same repo as the code it describes.
+
+## Install the skill
+
+From your project root:
+
+```bash
+jarviscore init --skill
+```
+
+This writes `SKILL.md` to the locations editors discover:
+
+| Editor | Location | Loaded |
+|---|---|---|
+| GitHub Copilot | `.github/skills/jarviscore/` | Automatically, when a task matches the skill description |
+| Claude Code | `.claude/skills/jarviscore/` | Automatically, same trigger model |
+
+Commit these files. Everyone who opens the project gets an editor that knows JarvisCore.
+
+## Cursor and other AGENTS.md tools
+
+Tools that read `AGENTS.md` (Cursor, Codex, and others) get the same knowledge with one line in your project's `AGENTS.md`:
+
+```markdown
+When working with jarviscore code, read .github/skills/jarviscore/SKILL.md first.
+```
+
+## Any tool: llms.txt
+
+The documentation site serves [llms.txt](https://jarviscore.developers.prescottdata.io/llms.txt), a curated index of these docs for AI ingestion. Point research agents or custom tooling at it instead of scraping.
+
+## Keeping it current
+
+The skill is versioned with the package. After upgrading JarvisCore:
+
+```bash
+jarviscore init --skill --force
+```

--- a/jarviscore/docs/llms.txt
+++ b/jarviscore/docs/llms.txt
@@ -1,0 +1,30 @@
+# JarvisCore
+
+> Open source Python framework for building autonomous multi-agent AI systems in production. Peer-to-peer agent orchestration over a SWIM gossip mesh, four-tier agent memory with cross-session semantics via Athena MemOS, zero-trust credentials via Nexus, sandboxed code generation with self-repair, and automatic full-stack tracing.
+
+Package: `jarviscore-framework` on PyPI. Import name: `jarviscore`. Python 3.10+.
+
+## Start here
+
+- [Getting Started](https://jarviscore.developers.prescottdata.io/getting-started/): install, one-key configuration, first agent
+- [Architecture](https://jarviscore.developers.prescottdata.io/concepts/architecture/): the mental model
+- [Agents](https://jarviscore.developers.prescottdata.io/concepts/agents/): identity and lifecycle
+
+## Core guides
+
+- [AutoAgent](https://jarviscore.developers.prescottdata.io/guides/autoagent/): autonomous agents with the full cognitive stack
+- [CustomAgent](https://jarviscore.developers.prescottdata.io/guides/customagent/): deterministic worker agents
+- [Workflow DAGs](https://jarviscore.developers.prescottdata.io/guides/workflows/): multi-step orchestration
+- [Memory](https://jarviscore.developers.prescottdata.io/concepts/memory/): four tiers, Athena MemOS setup
+- [P2P Communication](https://jarviscore.developers.prescottdata.io/concepts/p2p/): the agent mesh
+- [Observability](https://jarviscore.developers.prescottdata.io/guides/observability/): tracing, metrics, jarviscore inspect
+- [HITL Escalation](https://jarviscore.developers.prescottdata.io/guides/hitl/): human-in-the-loop
+- [Nexus Credentials](https://jarviscore.developers.prescottdata.io/guides/nexus/): zero-trust auth
+- [Integrations](https://jarviscore.developers.prescottdata.io/guides/integrations/): 46 services, 237+ prebuilt actions
+- [Production Deployment](https://jarviscore.developers.prescottdata.io/guides/production/)
+
+## Reference
+
+- [Configuration](https://jarviscore.developers.prescottdata.io/reference/configuration/): every environment variable
+- [CLI](https://jarviscore.developers.prescottdata.io/reference/cli/): init, check, memory, nexus, atom, inspect
+- [AI Editor Setup](https://jarviscore.developers.prescottdata.io/guides/ai-editors/): skill for Copilot, Claude Code, Cursor

--- a/jarviscore/skills/jarviscore/SKILL.md
+++ b/jarviscore/skills/jarviscore/SKILL.md
@@ -1,0 +1,114 @@
+---
+name: jarviscore
+description: Build multi-agent AI systems with the JarvisCore Python framework. Use when writing, reviewing, or debugging code that imports jarviscore, defines AutoAgent or CustomAgent classes, runs a Mesh, or configures agent memory (Athena), P2P, Nexus credentials, or tracing.
+---
+
+# JarvisCore
+
+Python framework for production multi-agent AI. Agents run on a peer-to-peer mesh, remember across sessions, and trace everything they do. Package: `jarviscore-framework` (import name `jarviscore`). Python 3.10+.
+
+## The one decision that matters: pick the right profile
+
+- `CustomAgent`: you bring the brain. Deterministic control, you implement the logic. Use for workers with known logic, API-driven services, wrapping existing code.
+- `AutoAgent`: the framework brings the brain. LLM task execution with sandboxed code generation, self-repair, and a verified-work registry. Use when the task is described, not coded.
+
+There is nothing in between. Do not simulate one with the other.
+
+## Minimal AutoAgent (correct, complete)
+
+```python
+import asyncio
+from jarviscore import Mesh
+from jarviscore.profiles import AutoAgent
+
+class ResearcherAgent(AutoAgent):
+    role = "researcher"                      # required
+    capabilities = ["research", "analysis"]  # required
+    system_prompt = "You are a rigorous research analyst."  # required
+
+async def main():
+    mesh = Mesh()
+    mesh.add(ResearcherAgent)
+    await mesh.start()
+    result = await mesh.run_task(agent="researcher", task="Compare SWIM and Raft.")
+    print(result)
+
+asyncio.run(main())
+```
+
+Optional AutoAgent class attributes: `goal_oriented = True` (routes tasks through a Plan, Execute, Evaluate loop), `default_kernel_role = "..."`, `requires_auth = True` (injects Nexus-backed `_auth_manager`).
+
+## Minimal CustomAgent
+
+```python
+from jarviscore.profiles import CustomAgent
+
+class ProcessorAgent(CustomAgent):
+    role = "processor"
+    capabilities = ["processing"]
+
+    async def execute_task(self, task):
+        return {"status": "success", "output": ...}
+
+    async def on_peer_request(self, msg):          # P2P handler
+        return {"status": "success", "result": ...}
+```
+
+## Two ways to run, one rule
+
+- `mesh.run_task(agent=..., task=...)`: one task, one agent. Single asks and hand-rolled pipelines.
+- `mesh.workflow(id, steps)`: declared steps as one traced unit with ordering, dependencies, and retries.
+
+Rule: if you are pasting one agent's output into another agent's prompt by hand, use `workflow`.
+
+```python
+results = await mesh.workflow("wf-1", [
+    {"agent": "researcher", "task": "Gather data on X"},
+    {"agent": "analyst", "task": "Write a report from the research"},
+])
+print(results[0]["output"])   # results carry status, output, metadata
+```
+
+## Configuration
+
+Exactly one LLM provider is required. Set in `.env`:
+
+- Claude: `CLAUDE_API_KEY` + `CLAUDE_MODEL`
+- Azure OpenAI: `AZURE_API_KEY` + `AZURE_ENDPOINT` + `AZURE_DEPLOYMENT`
+- Gemini: `GEMINI_API_KEY` + `GEMINI_MODEL`
+- vLLM/local: `LLM_ENDPOINT` + `LLM_MODEL`
+
+Everything else is optional and additive: `REDIS_URL` (distributed workflows, cross-session state), `ATHENA_URL` (cross-session semantic memory, wired into AutoAgent automatically), `P2P_ENABLED=true` (multi-machine mesh, needs `pip install "jarviscore-framework[p2p]"`).
+
+Verify a setup with `jarviscore check --validate-llm`, never by guessing.
+
+## CLI verbs
+
+```
+jarviscore init            # scaffold .env.example (--full for every option)
+jarviscore check           # health check; --validate-llm makes a real call
+jarviscore memory init     # pull + start the Athena memory stack (Docker)
+jarviscore memory status   # health of all memory tiers
+jarviscore nexus init      # zero-trust credential broker (Docker)
+jarviscore inspect [wf]    # read recorded traces: what did my agents do?
+jarviscore atom list       # 46 service integrations, 237+ prebuilt actions
+```
+
+## House rules the framework enforces (do not fight them)
+
+- Nothing is truncated silently. If you clip content in agent context, label it and keep a retrieval path. The framework does; your code should too.
+- Failures are loud. Do not swallow exceptions in handlers; return `{"status": "failure", ...}` shapes or raise.
+- Credentials never enter agent reasoning. Use `requires_auth`/Nexus atoms, never put raw secrets in prompts or task strings.
+- Memory tiers are additive. Code must work with tiers absent; check for None rather than assuming Redis or Athena exists.
+
+## Common mistakes
+
+- Inventing constructor arguments. Profiles configure via class attributes; `Mesh()` needs no arguments for a single process.
+- Forgetting `await mesh.start()` before running tasks.
+- Using `AutoAgent` for deterministic logic (slow, expensive) or `CustomAgent` for open-ended tasks (you will rebuild the kernel badly).
+- Reading `result["payload"]`. The output key is `output`.
+- Assuming P2P works without the `[p2p]` extra installed.
+
+## Deeper documentation
+
+Full docs: https://jarviscore.developers.prescottdata.io/ (guides for workflows, HITL, browser automation, RAG, FastAPI integration, observability, production deployment).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -121,6 +121,7 @@ nav:
       - Testing Atoms: guides/testing-atoms.md
       - System Prompts: guides/system-prompts.md
       - Testing: guides/testing.md
+      - AI Editor Setup: guides/ai-editors.md
       - Production Deployment: guides/production.md
       - Migration: guides/migration.md
   - Examples:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -124,6 +124,7 @@ jarviscore = [
     "docs/*.md",
     "data/.env.example",
     "data/examples/*.py",
+    "skills/jarviscore/SKILL.md",
     # Nexus local-stack data — bundled so pip install users don't need the repo
     "nexus/_data/docker-compose.nexus.yml",
     "nexus/_data/001_initial_schema.sql",

--- a/tests/test_cli_skill.py
+++ b/tests/test_cli_skill.py
@@ -1,0 +1,47 @@
+"""Tests for jarviscore init --skill: AI editor skill installation."""
+
+from pathlib import Path
+
+import jarviscore
+from jarviscore.cli.scaffold import copy_skill
+
+_SKILL = Path(jarviscore.__file__).parent / "skills" / "jarviscore" / "SKILL.md"
+
+
+def test_packaged_skill_exists_with_valid_frontmatter():
+    skill = Path(str(__import__("importlib.resources", fromlist=["files"]).files("jarviscore"))) / "skills" / "jarviscore" / "SKILL.md"
+    assert skill.exists()
+    text = skill.read_text()
+    assert text.startswith("---\n")
+    assert "name: jarviscore" in text
+    assert "description:" in text
+    assert "\u2014" not in text                       # house style: no em dashes
+
+
+def test_skill_installs_to_both_editor_locations(tmp_path):
+    assert copy_skill(tmp_path, force=False) is True
+    for editor_dir in (".github", ".claude"):
+        dest = tmp_path / editor_dir / "skills" / "jarviscore" / "SKILL.md"
+        assert dest.exists()
+        assert "AutoAgent" in dest.read_text()
+
+
+def test_skill_does_not_overwrite_without_force(tmp_path):
+    target = tmp_path / ".github" / "skills" / "jarviscore" / "SKILL.md"
+    target.parent.mkdir(parents=True)
+    target.write_text("customised")
+    copy_skill(tmp_path, force=False)
+    assert target.read_text() == "customised"        # preserved
+    assert (tmp_path / ".claude" / "skills" / "jarviscore" / "SKILL.md").exists()
+    copy_skill(tmp_path, force=True)
+    assert target.read_text() != "customised"        # force overwrites
+
+
+def test_skill_teaches_the_real_api_surface():
+    """The skill must never drift from the code it describes."""
+    text = (Path(str(__import__("importlib.resources", fromlist=["files"]).files("jarviscore"))) / "skills" / "jarviscore" / "SKILL.md").read_text()
+    from jarviscore.profiles import AutoAgent, CustomAgent  # noqa: F401  (import = contract)
+
+    for claim in ("mesh.run_task", "mesh.workflow", "await mesh.start()",
+                  "system_prompt", "goal_oriented", "on_peer_request"):
+        assert claim in text, f"skill lost the {claim} contract"


### PR DESCRIPTION
feat: teach AI editors jarviscore - skill, installer, llms.txt

Developers write jarviscore code inside Copilot, Claude Code, and
Cursor. Those tools hallucinate APIs unless the framework hands them
its knowledge. This ships that as product:

- jarviscore/skills/jarviscore/SKILL.md: the editor skill. Verified
  API contracts (profile class attributes, run_task vs workflow rule,
  result shape), configuration essentials, house rules, and the
  mistakes we actually see. Every claim checked against source.
- jarviscore init --skill: installs the skill to .github/skills/
  (Copilot) and .claude/skills/ (Claude Code). Committed with the
  project, every collaborator's editor knows the framework.
- guides/ai-editors.md: setup for Copilot, Claude Code, and
  AGENTS.md-based tools like Cursor. Added to the Guides nav.
- docs/llms.txt: curated docs index served at the site root for AI
  ingestion.

4 tests, including one that imports the profiles and asserts the
skill still teaches the real API surface, so skill drift fails CI.
Also fixes a pre-existing F541 in scaffold.py.
