### PR TITLE
feat: github write atoms and a working nexus list

### DIFF
--- a/jarviscore/cli/nexus.py
+++ b/jarviscore/cli/nexus.py
@@ -487,15 +487,43 @@ def cmd_list(args):
         try:
             req = urllib.request.urlopen(f"{gateway_url}/v1/providers", timeout=5)
             providers = json.loads(req.read())
-            if providers:
-                print(_bold("  Gateway providers:"))
-                for p in providers:
-                    name = p.get("provider", p.get("name", "?"))
-                    atype = p.get("auth_type", "?")
+
+            # The gateway returns {auth_type: {provider_name: {...}}}. Older
+            # builds returned a flat list, so accept both shapes.
+            rows = []
+            if isinstance(providers, dict):
+                for auth_type, bundle in providers.items():
+                    if isinstance(bundle, dict):
+                        rows.extend((name, auth_type) for name in bundle)
+                    else:
+                        rows.append((str(bundle), auth_type))
+            elif isinstance(providers, list):
+                rows = [
+                    (p.get("provider", p.get("name", "?")), p.get("auth_type", "?"))
+                    for p in providers if isinstance(p, dict)
+                ]
+
+            needle = (getattr(args, "search", None) or "").lower()
+            if needle:
+                rows = [r for r in rows if needle in r[0].lower()]
+
+            if rows:
+                total = len(rows)
+                label = f"  Gateway providers ({total})"
+                if needle:
+                    label += f" matching {needle!r}"
+                print(_bold(label + ":"))
+                for name, atype in sorted(rows):
                     print(f"  {_ok(name):<30} {atype}")
                 print()
-        except Exception:
-            pass  # gateway optional — don't fail if unreachable
+            elif needle:
+                print(_warn(f"  No gateway provider matches {needle!r}."))
+                print(_info(f"  Register it: jarviscore nexus register {needle} --client-id=... --client-secret=..."))
+                print()
+        except Exception as e:
+            # Gateway is optional — never fail the command, but say why it's missing.
+            print(_warn(f"  Gateway providers unavailable: {e}"))
+            print()
 
 
 def cmd_test(args):
@@ -587,7 +615,9 @@ def build_parser() -> argparse.ArgumentParser:
     reg.add_argument("--api-key",       default=None, help="API key (for api_key providers)")
 
     # list
-    sub.add_parser("list", help="List registered providers")
+    lst = sub.add_parser("list", help="List registered providers")
+    lst.add_argument("--search", default=None,
+                     help="Only show gateway providers whose name contains this text")
 
     # test
     tst = sub.add_parser("test", help="Test a provider connection end-to-end")

--- a/jarviscore/integrations/atoms/github/github_create_branch.py
+++ b/jarviscore/integrations/atoms/github/github_create_branch.py
@@ -1,0 +1,55 @@
+def github_create_branch(auth_info: dict, owner: str, repo: str, branch: str, from_branch: str = None) -> dict:
+    import requests
+    _base = "https://api.github.com"
+    _h = {"Authorization": f"Bearer {auth_info.get('access_token', '')}", "Content-Type": "application/json"}
+    def _get(p, params=None, headers=None):
+        _r = requests.get(f"{_base}{p}", headers={**_h, **(headers or {})}, params=params or {}, timeout=30)
+        _r.raise_for_status()
+        return _r.json()
+    def _post(p, data=None, headers=None):
+        _r = requests.post(f"{_base}{p}", headers={**_h, **(headers or {})}, json=data, timeout=30)
+        _r.raise_for_status()
+        return _r.json()
+    def _put(p, data=None, headers=None):
+        _r = requests.put(f"{_base}{p}", headers={**_h, **(headers or {})}, json=data, timeout=30)
+        _r.raise_for_status()
+        return _r.json()
+    def _patch(p, data=None, headers=None):
+        _r = requests.patch(f"{_base}{p}", headers={**_h, **(headers or {})}, json=data, timeout=30)
+        _r.raise_for_status()
+        return _r.json() if _r.content else {}
+    def _delete(p, headers=None):
+        _r = requests.delete(f"{_base}{p}", headers={**_h, **(headers or {})}, timeout=30)
+        _r.raise_for_status()
+        return _r.json() if _r.content else {}
+    _accept = {"Accept": "application/vnd.github+json"}
+
+    # Default to the repo's own default branch rather than assuming "main".
+    base_branch = from_branch
+    if not base_branch:
+        base_branch = _get(f"/repos/{owner}/{repo}", headers=_accept).get("default_branch", "main")
+
+    base_ref = _get(f"/repos/{owner}/{repo}/git/ref/heads/{base_branch}", headers=_accept)
+    base_sha = base_ref["object"]["sha"]
+
+    # Creating a ref that already exists returns 422; treat that as success so
+    # re-running a workflow against the same branch is not a hard failure.
+    try:
+        r = _post(f"/repos/{owner}/{repo}/git/refs",
+                  data={"ref": f"refs/heads/{branch}", "sha": base_sha},
+                  headers=_accept)
+        created = True
+    except requests.HTTPError as e:
+        if e.response is None or e.response.status_code != 422:
+            raise
+        r = _get(f"/repos/{owner}/{repo}/git/ref/heads/{branch}", headers=_accept)
+        created = False
+
+    return {
+        "branch": branch,
+        "ref": r.get("ref"),
+        "sha": r["object"]["sha"],
+        "from_branch": base_branch,
+        "created": created,
+        "url": f"https://github.com/{owner}/{repo}/tree/{branch}",
+    }

