### PR TITLE
fix: memory init detects Azure OpenAI; stack ports are overridable

### DIFF
--- a/jarviscore/cli/memory.py
+++ b/jarviscore/cli/memory.py
@@ -258,18 +258,33 @@ def _find_athena_repo() -> Optional[Path]:
     return None
 
 
-def _pick_llm_key() -> tuple[str, str]:
+def _pick_llm_key() -> tuple[str, str, str]:
     """
     Find an LLM API key from the current environment.
-    Returns (provider, key) — prefers Gemini, then Anthropic, then OpenAI.
+    Returns (provider, key, model). Prefers Gemini, then Azure OpenAI,
+    then OpenAI, then Anthropic.
     """
+    # Azure needs the endpoint too; the compose passes AZURE_OPENAI_* through
+    azure_key = os.environ.get("AZURE_OPENAI_API_KEY", "").strip() or os.environ.get("AZURE_API_KEY", "").strip()
+    azure_endpoint = os.environ.get("AZURE_OPENAI_ENDPOINT", "").strip() or os.environ.get("AZURE_ENDPOINT", "").strip()
     checks = [
         ("gemini", "GEMINI_API_KEY", "gemini-2.0-flash"),
         ("gemini", "GOOGLE_API_KEY", "gemini-2.0-flash"),
         ("openai", "OPENAI_API_KEY", "gpt-4o-mini"),
         ("anthropic", "ANTHROPIC_API_KEY", "claude-3-haiku-20240307"),
     ]
-    for provider, env_var, model in checks:
+    for provider, env_var, model in checks[:2]:
+        key = os.environ.get(env_var, "").strip()
+        if key:
+            return provider, key, model
+    if azure_key and azure_endpoint:
+        model = os.environ.get("AZURE_DEPLOYMENT", "").strip() or "gpt-4o"
+        os.environ.setdefault("AZURE_OPENAI_API_KEY", azure_key)
+        os.environ.setdefault("AZURE_OPENAI_ENDPOINT", azure_endpoint)
+        return "azure", azure_key, model
+    if azure_key and not azure_endpoint:
+        _warn("AZURE_OPENAI_API_KEY is set but AZURE_OPENAI_ENDPOINT is not; skipping Azure")
+    for provider, env_var, model in checks[2:]:
         key = os.environ.get(env_var, "").strip()
         if key:
             return provider, key, model
@@ -319,7 +334,7 @@ def cmd_init(args: argparse.Namespace) -> None:
     # LLM key
     provider, llm_key, model = _pick_llm_key()
     if not llm_key:
-        _err("No LLM API key found. Set one of: GEMINI_API_KEY, OPENAI_API_KEY, ANTHROPIC_API_KEY")
+        _err("No LLM API key found. Set one of: GEMINI_API_KEY, AZURE_OPENAI_API_KEY (+ AZURE_OPENAI_ENDPOINT), OPENAI_API_KEY, ANTHROPIC_API_KEY")
         sys.exit(1)
     print(f"  ✅  LLM: {provider} / {model}")
 
@@ -359,7 +374,8 @@ def cmd_init(args: argparse.Namespace) -> None:
     # 4. Wait for Athena health (up to 90s — Milvus init is slow)
     print()
     print("  Waiting for Athena to be ready (Milvus takes ~60s on first boot)...")
-    athena_url = "http://localhost:8080"
+    athena_port = os.environ.get("ATHENA_PORT", "8080").strip() or "8080"
+    athena_url = f"http://localhost:{athena_port}"
     for attempt in range(90):
         try:
             resp = urllib.request.urlopen(f"{athena_url}/api/v1/health", timeout=2)

--- a/jarviscore/docs/reference/configuration.md
+++ b/jarviscore/docs/reference/configuration.md
@@ -118,6 +118,11 @@ Athena provides three-tier persistent memory (STM, MTM, and LTM graph) that span
 | `ATHENA_TENANT_ID` | `default` | Tenant namespace for memory isolation across teams or environments |
 | `ATHENA_HTTP_TIMEOUT` | `10.0` | Seconds before an Athena HTTP call times out. Increase if your Athena instance is remote or under load. |
 | `ATHENA_SESSION_TTL_DAYS` | `30` | How long a session ID is cached in Redis before Athena re-issues it. |
