### PR TITLE
fix(mesh): give PeerClient the P2P coordinator at injection time

### DIFF
--- a/examples/mesh_live_roster_demo.py
+++ b/examples/mesh_live_roster_demo.py
@@ -1,0 +1,132 @@
+"""
+The Roster Writes Itself
+========================
+No LLM key. No Redis. No config. Just the mesh.
+
+Most multi-agent frameworks make you hand-maintain an org chart: graph edges,
+routing tables, and system prompts with peer names hardcoded into them. Add an
+agent and you edit all of it. Kill an agent and every prompt naming it is a lie.
+
+This demo shows the roster maintaining itself:
+
+  1. Three agents join a mesh. Nobody wires anyone to anyone.
+  2. We print the researcher's LIVE system prompt — the peer roster is generated.
+  3. A fourth specialist joins mid-run. It appears in the prompt. No redeploy.
+  4. The LLM's ask_peer tool is enum-constrained to peers that are actually online,
+     so the model cannot hallucinate a teammate that isn't there.
+  5. Two agents talk DIRECTLY — no supervisor in the path.
+  6. The specialist leaves. It disappears from the prompt.
+
+Transport note: the mesh auto-detects infrastructure. With no Redis and no free
+SWIM port this runs on the in-process transport (peer_local) and the peer API is
+identical — same code moves to peer_distributed (Redis) or peer_swim (SWIM/ZMQ)
+with zero changes to your agents.
+
+Run:
+    python examples/mesh_live_roster_demo.py
+"""
+import asyncio
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from jarviscore import Mesh
+from jarviscore.core.agent import Agent
+
+BASE_PROMPT = "You are a research agent. Answer using the mesh when useful."
+
+
+def banner(n: int, text: str) -> None:
+    print(f"\n{'━' * 68}\n  {n}. {text}\n{'━' * 68}")
+
+
+class DemoAgent(Agent):
+    """Deterministic stand-in so the demo needs no LLM key."""
+
+    async def execute_task(self, task):
+        return {"status": "completed", "by": self.role}
+
+
+class ResearchAgent(DemoAgent):
+    role = "researcher"
+    capabilities = ["research", "search"]
+    description = "Gathers source material"
+
+
+class AnalystAgent(DemoAgent):
+    role = "analyst"
+    capabilities = ["analysis", "charting"]
+    description = "Turns findings into insight"
+
+    async def run(self):
+        """Answer peer requests directly — no orchestrator involved."""
+        while True:
+            msg = await self.peers.receive(timeout=30)
+            if msg is None:
+                continue
+            await self.peers.respond(msg, {"verdict": "signal, not noise", "confidence": 0.9})
+
+
+class WriterAgent(DemoAgent):
+    role = "writer"
+    capabilities = ["writing"]
+    description = "Drafts the final brief"
+
+
+class ComplianceAgent(DemoAgent):
+    role = "compliance"
+    capabilities = ["policy_check", "risk_review"]
+    description = "Reviews output against policy"
+
+
+async def main():
+    mesh = Mesh()
+    mesh.add(ResearchAgent)
+    analyst = mesh.add(AnalystAgent)
+    mesh.add(WriterAgent)
+    await mesh.start()
+
+    researcher = next(a for a in mesh.agents if a.role == "researcher")
+    analyst_loop = asyncio.create_task(analyst.run())
+
+    banner(1, "The researcher's system prompt — nobody wrote the peer list")
+    print(researcher.peers.build_system_prompt(BASE_PROMPT))
+
+    banner(2, "A compliance specialist joins the running mesh")
+    mesh.add(ComplianceAgent)
+    await asyncio.sleep(0.2)
+    print(researcher.peers.get_cognitive_context())
+    print(">>> 'compliance' is now in the prompt. No redeploy. No edit.")
+
+    banner(3, "The LLM's ask_peer tool — constrained to who is ONLINE")
+    ask = [s for s in researcher.peers.as_tool().schema if s["name"] == "ask_peer"][0]
+    print(ask["description"])
+    print("allowed values:", json.dumps(ask["input_schema"]["properties"]["role"]["enum"]))
+    print(">>> The model literally cannot ask for an agent that isn't running.")
+
+    banner(4, "Discovery is a query, with load balancing built in")
+    print("by capability 'analysis' :", [p.role for p in researcher.peers.discover(capability="analysis")])
+    print("by role, round_robin     :", [p.role for p in researcher.peers.discover(role="analyst", strategy="round_robin")])
+
+    banner(5, "Researcher asks the analyst DIRECTLY — no supervisor hop")
+    reply = await researcher.peers.request("analyst", {"need": "read this finding"}, timeout=10)
+    print("reply received:", reply)
+
+    banner(6, "The specialist leaves")
+    mesh.agents = [a for a in mesh.agents if a.role != "compliance"]
+    for role_agents in list(researcher.peers._agent_registry.values()):
+        for a in list(role_agents):
+            if a.role == "compliance":
+                role_agents.remove(a)
+    await asyncio.sleep(0.2)
+    print(researcher.peers.get_cognitive_context())
+    print(">>> Gone from the prompt. Nothing to clean up.")
+
+    analyst_loop.cancel()
+    print("\nNo org chart was harmed in the making of this demo.\n")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/jarviscore/core/mesh.py
+++ b/jarviscore/core/mesh.py
@@ -1030,7 +1030,9 @@ class Mesh:
             _spec.loader.exec_module(_mod)
             PeerClient = _mod.PeerClient
 