--- a/jarviscore/integrations/atoms/github/github_create_or_update_file.py
+++ b/jarviscore/integrations/atoms/github/github_create_or_update_file.py
@@ -1,0 +1,60 @@
+def github_create_or_update_file(auth_info: dict, owner: str, repo: str, path: str, content: str, message: str, branch: str = None, sha: str = None) -> dict:
+    import requests
+    _base = "https://api.github.com"
+    _h = {"Authorization": f"Bearer {auth_info.get('access_token', '')}", "Content-Type": "application/json"}
+    def _get(p, params=None, headers=None):
+        _r = requests.get(f"{_base}{p}", headers={**_h, **(headers or {})}, params=params or {}, timeout=30)
+        _r.raise_for_status()
+        return _r.json()
+    def _post(p, data=None, headers=None):
+        _r = requests.post(f"{_base}{p}", headers={**_h, **(headers or {})}, json=data, timeout=30)
+        _r.raise_for_status()
+        return _r.json()
+    def _put(p, data=None, headers=None):
+        _r = requests.put(f"{_base}{p}", headers={**_h, **(headers or {})}, json=data, timeout=30)
+        _r.raise_for_status()
+        return _r.json()
+    def _patch(p, data=None, headers=None):
+        _r = requests.patch(f"{_base}{p}", headers={**_h, **(headers or {})}, json=data, timeout=30)
+        _r.raise_for_status()
+        return _r.json() if _r.content else {}
+    def _delete(p, headers=None):
+        _r = requests.delete(f"{_base}{p}", headers={**_h, **(headers or {})}, timeout=30)
+        _r.raise_for_status()
+        return _r.json() if _r.content else {}
+    import base64
+    _accept = {"Accept": "application/vnd.github+json"}
+    clean_path = path.lstrip("/")
+
+    # An update needs the blob sha of the file being replaced. Look it up when
+    # the caller did not supply one; a 404 means the file is new.
+    if sha is None:
+        params = {"ref": branch} if branch else {}
+        try:
+            existing = _get(f"/repos/{owner}/{repo}/contents/{clean_path}", params=params, headers=_accept)
+            if isinstance(existing, dict):
+                sha = existing.get("sha")
+        except requests.HTTPError as e:
+            if e.response is None or e.response.status_code != 404:
+                raise
+
+    payload = {
+        "message": message,
+        "content": base64.b64encode(content.encode("utf-8")).decode("ascii"),
+    }
+    if branch:
+        payload["branch"] = branch
+    if sha:
+        payload["sha"] = sha
+
+    r = _put(f"/repos/{owner}/{repo}/contents/{clean_path}", data=payload, headers=_accept)
+    c = r.get("content") or {}
+    commit = r.get("commit") or {}
+    return {
+        "path": c.get("path", clean_path),
+        "sha": c.get("sha"),
+        "url": c.get("html_url"),
+        "commit_sha": commit.get("sha"),
+        "commit_url": commit.get("html_url"),
+        "created": sha is None,
+    }