+| `ATHENA_PORT` | `8080` | Host port for the Athena server when the stack is started by `memory init` |
+
+Every published port in the local stack is overridable for co-located deployments: `ATHENA_REDIS_PORT` (6380), `ATHENA_MONGO_PORT` (27017), `ATHENA_MINIO_PORT` (9000), `ATHENA_MINIO_CONSOLE_PORT` (9001), `ATHENA_MILVUS_PORT` (19530), `ATHENA_MILVUS_METRICS_PORT` (9091), `ATHENA_ARANGO_PORT` (8529).
+
+Azure OpenAI is detected automatically by `memory init` when `AZURE_OPENAI_API_KEY` and `AZURE_OPENAI_ENDPOINT` are set (deployment name from `AZURE_DEPLOYMENT`, default `gpt-4o`).
 
 Initial setup:
 

--- a/jarviscore/memory/_data/docker-compose.athena.yml
+++ b/jarviscore/memory/_data/docker-compose.athena.yml
@@ -14,6 +14,14 @@
 # Required environment variables (set by `jarviscore memory init`):
 #   ATHENA_LLM_API_KEY     — Gemini / OpenAI API key for MTM summarisation
 #
+# ── HOST PORTS ───────────────────────────────────────────────────────────────
+# Every published port is overridable, so the stack can co-locate with
+# other services. Defaults in parentheses:
+#   ATHENA_PORT (8080), ATHENA_REDIS_PORT (6380), ATHENA_MONGO_PORT (27017),
+#   ATHENA_MINIO_PORT (9000), ATHENA_MINIO_CONSOLE_PORT (9001),
+#   ATHENA_MILVUS_PORT (19530), ATHENA_MILVUS_METRICS_PORT (9091),
+#   ATHENA_ARANGO_PORT (8529)
+#
 # ── ARCHITECTURE ─────────────────────────────────────────────────────────────
 #   athena         (:8080)  — Go memory server (STM→MTM→LTM pipeline)
 #   redis          (:6379)  — STM hot cache
@@ -38,7 +46,7 @@ services:
     image: ${ATHENA_IMAGE:-ghcr.io/prescott-data/athena:latest}
     container_name: athena
     ports:
-      - "8080:8080"
+      - "${ATHENA_PORT:-8080}:8080"
     environment:
       MEMORY_OS_PORT: 8080
       APP_ENV: local
@@ -110,7 +118,7 @@ services:
     image: redis:7-alpine
     container_name: athena-redis
     ports:
-      - "6380:6379"   # 6380 on host to avoid conflict with jarviscore redis
+      - "${ATHENA_REDIS_PORT:-6380}:6379"   # 6380 on host to avoid conflict with jarviscore redis
     command: redis-server --appendonly yes --requirepass devpassword
     volumes:
       - athena_redis_data:/data
@@ -128,7 +136,7 @@ services:
     image: mongo:7
     container_name: athena-mongodb
     ports:
-      - "27017:27017"
+      - "${ATHENA_MONGO_PORT:-27017}:27017"
     environment:
       MONGO_INITDB_ROOT_USERNAME: admin
       MONGO_INITDB_ROOT_PASSWORD: admin123
@@ -165,8 +173,8 @@ services:
       MINIO_SECRET_KEY: minioadmin
     command: minio server /minio_data --console-address ":9001"
     ports:
-      - "9000:9000"
-      - "9001:9001"
+      - "${ATHENA_MINIO_PORT:-9000}:9000"
+      - "${ATHENA_MINIO_CONSOLE_PORT:-9001}:9001"
     volumes:
       - athena_minio_data:/minio_data
     networks:
@@ -197,8 +205,8 @@ services:
       ETCD_ENDPOINTS: etcd:2379
       MINIO_ADDRESS: minio:9000
     ports:
-      - "19530:19530"
-      - "9091:9091"
+      - "${ATHENA_MILVUS_PORT:-19530}:19530"
+      - "${ATHENA_MILVUS_METRICS_PORT:-9091}:9091"
     volumes:
       - athena_milvus_data:/var/lib/milvus
     depends_on:
@@ -213,7 +221,7 @@ services:
     image: arangodb:latest
     container_name: athena-arangodb
     ports:
-      - "8529:8529"
+      - "${ATHENA_ARANGO_PORT:-8529}:8529"
     environment:
       ARANGO_ROOT_PASSWORD: athena_dev
     volumes:


### PR DESCRIPTION
Closes #42 and #41. Azure-only environments no longer fail init (key + endpoint detected, deployment from AZURE_DEPLOYMENT), and all eight published host ports are ${VAR:-default} overridable for co-located stacks, respected by the CLI health poll and ATHENA_URL. Compose header and configuration reference document the list. Verified with docker compose config and a detection unit check.