### PR TITLE
security: enforce TLS certificate verification on all outbound HTTPS

### DIFF
--- a/jarviscore/core/tls.py
+++ b/jarviscore/core/tls.py
@@ -1,0 +1,41 @@
+"""Shared TLS context factory.
+
+Every outbound HTTPS connection in the framework verifies certificates.
+The only way to disable verification is the JARVISCORE_TLS_INSECURE
+environment variable, which exists for corporate-proxy debugging and
+logs a prominent warning each time it is used.
+"""
+
+import logging
+import os
+import ssl
+
+logger = logging.getLogger(__name__)
+
+_TRUTHY = {"1", "true", "yes", "on"}
+
+
+def create_ssl_context() -> ssl.SSLContext:
+    """Return a verifying SSL context backed by the certifi CA bundle.
+
+    Falls back to the system trust store when certifi is unavailable.
+    Verification stays on in both cases. Set JARVISCORE_TLS_INSECURE=1
+    to disable verification entirely; a warning is logged because this
+    exposes traffic (including auth headers) to interception.
+    """
+    if os.environ.get("JARVISCORE_TLS_INSECURE", "").strip().lower() in _TRUTHY:
+        ctx = ssl.create_default_context()
+        ctx.check_hostname = False
+        ctx.verify_mode = ssl.CERT_NONE
+        logger.warning(
+            "TLS certificate verification DISABLED via JARVISCORE_TLS_INSECURE. "
+            "Traffic is exposed to interception. Never use this in production."
+        )
+        return ctx
+
+    try:
+        import certifi
+
+        return ssl.create_default_context(cafile=certifi.where())
+    except ImportError:
+        return ssl.create_default_context()

--- a/jarviscore/execution/search.py
+++ b/jarviscore/execution/search.py
@@ -24,8 +24,7 @@ import logging
 import os
 import re
 import time
-import xml.etree.ElementTree as ET
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional
 from urllib.parse import quote_plus, urlparse
 
 import aiohttp
@@ -133,20 +132,11 @@ class InternetSearch:
     # ──────────────────────────────────────────────────────────────────────
 
     async def initialize(self) -> None:
-        """Initialize aiohttp session with SSL fallback (macOS compat)."""
+        """Initialize aiohttp session with a verifying SSL context."""
         if self.session is None or self.session.closed:
-            import ssl
-            ssl_ctx = None
-            try:
-                import certifi
-                ssl_ctx = ssl.create_default_context(cafile=certifi.where())
-            except (ImportError, Exception):
-                ssl_ctx = ssl.create_default_context()
-                ssl_ctx.check_hostname = False
-                ssl_ctx.verify_mode = ssl.CERT_NONE
-                logger.debug("SSL: lenient context (certifi unavailable)")
+            from jarviscore.core.tls import create_ssl_context
 
-            connector = aiohttp.TCPConnector(ssl=ssl_ctx)
+            connector = aiohttp.TCPConnector(ssl=create_ssl_context())
             self.session = aiohttp.ClientSession(
                 connector=connector,
                 timeout=aiohttp.ClientTimeout(total=10),
@@ -443,7 +433,7 @@ class InternetSearch:
                         ]
                         logger.info("Serper: %d results", len(results))
                         return results
-                except Exception as e:
+                except Exception:
                     if attempt == 2:
                         raise
                     await asyncio.sleep(1.0 * (2 ** attempt))

