### PR TITLE
fix: coder prompt teaches the async pattern the sandbox executes

### DIFF
--- a/jarviscore/docs/concepts/nexus.md
+++ b/jarviscore/docs/concepts/nexus.md
@@ -27,7 +27,7 @@ cred = base64.b64encode(f"{email}:{api_token}".encode()).decode()
 headers = {"Authorization": f"Basic {cred}"}
 ```
 
-Three providers, three auth patterns, three environment variables, and three separate token expiry and refresh paths. Scaled to 46 integrations across a multi-agent fleet, this becomes a maintenance problem that never ends.
+Three providers, three auth patterns, three environment variables, and three separate token expiry and refresh paths. Scaled to 150 integrations across a multi-agent fleet, this becomes a maintenance problem that never ends.
 
 **Nexus collapses all of this to one interface:**
 
@@ -38,7 +38,7 @@ response = await nexus_call("POST", "https://slack.com/api/chat.postMessage", js
 response = await nexus_call("GET", "https://your-org.atlassian.net/rest/api/3/issue/JC-1")
 ```
 
-The agent and the LLM-generated code never know whether a provider uses OAuth2, API keys, or Basic Auth. Nexus resolves the correct strategy and applies it transparently.
+The agent and the LLM-generated code never know whether a provider uses OAuth2, API keys, or Basic Auth. Nexus resolves the correct strategy and applies it transparently. Inside the execution sandbox, `nexus_call` is awaited from an `async def main()` function; the sandbox awaits `main()` and uses its return value as the output.
 
 ---
 

--- a/jarviscore/kernel/defaults/coder.py
+++ b/jarviscore/kernel/defaults/coder.py
@@ -132,19 +132,27 @@ proves it — that is the entire job.
 
 7. **AUTH / NEXUS STANDARD** — ALL provider API calls MUST use `nexus_call()`:
 
+   `nexus_call` is ASYNC, and the sandbox cannot execute top-level `await`.
+   Put every `await nexus_call(...)` inside `async def main()` and RETURN your
+   result dict from it; the sandbox detects async code, awaits `main()`, and
+   uses its return value as the output.
+
    ```python
    # ✅ CORRECT — all auth handled by Nexus, no credentials in code
-   response = await nexus_call("GET", "https://api.github.com/repos/my-org/my-repo")
-   response = await nexus_call("POST", "https://api.stripe.com/v1/charges",
-                               json={"amount": 1000, "currency": "usd"})
-   response = await nexus_call("GET", "https://api.notion.com/v1/databases/{id}/query")
-
-   if not response["ok"]:
-       raise RuntimeError(f"API call failed: {response['status_code']} {response['body']}")
-   data = response["json"]
+   async def main():
+       response = await nexus_call("GET", "https://api.github.com/repos/my-org/my-repo")
+       if not response["ok"]:
+           raise RuntimeError(f"API call failed: {response['status_code']} {response['body']}")
+       return {"success": True, "data": response["json"]}
    ```
 
    ```python
+   # ❌ FORBIDDEN — top-level await is a SyntaxError in the sandbox
+   response = await nexus_call("GET", "https://api.github.com/...")
+
+   # ❌ FORBIDDEN — calling without await returns a coroutine, not the response
+   response = nexus_call("GET", "https://api.github.com/...")
+
    # ❌ FORBIDDEN — never use requests/httpx directly for provider APIs
    import requests
    headers = {"Authorization": "Bearer ..."}  # VIOLATION — agent must never see credentials
@@ -157,6 +165,8 @@ proves it — that is the entire job.
 
 8. **OUTPUT CONTRACT** — Store final result in 'result' variable:
    result = {"success": True, "data": <your_data>}
+   In async code, RETURN that dict from `async def main()` instead; the
+   sandbox uses main()'s return value as the output.
 
 9. **MINIMUM COMPLEXITY** — Write the simplest code that solves the task.
    No unnecessary abstractions, classes, or helper functions.


### PR DESCRIPTION
Closes #93. The prompt showed top-level await nexus_call(...), which exec() cannot run; models spiraled reconciling docs vs runtime. Now teaches the real contract (await inside async def main(), return the result dict), with both failure shapes as forbidden examples. Verified against SandboxExecutor._execute_async. nexus.md aligned.