### PR TITLE
fix: lease exhaustion names the dimension that fired

### DIFF
--- a/jarviscore/kernel/lease.py
+++ b/jarviscore/kernel/lease.py
@@ -12,7 +12,7 @@ Role-based profiles configure different budgets per subagent type.
 
 import time
 from dataclasses import dataclass, field
-from typing import Any, Dict, Literal, Optional
+from typing import Any, Dict, Optional
 
 
 # Role-specific lease profiles
@@ -95,17 +95,28 @@ class ExecutionLease:
 
     def is_expired(self) -> bool:
         """Check if any budget dimension is exhausted."""
-        if self.thinking_used + self.action_used >= self.max_total_tokens:
-            return True
+        return bool(self.expired_dimensions())
+
+    def expired_dimensions(self) -> list:
+        """Name every exhausted budget dimension as "name(used/limit)".
+
+        Five dimensions can end a lease; each needs a different remedy,
+        so the yield summary must say which one fired.
+        """
+        dims = []
+        total_used = self.thinking_used + self.action_used
+        if total_used >= self.max_total_tokens:
+            dims.append(f"total_tokens({total_used}/{self.max_total_tokens})")
         if self.thinking_used >= self.thinking_budget:
-            return True
+            dims.append(f"thinking({self.thinking_used}/{self.thinking_budget})")
         if self.action_used >= self.action_budget:
-            return True
+            dims.append(f"action({self.action_used}/{self.action_budget})")
         if self.turns_used >= self.emergency_turn_fuse:
-            return True
-        if self.elapsed_ms() >= self.wall_clock_ms:
-            return True
-        return False
+            dims.append(f"turn_fuse({self.turns_used}/{self.emergency_turn_fuse})")
+        elapsed = int(self.elapsed_ms())
+        if elapsed >= self.wall_clock_ms:
+            dims.append(f"wall_clock({elapsed}ms/{self.wall_clock_ms}ms)")
+        return dims
 
     def remaining_thinking(self) -> int:
         """Remaining thinking tokens."""

--- a/jarviscore/kernel/subagent.py
+++ b/jarviscore/kernel/subagent.py
@@ -545,13 +545,15 @@ class BaseSubAgent(ABC):
 
             # ── Emergency guards ──
             if self._cognition.lease.is_expired():
-                self._log.warning("Lease expired")
+                exhausted = ", ".join(self._cognition.lease.expired_dimensions()) or "unknown"
+                self._log.warning(f"Lease expired: {exhausted}")
                 return AgentOutput(
                     status="yield",
-                    summary=f"Lease budget exhausted after {turn} turns",
+                    summary=f"Lease budget exhausted after {turn} turns: {exhausted}",
                     payload=state.get_final_output(),
                     trajectory=trajectory,
                     metadata={"tokens": total_tokens, "cost_usd": total_cost,
+                              "lease_exhausted": exhausted,
                               "typed_outcome": "YIELD_LEASE_EXHAUSTED"},
                 )
 

--- a/tests/test_lease_exhaustion_message.py
+++ b/tests/test_lease_exhaustion_message.py
@@ -1,0 +1,58 @@
+"""Lease exhaustion names the dimension that fired (#92)."""
+
+from jarviscore.kernel.lease import ExecutionLease
+
+
+def _lease(**overrides):
+    lease = ExecutionLease.for_role("researcher")
+    for k, v in overrides.items():
+        setattr(lease, k, v)
+    return lease
+
+
+def test_fresh_lease_reports_nothing():
+    lease = _lease()
+    assert lease.expired_dimensions() == []
+    assert not lease.is_expired()
+
+
+def test_thinking_exhaustion_named():
+    lease = _lease()
+    lease.thinking_used = lease.thinking_budget
+    dims = lease.expired_dimensions()
+    assert any(d.startswith("thinking(") for d in dims)
+    assert lease.is_expired()
+
+
+def test_action_exhaustion_named():
+    lease = _lease()
+    lease.action_used = lease.action_budget
+    assert any(d.startswith("action(") for d in lease.expired_dimensions())
+
+
+def test_total_exhaustion_named_with_counts():
+    lease = _lease()
+    lease.thinking_used = lease.max_total_tokens
+    dims = lease.expired_dimensions()
+    total = next(d for d in dims if d.startswith("total_tokens("))
+    assert f"{lease.max_total_tokens}/{lease.max_total_tokens}" in total
+
+
+def test_turn_fuse_named():
+    lease = _lease()
+    lease.turns_used = lease.emergency_turn_fuse
+    assert any(d.startswith("turn_fuse(") for d in lease.expired_dimensions())
+
+
+def test_wall_clock_named():
+    lease = _lease()
+    lease.start_time -= (lease.wall_clock_ms / 1000) + 1
+    assert any(d.startswith("wall_clock(") for d in lease.expired_dimensions())
+
+
+def test_multiple_dimensions_all_named():
+    lease = _lease()
+    lease.thinking_used = lease.thinking_budget
+    lease.turns_used = lease.emergency_turn_fuse
+    dims = lease.expired_dimensions()
+    assert len(dims) >= 2


### PR DESCRIPTION
Closes #92. ExecutionLease.expired_dimensions() reports every exhausted budget as name(used/limit); the subagent yield summary, warning log, and metadata carry it. Diagnosis is now one log line instead of an hour of forensics. 7 tests.