-        is_p2p = self.mode == MeshMode.P2P
+        # Derive P2P from the live coordinator, not self.mode — the mode shim is
+        # assigned later in start(), so it is still "auto" at injection time.
+        is_p2p = self._p2p_coordinator is not None
 
         node_id = ""
         if is_p2p and self._p2p_coordinator and self._p2p_coordinator.swim_manager:


### PR DESCRIPTION
## The bug

`Mesh._inject_peer_clients()` decides whether the mesh is P2P by reading `self.mode`:

```python
is_p2p = self.mode == MeshMode.P2P
coordinator = self._p2p_coordinator if is_p2p else None
```

But `self.mode` is only assigned to `MeshMode("p2p")` at **step 10** of `start()` — 66 lines *after* `_inject_peer_clients()` runs at **step 5**:

| line | what happens |
|---|---|
| 180 | `self.mode = MeshMode("auto")` |
| 374 | `self._inject_peer_clients()` ← reads `self.mode`, still `"auto"` |
| 440 | `self.mode = MeshMode("p2p")` ← set here, too late |

So `is_p2p` is always `False` at injection time, and **every `PeerClient` is built with `coordinator=None`** — even when SWIM is up and the mesh is fully formed.

## Impact

Two user-visible failures on any multi-process deployment:

1. **Remote agents are invisible to the agent.** `list_peers()` falls back to local agents only, so remote peers never reach `get_cognitive_context()`, `build_system_prompt()`, or the `ask_peer` tool schema. The self-updating roster silently works in-process only.
2. **Inbound cross-node peer requests can't be delivered.** `register_peer_client()` is skipped, so `_find_peer_client_by_role_or_id()` has nothing to route to. Symptom in logs:
   ```
   CONNECTION_READINESS: Connection to ZMQ node ... not ready AND SWIM reports not alive. Failing message.
   RETRY_LOGIC: Skipping retry for ... - target not alive per SWIM.
   ```

Note the gossip layer itself was fine throughout — `remote_agents` climbed 0 → 1 → 2 correctly. The data arrived; the agent just never got a handle to read it.

## The fix

```python
is_p2p = self._p2p_coordinator is not None
```

Derive P2P-ness from the live coordinator instead of the mode shim. `MeshMode` is already documented in this file as a deprecated back-compat shim, so keying core wiring off it was the underlying mistake — presence of the coordinator is the actual fact being tested, and it's true at the moment injection runs.

## Verification

Three independent OS processes, real SWIM/ZMQ, ports 7951 / 7952 / 7953 with the analyst as seed:

**Before**
```
000.470|UP    transports=['peer_local', 'peer_swim']
000.470|SWIM  coordinator=attached peer_client_coord=MISSING
        (no JOIN / ROSTER events ever fire; peer request is dropped)
```

**After**
```
000.470|SWIM  coordinator=attached peer_client_coord=ok
050.178|JOIN  'compliance' appeared in my roster
070.188|JOIN  'coordinator' appeared in my roster
100.150|ASK   sending real peer request to 'analyst' over the mesh
100.384|REPLY from 'analyst' :: {'exposure': '$1.4M', 'risk': 'elevated', ...}
```

Cross-process request/reply over ZMQ completed in **234ms**.

## Test suite

No regressions — identical results before and after:

```
BASELINE: 45 failed, 1409 passed, 43 skipped, 1 xfailed
WITH FIX: 45 failed, 1409 passed, 43 skipped, 1 xfailed
```

The 45 pre-existing failures are an unrelated httpx/openai incompatibility (`'AsyncHttpxClientWrapper' object has no attribute '_mounts'`).

## Also included

`examples/mesh_live_roster_demo.py` — runs with no API key, no Redis, no config. Demonstrates the roster regenerating itself as agents join and leave, and that the `ask_peer` tool schema is enum-constrained to agents that are actually online.

## Follow-ups (not in this PR)

- **No `LEAVE` convergence.** When a node is killed, SWIM marks it `SUSPECT` → `DEAD`, but the remote-agent registry doesn't appear to prune, so rosters only ever grow. Worth a separate issue.
- **Capability announcement is one-shot at startup.** Late joiners are only discovered because the demo re-announces on a timer; the framework may want a periodic re-announce built in.
- Consider adding `httpx[socks]` as an extra — LLM providers fail behind a SOCKS proxy without `socksio`.