--- a/jarviscore/integrations/atoms/github/github_create_pull_request.py
+++ b/jarviscore/integrations/atoms/github/github_create_pull_request.py
@@ -1,0 +1,57 @@
+def github_create_pull_request(auth_info: dict, owner: str, repo: str, title: str, head: str, base: str = None, body: str = None, draft: bool = False) -> dict:
+    import requests
+    _base = "https://api.github.com"
+    _h = {"Authorization": f"Bearer {auth_info.get('access_token', '')}", "Content-Type": "application/json"}
+    def _get(p, params=None, headers=None):
+        _r = requests.get(f"{_base}{p}", headers={**_h, **(headers or {})}, params=params or {}, timeout=30)
+        _r.raise_for_status()
+        return _r.json()
+    def _post(p, data=None, headers=None):
+        _r = requests.post(f"{_base}{p}", headers={**_h, **(headers or {})}, json=data, timeout=30)
+        _r.raise_for_status()
+        return _r.json()
+    def _put(p, data=None, headers=None):
+        _r = requests.put(f"{_base}{p}", headers={**_h, **(headers or {})}, json=data, timeout=30)
+        _r.raise_for_status()
+        return _r.json()
+    def _patch(p, data=None, headers=None):
+        _r = requests.patch(f"{_base}{p}", headers={**_h, **(headers or {})}, json=data, timeout=30)
+        _r.raise_for_status()
+        return _r.json() if _r.content else {}
+    def _delete(p, headers=None):
+        _r = requests.delete(f"{_base}{p}", headers={**_h, **(headers or {})}, timeout=30)
+        _r.raise_for_status()
+        return _r.json() if _r.content else {}
+    _accept = {"Accept": "application/vnd.github+json"}
+
+    target = base
+    if not target:
+        target = _get(f"/repos/{owner}/{repo}", headers=_accept).get("default_branch", "main")
+
+    payload = {"title": title, "head": head, "base": target, "draft": bool(draft)}
+    if body:
+        payload["body"] = body
+
+    # A pull request for this head/base pair may already be open; return it
+    # instead of failing so a re-run stays idempotent.
+    try:
+        pr = _post(f"/repos/{owner}/{repo}/pulls", data=payload, headers=_accept)
+    except requests.HTTPError as e:
+        if e.response is None or e.response.status_code != 422:
+            raise
+        open_prs = _get(f"/repos/{owner}/{repo}/pulls",
+                        params={"head": f"{owner}:{head}", "base": target, "state": "open"},
+                        headers=_accept)
+        if not open_prs:
+            raise
+        pr = open_prs[0]
+
+    return {
+        "number": pr["number"],
+        "title": pr["title"],
+        "state": pr["state"],
+        "url": pr["html_url"],
+        "head": pr["head"]["ref"],
+        "base": pr["base"]["ref"],
+        "created_at": pr["created_at"],
+    }


### PR DESCRIPTION
## What

The `github` bundle could read repos, files and pull requests, and could comment, but nothing in it wrote to a repository. An agent could review code it was handed; it could not put code somewhere a human would review it.

Adds the three atoms that close that gap, plus a fix to `nexus list`.

### New atoms

| Atom | Notes |
|---|---|
| `github_create_branch` | Branches from the repo's real `default_branch` rather than assuming `main` |
| `github_create_or_update_file` | Looks up the existing blob sha so update works, not just create |
| `github_create_pull_request` | Returns the already-open PR instead of failing on 422 |

All three are idempotent on re-run, which matters when a workflow retries a step. Atoms are discovered by directory glob, so no registry manifest changes were needed — the bundle goes 8 → 11 atoms.

### `nexus list` fix

The command printed a `Gateway providers:` header and then nothing. `/v1/providers` returns `{auth_type: {name: {...}}}` and the loop treated it as a list of dicts, so `p.get()` raised `AttributeError` straight into a bare `except Exception: pass`.

- handles both the dict and the legacy list shape
- adds `--search` for a catalog that is now 150 providers deep
- reports *why* the section is missing instead of swallowing the reason

```
$ jarviscore nexus list --search git
  Gateway providers (2) matching 'git':
  ✓  github             oauth2
  ✓  gitlab             oauth2
```

## Testing

```
jarviscore atom test --bundle github          # ALL PASSED
jarviscore atom list | grep -c github         # 11
```

Dry-run validation passes on all three new atoms (7 passed, 2 warnings each — the warnings are the bundle-wide missing `__init__.py` and the no-docstring convention shared with the existing 8 atoms).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MjYLRB2wS8vFJJUaywMthx