--- a/jarviscore/kernel/defaults/researcher.py
+++ b/jarviscore/kernel/defaults/researcher.py
@@ -1414,7 +1414,7 @@ CRITICAL EPISTEMIC CONTRACT: You CANNOT exit your turn by saying "I need to rese
         If `auth_info` is not supplied, credentials are resolved from the
         current step's auth context.
         """
-        import aiohttp, ssl, json as _json
+        import aiohttp, json as _json
 
         logger.info("[RESEARCHER] probe_target_api: base_url=%s", base_url)
 
@@ -1442,9 +1442,9 @@ CRITICAL EPISTEMIC CONTRACT: You CANNOT exit your turn by saying "I need to rese
                 headers.update(resolved_auth["headers"])
 
         base = base_url.rstrip("/")
-        ssl_ctx = ssl.create_default_context()
-        ssl_ctx.check_hostname = False
-        ssl_ctx.verify_mode = ssl.CERT_NONE
+        from jarviscore.core.tls import create_ssl_context
+
+        ssl_ctx = create_ssl_context()
 
         # Protocol-standard discovery paths — no vendor hardcoding.
         # base_url is already the API root; we append standard suffixes only.

--- a/jarviscore/search/internet_search.py
+++ b/jarviscore/search/internet_search.py
@@ -14,7 +14,7 @@ import re
 import time
 import xml.etree.ElementTree as ET
 from io import BytesIO
-from typing import Dict, Any, List, Optional, Tuple, Union
+from typing import Dict, Any, List, Optional, Tuple
 from urllib.parse import quote_plus, urlparse, urljoin
 
 # beautifulsoup4 — required for HTML→Markdown extraction.
@@ -119,14 +119,9 @@ class InternetSearch:
     async def initialize(self):
         """Initialize the HTTP session"""
         if self.session is None or self.session.closed:
-            # Create a custom SSL context that ignores verification errors
-            import ssl
-            ssl_context = ssl.create_default_context()
-            ssl_context.check_hostname = False
-            ssl_context.verify_mode = ssl.CERT_NONE
-            
-            # Create connector with the custom SSL context
-            connector = aiohttp.TCPConnector(ssl=ssl_context)
+            from jarviscore.core.tls import create_ssl_context
+
+            connector = aiohttp.TCPConnector(ssl=create_ssl_context())
             
             self.session = aiohttp.ClientSession(
                 connector=connector,
@@ -137,7 +132,7 @@ class InternetSearch:
                     "Accept-Language": "en-US,en;q=0.5"
                 }
             )
-            logger.info("HTTP session initialized (SSL verification disabled)")
+            logger.info("HTTP session initialized")
 
     @property
     def _session(self) -> aiohttp.ClientSession:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ dependencies = [
     "python-dotenv>=1.0.0",
     "httpx>=0.25.0",
     "aiohttp>=3.9.0",
+    "certifi",
 
     # LLM Providers — the engine. Always available, zero-config.
     # Developer picks which provider to use via env vars, not pip extras.

--- a/tests/test_tls_context.py
+++ b/tests/test_tls_context.py
@@ -1,0 +1,50 @@
+"""TLS context factory tests.
+
+Guards issue #89: no code path may silently disable certificate
+verification. The only opt-out is JARVISCORE_TLS_INSECURE, and it
+must log a warning.
+"""
+
+import ssl
+
+import pytest
+
+from jarviscore.core.tls import create_ssl_context
+
+
+def test_default_context_verifies(monkeypatch):
+    monkeypatch.delenv("JARVISCORE_TLS_INSECURE", raising=False)
+    ctx = create_ssl_context()
+    assert ctx.verify_mode == ssl.CERT_REQUIRED
+    assert ctx.check_hostname is True
+
+
+def test_insecure_env_opt_out_warns(monkeypatch, caplog):
+    monkeypatch.setenv("JARVISCORE_TLS_INSECURE", "1")
+    with caplog.at_level("WARNING", logger="jarviscore.core.tls"):
+        ctx = create_ssl_context()
+    assert ctx.verify_mode == ssl.CERT_NONE
+    assert ctx.check_hostname is False
+    assert any("DISABLED" in r.message for r in caplog.records)
+
+
+@pytest.mark.parametrize("value", ["0", "false", "", "no"])
+def test_falsy_env_values_stay_secure(monkeypatch, value):
+    monkeypatch.setenv("JARVISCORE_TLS_INSECURE", value)
+    ctx = create_ssl_context()
+    assert ctx.verify_mode == ssl.CERT_REQUIRED
+
+
+def test_no_remaining_cert_none_in_source():
+    """No module outside the factory may construct a CERT_NONE context."""
+    from pathlib import Path
+
+    import jarviscore
+
+    root = Path(jarviscore.__file__).parent
+    offenders = [
+        str(p.relative_to(root))
+        for p in root.rglob("*.py")
+        if p.name != "tls.py" and "CERT_NONE" in p.read_text(errors="ignore")
+    ]
+    assert offenders == [], f"TLS verification bypassed in: {offenders}"


### PR DESCRIPTION
## Summary

Closes #89. Three code paths disabled TLS certificate verification (`CERT_NONE`, `check_hostname=False`), the worst of them while sending Bearer tokens and Basic auth credentials:

| Site | Previous behaviour |
|---|---|
| `search/internet_search.py` | Verification disabled unconditionally |
| `execution/search.py` | Disabled whenever certifi import failed, bare `except` swallowed everything |
| `kernel/defaults/researcher.py` | Disabled during API discovery, with auth headers attached |

## Change

- New single factory `jarviscore.core.tls.create_ssl_context()`: verifies against the certifi CA bundle, falls back to the system trust store (still verifying).
- All three sites now use it. No module outside the factory constructs an SSL context.
- `certifi` promoted from transitive (via httpx) to an explicit dependency.
- Escape hatch for corporate proxies: `JARVISCORE_TLS_INSECURE=1`, logs a warning on every use.

## Tests

`tests/test_tls_context.py` (7 passing):
- secure default (`CERT_REQUIRED`, hostname checking on)
- opt-out sets `CERT_NONE` and logs the warning
- falsy env values stay secure
- source-tree scan asserting no `CERT_NONE` outside the factory (regression guard)

Ruff clean on all touched files; the one remaining diagnostic in `researcher.py` (unused `glob` import) is pre-existing.
