### PR TITLE
feat: guaranteed result_summary display field on task envelopes

### DIFF
--- a/jarviscore/core/envelope.py
+++ b/jarviscore/core/envelope.py
@@ -1,0 +1,75 @@
+"""Canonical display field for task envelopes.
+
+Every ``execute_task`` envelope carries ``result_summary``: always
+present, always plain prose, never JSON. Structured data stays in
+``output`` / ``payload`` / ``goal_execution`` for programmatic
+consumers; ``result_summary`` is the display contract (issue #40).
+"""
+
+from typing import Any, Dict, Optional
+
+# Keys downstream UIs were probing heuristically, in preference order.
+_PROSE_KEYS = (
+    "result_summary", "response", "content", "final_answer", "answer",
+    "summary", "message", "text", "brief",
+)
+
+
+def _prose_from(value: Any) -> Optional[str]:
+    """Extract display prose from a payload without serialising structures."""
+    if isinstance(value, str):
+        text = value.strip()
+        return text or None
+    if isinstance(value, dict):
+        for key in _PROSE_KEYS:
+            inner = value.get(key)
+            if isinstance(inner, str) and inner.strip():
+                return inner.strip()
+            if isinstance(inner, dict):
+                nested = _prose_from(inner)
+                if nested:
+                    return nested
+    return None
+
+
+def derive_result_summary(
+    status: str,
+    output: Any = None,
+    error: Any = None,
+    summary: Optional[str] = None,
+) -> str:
+    """Derive the canonical human-readable summary for an envelope.
+
+    Failure paths yield the error sentence (never a traceback or repr);
+    success paths prefer payload prose, then probed prose keys, then the
+    execution summary.
+    """
+    if status not in ("success", "complete"):
+        if isinstance(error, str) and error.strip():
+            return error.strip().splitlines()[0]
+        if error is not None:
+            return str(error).splitlines()[0]
+        if isinstance(summary, str) and summary.strip():
+            return summary.strip()
+        return f"Task ended with status: {status}"
+
+    prose = _prose_from(output)
+    if prose:
+        return prose
+    if isinstance(summary, str) and summary.strip():
+        return summary.strip()
+    return "Task completed."
+
+
+def attach_result_summary(envelope: Dict[str, Any], summary: Optional[str] = None) -> Dict[str, Any]:
+    """Ensure ``result_summary`` is present on *envelope* (idempotent)."""
+    existing = envelope.get("result_summary")
+    if isinstance(existing, str) and existing.strip():
+        return envelope
+    envelope["result_summary"] = derive_result_summary(
+        status=str(envelope.get("status", "")),
+        output=envelope.get("output", envelope.get("payload")),
+        error=envelope.get("error"),
+        summary=summary,
+    )
+    return envelope

--- a/jarviscore/docs/guides/autoagent.md
+++ b/jarviscore/docs/guides/autoagent.md
@@ -117,6 +117,8 @@ async def research(request: dict):
 
 Always check `step["status"] == "success"` before reading `step["payload"]`. A `"failure"` result has a populated `"summary"` explaining what went wrong.
 
+When calling `agent.execute_task()` directly, the returned envelope always carries `result_summary`: plain prose suitable for display, never JSON. Failure envelopes put a human-readable error sentence there. Structured data stays in `output` / `payload` / `goal_execution` for programmatic consumers.
+
 ---
 
 ## Lifecycle Hooks

--- a/jarviscore/profiles/autoagent.py
+++ b/jarviscore/profiles/autoagent.py
@@ -310,6 +310,19 @@ class AutoAgent(Profile):
             self._logger.debug("[AutoAgent] Profile load failed (non-fatal): %s", _pe)
 
     async def execute_task(self, task: Dict[str, Any]) -> Dict[str, Any]:
+        """Execute a task and return an envelope with a guaranteed
+        ``result_summary``: always present, always plain prose, never JSON
+        (issue #40). Structured data stays in ``output`` / ``payload`` /
+        ``goal_execution``. Delegates to the pipeline below.
+        """
+        from jarviscore.core.envelope import attach_result_summary
+
+        envelope = await self._execute_task_pipeline(task)
+        if isinstance(envelope, dict):
+            attach_result_summary(envelope)
+        return envelope
+
+    async def _execute_task_pipeline(self, task: Dict[str, Any]) -> Dict[str, Any]:
         """
         Execute task through the production Kernel pipeline.
 
@@ -466,11 +479,16 @@ class AutoAgent(Profile):
                 )
 
                 meta = output.metadata or {}
+                from jarviscore.core.envelope import derive_result_summary
                 result = {
                     "status": output.status,
                     "output": output.payload,
                     "payload": output.payload,
                     "error": None if output.status == "success" else output.summary,
+                    "result_summary": derive_result_summary(
+                        output.status, output.payload, None if output.status == "success" else output.summary,
+                        summary=output.summary,
+                    ),
                     "tokens": meta.get("tokens", {"input": 0, "output": 0, "total": 0}),
                     "cost_usd": meta.get("cost_usd", 0.0),
                     "repairs": 0,

--- a/jarviscore/profiles/customagent.py
+++ b/jarviscore/profiles/customagent.py
@@ -355,7 +355,9 @@ class CustomAgent(Profile):
         result = await self.on_peer_request(synthetic_msg)
 
         if result is not None:
-            return {"status": "success", "output": result}
+            from jarviscore.core.envelope import attach_result_summary
+
+            return attach_result_summary({"status": "success", "output": result})
 
         raise NotImplementedError(
             f"{self.__class__.__name__} must implement on_peer_request() or execute_task()\n\n"

--- a/tests/test_result_summary.py
+++ b/tests/test_result_summary.py
@@ -1,0 +1,45 @@
+"""result_summary display contract on execute_task envelopes (#40)."""
+
+from jarviscore.core.envelope import attach_result_summary, derive_result_summary
+
+
+def test_success_string_payload_is_the_summary():
+    assert derive_result_summary("success", "The answer is 42.") == "The answer is 42."
+
+
+def test_success_dict_probes_prose_keys():
+    out = {"data": {"rows": [1, 2]}, "final_answer": "Two rows matched."}
+    assert derive_result_summary("success", out) == "Two rows matched."
+
+
+def test_success_nested_prose():
+    out = {"response": {"content": "Done: report drafted."}}
+    assert derive_result_summary("success", out) == "Done: report drafted."
+
+
+def test_success_structured_only_falls_back_to_summary():
+    assert derive_result_summary("success", {"rows": [1]}, summary="Fetched one row.") == "Fetched one row."
+
+
+def test_success_never_serialises_dicts():
+    result = derive_result_summary("success", {"rows": [1, 2, 3]})
+    assert "{" not in result and "[" not in result
+
+
+def test_failure_uses_error_sentence_first_line_only():
+    err = "Kernel exception: boom\nTraceback (most recent call last):\n  ..."
+    assert derive_result_summary("failure", None, err) == "Kernel exception: boom"
+
+
+def test_yield_without_error_uses_summary():
+    assert derive_result_summary("yield", None, None, summary="Lease budget exhausted") == "Lease budget exhausted"
+
+
+def test_attach_is_idempotent():
+    env = {"status": "success", "output": "hi", "result_summary": "already set"}
+    assert attach_result_summary(env)["result_summary"] == "already set"
+
+
+def test_attach_fills_missing():
+    env = {"status": "failure", "output": None, "error": "no provider key"}
+    assert attach_result_summary(env)["result_summary"] == "no provider key"


### PR DESCRIPTION
Closes #40. Every execute_task envelope now carries result_summary: always present, always plain prose, never JSON. Failure paths carry the error sentence, never a traceback. Kills the heuristic key-walk extractors downstream UIs had to build. 9 tests; AutoAgent guide documents the contract.