### PR TITLE
fix: preserve Athena v0.1.5 context fields

### DIFF
--- a/jarviscore/docs/changelog.md
+++ b/jarviscore/docs/changelog.md
@@ -24,6 +24,19 @@ All notable changes to JarvisCore Framework are documented here. This project fo
 
 <div class="changelog-release" markdown>
 
+## 1.3.2 <span class="changelog-date">2026-09-01</span>
+
+**Fixed**
+
+- Athena v0.1.5 `GetContext` responses now retain canonical `relevantPages`
+  as MTM chains instead of silently dropping cross-session summaries. The
+  client also preserves segments, user persona, and LTPM status while keeping
+  compatibility with legacy response aliases.
+
+</div>
+
+<div class="changelog-release" markdown>
+
 ## 1.3.1
 
 **Added**

--- a/jarviscore/memory/athena_client.py
+++ b/jarviscore/memory/athena_client.py
@@ -274,6 +274,9 @@ class AthenaClient:
             Dict with keys:
                 stm_events: List[dict]  — recent turn events
                 mtm_chains: List[dict]  — summarised cognitive chains
+                segments: List[dict]    — Athena memory segments
+                user_persona: dict | None — inferred user persona
+                ltpm: dict | None       — long-term persistent-memory status
                 heat_score: float       — session heat (0.0–1.0)
         """
         try:
@@ -285,13 +288,35 @@ class AthenaClient:
             resp.raise_for_status()
             data = resp.json()
             return {
-                "stm_events": data.get("events", data.get("stmEvents", [])),
-                "mtm_chains": data.get("chains", data.get("mtmChains", [])),
-                "heat_score": data.get("heatScore", 0.0),
+                "stm_events": data.get(
+                    "stmEvents", data.get("stm_events", data.get("events", []))
+                ),
+                "mtm_chains": data.get(
+                    "relevantPages",
+                    data.get(
+                        "relevant_pages",
+                        data.get("mtmChains", data.get("chains", [])),
+                    ),
+                ),
+                "segments": data.get("segments", []),
+                "user_persona": data.get(
+                    "userPersona", data.get("user_persona")
+                ),
+                "ltpm": data.get("ltpm"),
+                "heat_score": data.get(
+                    "heatScore", data.get("heat_score", 0.0)
+                ),
             }
         except Exception as exc:
             logger.debug(f"[Athena] get_context failed: {exc}")
-            return {"stm_events": [], "mtm_chains": [], "heat_score": 0.0}
+            return {
+                "stm_events": [],
+                "mtm_chains": [],
+                "segments": [],
+                "user_persona": None,
+                "ltpm": None,
+                "heat_score": 0.0,
+            }
 
     async def search_memory(
         self,

--- a/jarviscore/memory/athena_memory.py
+++ b/jarviscore/memory/athena_memory.py
@@ -5,6 +5,9 @@ AthenaMemory — plugs into UnifiedMemory as an optional fourth tier.
 
 When an AthenaClient is wired in, every log_turn() write goes to BOTH
 the Redis EpisodicLedger AND Athena STM. The kernel's rehydrate_bundle()
+                            "segments": [...],     # memory segments when requested/available
+                            "user_persona": {...}, # inferred persona when available
+                            "ltpm": {...},         # long-term persistent-memory status
 call also pulls Athena MTM chains (summarised cognitive chains) as
 additional context, giving agents cross-session, semantically searchable
 memory instead of just the raw Redis stream.
@@ -31,7 +34,6 @@ from typing import Any, Dict, List, Optional
 from .athena_client import (
     AthenaClient,
     ROLE_AGENT,
-    ROLE_SYSTEM,
     TYPE_ACTION,
     TYPE_OBSERVATION,
     TYPE_THOUGHT,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "jarviscore-framework"
-version = "1.3.1"
+version = "1.3.2"
 description = "Orchestrate multi-agent systems with peer-to-peer coordination, unified memory, and built-in auth."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/test_athena_client.py
+++ b/tests/test_athena_client.py
@@ -1,0 +1,81 @@
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from jarviscore.memory.athena_client import AthenaClient
+
+
+def _response(payload):
+    response = MagicMock()
+    response.raise_for_status = MagicMock()
+    response.json.return_value = payload
+    return response
+
+
+@pytest.mark.asyncio
+async def test_get_context_preserves_athena_v015_response_fields():
+    client = AthenaClient("http://athena.test")
+    http = AsyncMock()
+    http.get.return_value = _response(
+        {
+            "stmEvents": [{"role": "user", "content": "recent"}],
+            "relevantPages": [{"id": "chain-1", "summary": "prior decision"}],
+            "segments": [{"id": "segment-1", "content": "evidence"}],
+            "userPersona": {"userId": "owner"},
+            "ltpm": {"status": "ready"},
+        }
+    )
+    client._client = http
+
+    context = await client.get_context("session-1", limit=7)
+
+    http.get.assert_awaited_once_with(
+        "/api/v1/sessions/session-1/context", params={"limit": 7}
+    )
+    assert context == {
+        "stm_events": [{"role": "user", "content": "recent"}],
+        "mtm_chains": [{"id": "chain-1", "summary": "prior decision"}],
+        "segments": [{"id": "segment-1", "content": "evidence"}],
+        "user_persona": {"userId": "owner"},
+        "ltpm": {"status": "ready"},
+        "heat_score": 0.0,
+    }
+
+
+@pytest.mark.asyncio
+async def test_get_context_retains_legacy_aliases():
+    client = AthenaClient("http://athena.test")
+    http = AsyncMock()
+    http.get.return_value = _response(
+        {
+            "events": [{"content": "legacy event"}],
+            "chains": [{"summary": "legacy chain"}],
+            "heatScore": 0.4,
+        }
+    )
+    client._client = http
+
+    context = await client.get_context("session-1")
+
+    assert context["stm_events"] == [{"content": "legacy event"}]
+    assert context["mtm_chains"] == [{"summary": "legacy chain"}]
+    assert context["heat_score"] == 0.4
+
+
+@pytest.mark.asyncio
+async def test_get_context_failure_returns_complete_empty_shape():
+    client = AthenaClient("http://athena.test")
+    http = AsyncMock()
+    http.get.side_effect = RuntimeError("offline")
+    client._client = http
+
+    context = await client.get_context("session-1")
+
+    assert context == {
+        "stm_events": [],
+        "mtm_chains": [],
+        "segments": [],
+        "user_persona": None,
+        "ltpm": None,
+        "heat_score": 0.0,
+    }


### PR DESCRIPTION
## Summary

Fixes #126.

JarvisCore now parses Athena v0.1.5's canonical `GetContext` response instead of silently dropping `relevantPages`. The normalized context also retains segments, user persona, and LTPM status while preserving legacy aliases.

This is released as `1.3.2`, a backward-compatible patch over public `1.3.1`.

## Validation

- `tests/test_athena_client.py`: 3 passed
- Athena client + `UnifiedMemory`: 18 passed
- Cloud deployment slice with host infrastructure variables sanitized: 12 passed
- P2P diagnostics: 15 passed
- Remaining post-stall suite tail: 183 passed
- Redis store: 51 passed
- Ruff on touched Python files: clean
- Wheel and sdist built as `1.3.2`; `twine check`: passed
- The monolithic suite is not fully green on current `main`: the unrelated
	`tests/test_fanout.py::TestAggregation::test_run_fanout_validates_inputs`
	calls `asyncio.get_event_loop()` after async tests and fails under Python 3.12
	because no current loop exists. It fails independently without this patch;
	the other 11 fan-out tests pass.

## Compatibility

Existing `stm_events`, `mtm_chains`, and `heat_score` keys remain. New normalized keys are additive: `segments`, `user_persona`, and `ltpm`.
