### PR TITLE
feat: complete Athena v0.1.6 client surface

### DIFF
--- a/jarviscore/config/settings.py
+++ b/jarviscore/config/settings.py
@@ -21,7 +21,6 @@ or as per-process env vars — not in a shared .env file.
     JARVISCORE_BIND_PORT=7949 python research_synthesizer.py
     JARVISCORE_BIND_PORT=7946 python research_node_1.py
 """
-import os
 from typing import Optional
 from pydantic import Field
 from pydantic_settings import BaseSettings
@@ -213,6 +212,8 @@ class Settings(BaseSettings):
     athena_tenant_id: str = "default"          # Namespace for multi-tenant Athena deployments
     athena_http_timeout: float = 10.0           # Seconds before Athena HTTP call times out
     athena_session_ttl_days: int = 30           # How long session_id is cached in Redis
+    athena_api_key: Optional[str] = None         # Optional Athena X-API-Key credential
+    athena_jwt_token: Optional[str] = None       # Optional Athena X-JWT-Token credential
 
 
     # === Browser ===

--- a/jarviscore/data/.env.example
+++ b/jarviscore/data/.env.example
@@ -73,6 +73,8 @@
 #
 # ATHENA_URL=http://localhost:8080
 # ATHENA_TENANT_ID=default
+# ATHENA_API_KEY=
+# ATHENA_JWT_TOKEN=
 
 
 # ═══════════════════════════════════════════════════════════════

--- a/jarviscore/docs/changelog.md
+++ b/jarviscore/docs/changelog.md
@@ -24,6 +24,26 @@ All notable changes to JarvisCore Framework are documented here. This project fo
 
 <div class="changelog-release" markdown>
 
+## 1.4.0 <span class="changelog-date">2026-09-01</span>
+
+**Added**
+
+- Athena v0.1.6 client parity for session reads/deletes, interactions,
+  query-aware context, metadata-filtered semantic search, topics, segments,
+  graph analytics, structured payloads, source timestamps, and durable event
+  IDs through `store_event_with_id()`.
+- Optional `ATHENA_API_KEY` and `ATHENA_JWT_TOKEN` authentication headers.
+
+**Changed**
+
+- `store_event()` remains boolean for compatibility while accepting optional
+  timestamp, payload, and MIME arguments. Closed HTTP clients are recreated on
+  the next request instead of permanently disabling Athena access.
+
+</div>
+
+<div class="changelog-release" markdown>
+
 ## 1.3.2 <span class="changelog-date">2026-09-01</span>
 
 **Fixed**

--- a/jarviscore/docs/concepts/memory.md
+++ b/jarviscore/docs/concepts/memory.md
@@ -174,26 +174,44 @@ if athena:
     )
     await am.on_task_assigned("task-1", "Analyse Q1 revenue trends", "researcher")
     ctx = await am.get_memory_context(limit=15)
+
+    event_id = await athena.store_event_with_id(
+        am.session_id,
+        "agent",
+        "observation",
+        "Q1 analysis completed",
+        {"workflow_id": "q1-analysis"},
+        payload=b'{"revenue_growth": 0.18}',
+        mime_type="application/json",
+    )
+    related = await athena.search_memory(
+        am.session_id,
+        "prior revenue analysis",
+        metadata_filter={"origin_service": "jarviscore"},
+    )
 ```
 
-The `get_athena_client()` factory reads `ATHENA_URL` and `ATHENA_TENANT_ID` from the environment and returns `None` if `ATHENA_URL` is not set. This lets you safely call `get_athena_client()` unconditionally and treat the result as optional.
+The `get_athena_client()` factory reads `ATHENA_URL`, `ATHENA_TENANT_ID`,
+`ATHENA_HTTP_TIMEOUT`, `ATHENA_API_KEY`, and `ATHENA_JWT_TOKEN` from the
+environment and returns `None` if `ATHENA_URL` is not set. This lets you safely
+call it unconditionally and treat the result as optional.
 
 ---
 
 ## Setting Up Athena
 
-Athena runs as a Docker-composed stack. The `jarviscore memory init` command automates the setup from source.
+Athena runs as a Docker-composed stack. The `jarviscore memory init` command
+pulls the published Athena image and starts the complete memory stack.
 
 ```bash
-git clone https://github.com/Prescott-Data/athena ~/athena
 jarviscore memory init
 ```
 
 `memory init` performs the following steps automatically:
 
-1. Locates the Athena source repository at `~/athena` or at the path set in `ATHENA_DIR`.
-2. Detects an LLM API key from the current environment (prefers Gemini, then Anthropic, then OpenAI).
-3. Builds and starts all Athena services with `docker compose up -d --build`.
+1. Detects an LLM API key from the current environment.
+2. Pulls and starts the published Athena image and its backing services.
+3. Keeps `--from-source` available for Athena contributors with a local checkout.
 4. Waits up to 90 seconds for the Athena health endpoint to return `ok`.
 5. Writes `ATHENA_URL=http://localhost:8080` to the project `.env` file.
 
@@ -203,8 +221,9 @@ After setup, verify that all memory tiers are reachable:
 jarviscore memory status
 ```
 
-!!! note "First-build duration"
-    The first `memory init` build takes approximately two minutes because it compiles the Milvus vector database from source. Subsequent starts use Docker layer caching and complete in under 10 seconds.
+!!! note "Developing Athena itself"
+    Run `jarviscore memory init --from-source` to build from `ATHENA_DIR`,
+    `~/athena`, or a sibling Athena checkout instead of pulling the image.
 
 ---
 

--- a/jarviscore/docs/reference/configuration.md
+++ b/jarviscore/docs/reference/configuration.md
@@ -135,6 +135,8 @@ Athena provides three-tier persistent memory (STM, MTM, and LTM graph) that span
 | `ATHENA_TENANT_ID` | `default` | Tenant namespace for memory isolation across teams or environments |
 | `ATHENA_HTTP_TIMEOUT` | `10.0` | Seconds before an Athena HTTP call times out. Increase if your Athena instance is remote or under load. |
 | `ATHENA_SESSION_TTL_DAYS` | `30` | How long a session ID is cached in Redis before Athena re-issues it. |
+| `ATHENA_API_KEY` | — | Optional API key sent as `X-API-Key`. Keep it out of prompts and logs. |
+| `ATHENA_JWT_TOKEN` | — | Optional JWT sent as `X-JWT-Token` for tenant/user isolation. |
 | `ATHENA_PORT` | `8080` | Host port for the Athena server when the stack is started by `memory init` |
 
 Every published port in the local stack is overridable for co-located deployments: `ATHENA_REDIS_PORT` (6380), `ATHENA_MONGO_PORT` (27017), `ATHENA_MINIO_PORT` (9000), `ATHENA_MINIO_CONSOLE_PORT` (9001), `ATHENA_MILVUS_PORT` (19530), `ATHENA_MILVUS_METRICS_PORT` (9091), `ATHENA_ARANGO_PORT` (8529).

--- a/jarviscore/memory/__init__.py
+++ b/jarviscore/memory/__init__.py
@@ -58,6 +58,8 @@ def get_athena_client(settings=None) -> "AthenaClient | None":
         if athena:
             am = await AthenaMemory.create("my-agent", athena, redis_store)
     """
+    import os
+
     if settings is None:
         try:
             from jarviscore.config.settings import settings as _s
@@ -67,7 +69,6 @@ def get_athena_client(settings=None) -> "AthenaClient | None":
 
     url = (getattr(settings, "athena_url", None) or "").strip()
     if not url:
-        import os
         url = os.getenv("ATHENA_URL", "").strip()
 
     if not url:
@@ -75,4 +76,12 @@ def get_athena_client(settings=None) -> "AthenaClient | None":
 
     tenant = getattr(settings, "athena_tenant_id", "default")
     timeout = getattr(settings, "athena_http_timeout", 10.0)
-    return AthenaClient(base_url=url, tenant_id=tenant, timeout=timeout)
+    api_key = getattr(settings, "athena_api_key", None) or os.getenv("ATHENA_API_KEY")
+    jwt_token = getattr(settings, "athena_jwt_token", None) or os.getenv("ATHENA_JWT_TOKEN")
+    return AthenaClient(
+        base_url=url,
+        tenant_id=tenant,
+        timeout=timeout,
+        api_key=api_key,
+        jwt_token=jwt_token,
+    )

--- a/jarviscore/memory/athena_client.py
+++ b/jarviscore/memory/athena_client.py
@@ -12,7 +12,9 @@ It adds zero dependencies — httpx is already in jarviscore core.
 
 Configuration:
     ATHENA_URL=http://localhost:8080   (required to enable Athena)
-    ATHENA_TENANT_ID=my-app          (default: "default")
+    ATHENA_TENANT_ID=my-app            (default: "default")
+    ATHENA_API_KEY=...                 (optional X-API-Key authentication)
+    ATHENA_JWT_TOKEN=...               (optional X-JWT-Token authentication)
 
 Graceful degradation:
     If ATHENA_URL is not set, all methods return empty/None and log a
@@ -35,8 +37,10 @@ Athena API reference (memory.proto → HTTP gateway):
 
 from __future__ import annotations
 
+import base64
 import logging
 import os
+from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional
 
 logger = logging.getLogger(__name__)
@@ -72,10 +76,14 @@ class AthenaClient:
         base_url: str,
         tenant_id: str = "default",
         timeout: float = 10.0,
+        api_key: Optional[str] = None,
+        jwt_token: Optional[str] = None,
     ) -> None:
         self._base_url = base_url.rstrip("/")
         self._tenant_id = tenant_id
         self._timeout = timeout
+        self._api_key = api_key
+        self._jwt_token = jwt_token
         self._client = None  # lazy-init httpx.AsyncClient
 
     @classmethod
@@ -99,16 +107,30 @@ class AthenaClient:
             )
             return None
         tenant = os.getenv("ATHENA_TENANT_ID", "default")
-        return cls(base_url=url, tenant_id=tenant)
+        timeout = float(os.getenv("ATHENA_HTTP_TIMEOUT", "10.0"))
+        return cls(
+            base_url=url,
+            tenant_id=tenant,
+            timeout=timeout,
+            api_key=os.getenv("ATHENA_API_KEY") or None,
+            jwt_token=os.getenv("ATHENA_JWT_TOKEN") or None,
+        )
 
-    async def _http(self) :
+    async def _http(self):
         """Lazy-init httpx.AsyncClient (imported only when actually used)."""
-        if self._client is None:
+        is_closed = getattr(self._client, "is_closed", False)
+        if self._client is None or is_closed is True:
             import httpx  # already in jarviscore core deps
+
+            headers = {"Content-Type": "application/json"}
+            if self._api_key:
+                headers["X-API-Key"] = self._api_key
+            if self._jwt_token:
+                headers["X-JWT-Token"] = self._jwt_token
             self._client = httpx.AsyncClient(
                 base_url=self._base_url,
                 timeout=self._timeout,
-                headers={"Content-Type": "application/json"},
+                headers=headers,
             )
         return self._client
 
@@ -119,6 +141,29 @@ class AthenaClient:
             self._client = None
 
     # ── Session Management ────────────────────────────────────────────────────
+
+    async def get_session(self, session_id: str) -> Optional[Dict[str, Any]]:
+        """Return one Athena session, or ``None`` when it cannot be read."""
+        try:
+            http = await self._http()
+            resp = await http.get(f"/api/v1/sessions/{session_id}")
+            resp.raise_for_status()
+            data = resp.json()
+            return data.get("session") or data
+        except Exception as exc:
+            logger.debug(f"[Athena] get_session failed for '{session_id}': {exc}")
+            return None
+
+    async def delete_session(self, session_id: str) -> bool:
+        """Delete one Athena session."""
+        try:
+            http = await self._http()
+            resp = await http.delete(f"/api/v1/sessions/{session_id}")
+            resp.raise_for_status()
+            return bool(resp.json().get("success", False))
+        except Exception as exc:
+            logger.warning(f"[Athena] delete_session failed for '{session_id}': {exc}")
+            return False
 
     async def create_session(
         self,
@@ -208,6 +253,39 @@ class AthenaClient:
 
     # ── Memory Writes ─────────────────────────────────────────────────────────
 
+    async def store_interaction(
+        self,
+        session_id: str,
+        user_message: str,
+        agent_response: str,
+        metadata: Optional[Dict[str, str]] = None,
+        timestamp: Optional[datetime | str] = None,
+    ) -> bool:
+        """Store one user-agent exchange through Athena's interaction API."""
+        try:
+            http = await self._http()
+            payload: Dict[str, Any] = {
+                "session_id": session_id,
+                "user_message": user_message,
+                "agent_response": agent_response,
+                "metadata": {
+                    "tenant_id": self._tenant_id,
+                    "origin_service": "jarviscore",
+                    **(metadata or {}),
+                },
+            }
+            serialized_timestamp = _rfc3339(timestamp)
+            if serialized_timestamp:
+                payload["timestamp"] = serialized_timestamp
+            resp = await http.post(
+                f"/api/v1/sessions/{session_id}/interactions", json=payload
+            )
+            resp.raise_for_status()
+            return bool(resp.json().get("success", False))
+        except Exception as exc:
+            logger.warning(f"[Athena] store_interaction failed: {exc}")
+            return False
+
     async def store_event(
         self,
         session_id: str,
@@ -215,6 +293,10 @@ class AthenaClient:
         event_type: str,
         content: str,
         metadata: Optional[Dict[str, str]] = None,
+        *,
+        timestamp: Optional[datetime | str] = None,
+        payload: Optional[bytes] = None,
+        mime_type: Optional[str] = None,
     ) -> bool:
         """
         Store a single typed event in Athena STM.
@@ -227,13 +309,69 @@ class AthenaClient:
             event_type:  TYPE_MESSAGE / TYPE_THOUGHT / TYPE_ACTION / TYPE_OBSERVATION
             content:     The event text content
             metadata:    Optional k/v enrichment (task_id, workflow_id, etc.)
+            timestamp:   Optional occurrence time as datetime or RFC3339 string
+            payload:     Optional exact binary payload, base64-encoded for REST
+            mime_type:   Required MIME type when payload is provided
 
         Returns:
             True if stored successfully, False on error.
         """
+        result = await self._store_event(
+            session_id,
+            role,
+            event_type,
+            content,
+            metadata,
+            timestamp=timestamp,
+            payload=payload,
+            mime_type=mime_type,
+        )
+        return result is not None
+
+    async def store_event_with_id(
+        self,
+        session_id: str,
+        role: str,
+        event_type: str,
+        content: str,
+        metadata: Optional[Dict[str, str]] = None,
+        *,
+        timestamp: Optional[datetime | str] = None,
+        payload: Optional[bytes] = None,
+        mime_type: Optional[str] = None,
+    ) -> Optional[str]:
+        """Store an event and return its durable Athena event ID."""
+        result = await self._store_event(
+            session_id,
+            role,
+            event_type,
+            content,
+            metadata,
+            timestamp=timestamp,
+            payload=payload,
+            mime_type=mime_type,
+        )
+        if result is None:
+            return None
+        return str(result.get("eventId") or result.get("event_id") or "") or None
+
+    async def _store_event(
+        self,
+        session_id: str,
+        role: str,
+        event_type: str,
+        content: str,
+        metadata: Optional[Dict[str, str]],
+        *,
+        timestamp: Optional[datetime | str],
+        payload: Optional[bytes],
+        mime_type: Optional[str],
+    ) -> Optional[Dict[str, Any]]:
+        if payload is not None and not mime_type:
+            raise ValueError("mime_type is required when payload is provided")
         try:
             http = await self._http()
-            payload: Dict[str, Any] = {
+            request: Dict[str, Any] = {
                 "session_id": session_id,
                 "role": role,
                 "type": event_type,
@@ -244,14 +382,21 @@ class AthenaClient:
                     **(metadata or {}),
                 },
             }
+            serialized_timestamp = _rfc3339(timestamp)
+            if serialized_timestamp:
+                request["timestamp"] = serialized_timestamp
+            if payload is not None:
+                request["payload"] = base64.b64encode(payload).decode("ascii")
+                request["mime_type"] = mime_type
             resp = await http.post(
-                f"/api/v1/sessions/{session_id}/events", json=payload
+                f"/api/v1/sessions/{session_id}/events", json=request
             )
             resp.raise_for_status()
-            return True
+            data = resp.json()
+            return data if data.get("success", True) else None
         except Exception as exc:
             logger.warning(f"[Athena] store_event failed: {exc}")
-            return False
+            return None
 
     # ── Memory Reads ──────────────────────────────────────────────────────────
 
@@ -259,6 +404,9 @@ class AthenaClient:
         self,
         session_id: str,
         limit: int = 20,
+        *,
+        query: str = "",
+        include_segments: bool = False,
     ) -> Dict[str, Any]:
         """
         Retrieve recent STM events + relevant MTM chains from Athena.
@@ -281,10 +429,12 @@ class AthenaClient:
         """
         try:
             http = await self._http()
-            resp = await http.get(
-                f"/api/v1/sessions/{session_id}/context",
-                params={"limit": limit},
-            )
+            params: Dict[str, Any] = {"limit": limit}
+            if query:
+                params["query"] = query
+            if include_segments:
+                params["includeSegments"] = True
+            resp = await http.get(f"/api/v1/sessions/{session_id}/context", params=params)
             resp.raise_for_status()
             data = resp.json()
             return {
@@ -324,6 +474,7 @@ class AthenaClient:
         query: str,
         limit: int = 5,
         similarity_threshold: float = 0.7,
+        metadata_filter: Optional[Dict[str, str]] = None,
     ) -> List[Dict[str, Any]]:
         """
         Semantic search across the agent's memory (MTM vector store).
@@ -345,6 +496,7 @@ class AthenaClient:
                 "query": query,
                 "limit": limit,
                 "similarity_threshold": similarity_threshold,
+                "filter": metadata_filter or {},
             }
             resp = await http.post(
                 f"/api/v1/sessions/{session_id}/context/search", json=payload
@@ -355,6 +507,41 @@ class AthenaClient:
         except Exception as exc:
             logger.debug(f"[Athena] search_memory failed: {exc}")
             return []
+
+    async def analyze_topics(self, session_id: str) -> List[Dict[str, Any]]:
+        """Return Athena's topic analysis for a session."""
+        try:
+            http = await self._http()
+            resp = await http.get(f"/api/v1/sessions/{session_id}/analysis/topics")
+            resp.raise_for_status()
+            return resp.json().get("topics", [])
+        except Exception as exc:
+            logger.debug(f"[Athena] analyze_topics failed: {exc}")
+            return []
+
+    async def get_segments(self, session_id: str, limit: int = 20) -> List[Dict[str, Any]]:
+        """Return Athena memory segments for a session."""
+        try:
+            http = await self._http()
+            resp = await http.get(
+                f"/api/v1/sessions/{session_id}/segments", params={"limit": limit}
+            )
+            resp.raise_for_status()
+            return resp.json().get("segments", [])
+        except Exception as exc:
+            logger.debug(f"[Athena] get_segments failed: {exc}")
+            return []
+
+    async def trigger_graph_analytics(self) -> bool:
+        """Trigger Athena's administrative graph-analytics job."""
+        try:
+            http = await self._http()
+            resp = await http.post("/api/v1/admin/analytics/trigger", json={})
+            resp.raise_for_status()
+            return bool(resp.json().get("success", False))
+        except Exception as exc:
+            logger.warning(f"[Athena] trigger_graph_analytics failed: {exc}")
+            return False
 
     async def get_heat_metrics(self, session_id: str) -> Dict[str, Any]:
         """
@@ -370,7 +557,8 @@ class AthenaClient:
             http = await self._http()
             resp = await http.get(f"/api/v1/sessions/{session_id}/analysis/heat")
             resp.raise_for_status()
-            return resp.json()
+            data = resp.json()
+            return data.get("heatMetrics", data.get("heat_metrics", data))
         except Exception as exc:
             logger.debug(f"[Athena] get_heat_metrics failed: {exc}")
             return {}
@@ -399,3 +587,12 @@ class AthenaClient:
             return resp.json()
         except Exception as exc:
             return {"status": "unreachable", "error": str(exc)}
+
+
+def _rfc3339(value: Optional[datetime | str]) -> Optional[str]:
+    if value is None:
+        return None
+    if isinstance(value, str):
+        return value
+    moment = value if value.tzinfo else value.replace(tzinfo=timezone.utc)
+    return moment.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "jarviscore-framework"
-version = "1.3.2"
+version = "1.4.0"
 description = "Orchestrate multi-agent systems with peer-to-peer coordination, unified memory, and built-in auth."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/test_athena_client.py
+++ b/tests/test_athena_client.py
@@ -1,8 +1,11 @@
-from unittest.mock import AsyncMock, MagicMock
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 from jarviscore.memory.athena_client import AthenaClient
+from jarviscore.memory import get_athena_client
 
 
 def _response(payload):
@@ -79,3 +82,187 @@ async def test_get_context_failure_returns_complete_empty_shape():
         "ltpm": None,
         "heat_score": 0.0,
     }
+
+
+@pytest.mark.asyncio
+async def test_get_context_sends_query_and_segment_options():
+    client = AthenaClient("http://athena.test")
+    http = AsyncMock()
+    http.get.return_value = _response({})
+    client._client = http
+
+    await client.get_context(
+        "session-1", limit=8, query="prior decisions", include_segments=True
+    )
+
+    http.get.assert_awaited_once_with(
+        "/api/v1/sessions/session-1/context",
+        params={
+            "limit": 8,
+            "query": "prior decisions",
+            "includeSegments": True,
+        },
+    )
+
+
+@pytest.mark.asyncio
+async def test_store_event_with_id_serializes_payload_and_timestamp():
+    client = AthenaClient("http://athena.test", tenant_id="tenant-1")
+    http = AsyncMock()
+    http.post.return_value = _response(
+        {"success": True, "eventId": "68b5f26cc7e80f7a577792a1"}
+    )
+    client._client = http
+
+    event_id = await client.store_event_with_id(
+        "session-1",
+        "agent",
+        "observation",
+        "structured result",
+        {"workflow_id": "wf-1"},
+        timestamp=datetime(2026, 9, 1, 12, 30, tzinfo=timezone.utc),
+        payload=b'{"result": 42}',
+        mime_type="application/json",
+    )
+
+    assert event_id == "68b5f26cc7e80f7a577792a1"
+    request = http.post.await_args.kwargs["json"]
+    assert request["timestamp"] == "2026-09-01T12:30:00Z"
+    assert request["payload"] == "eyJyZXN1bHQiOiA0Mn0="
+    assert request["mime_type"] == "application/json"
+    assert request["metadata"] == {
+        "tenant_id": "tenant-1",
+        "origin_service": "jarviscore",
+        "workflow_id": "wf-1",
+    }
+
+
+@pytest.mark.asyncio
+async def test_store_event_keeps_boolean_compatibility():
+    client = AthenaClient("http://athena.test")
+    http = AsyncMock()
+    http.post.return_value = _response({"success": True, "eventId": "event-1"})
+    client._client = http
+
+    assert await client.store_event(
+        "session-1", "agent", "observation", "result"
+    ) is True
+
+
+@pytest.mark.asyncio
+async def test_store_event_requires_mime_type_for_payload():
+    client = AthenaClient("http://athena.test")
+    with pytest.raises(ValueError, match="mime_type"):
+        await client.store_event(
+            "session-1", "agent", "observation", "result", payload=b"data"
+        )
+
+
+@pytest.mark.asyncio
+async def test_search_memory_sends_metadata_filter():
+    client = AthenaClient("http://athena.test")
+    http = AsyncMock()
+    http.post.return_value = _response({"results": [{"sourceId": "chain-1"}]})
+    client._client = http
+
+    results = await client.search_memory(
+        "session-1",
+        "gold decisions",
+        limit=3,
+        similarity_threshold=0.8,
+        metadata_filter={"origin_service": "billy"},
+    )
+
+    assert results == [{"sourceId": "chain-1"}]
+    assert http.post.await_args.kwargs["json"]["filter"] == {
+        "origin_service": "billy"
+    }
+
+
+@pytest.mark.asyncio
+async def test_session_interaction_and_analysis_methods():
+    client = AthenaClient("http://athena.test")
+    http = AsyncMock()
+    http.get.side_effect = [
+        _response({"session": {"sessionId": "session-1"}}),
+        _response({"topics": [{"topic": "markets"}]}),
+        _response({"segments": [{"id": "segment-1"}]}),
+    ]
+    http.post.side_effect = [
+        _response({"success": True}),
+        _response({"success": True}),
+    ]
+    http.delete.return_value = _response({"success": True})
+    client._client = http
+
+    assert await client.get_session("session-1") == {"sessionId": "session-1"}
+    assert await client.store_interaction(
+        "session-1", "question", "answer", {"channel": "telegram"}
+    ) is True
+    assert await client.analyze_topics("session-1") == [{"topic": "markets"}]
+    assert await client.get_segments("session-1", limit=4) == [{"id": "segment-1"}]
+    assert await client.trigger_graph_analytics() is True
+    assert await client.delete_session("session-1") is True
+    assert http.get.await_args_list[-1].kwargs["params"] == {"limit": 4}
+
+
+@pytest.mark.asyncio
+async def test_heat_metrics_unwraps_canonical_response():
+    client = AthenaClient("http://athena.test")
+    http = AsyncMock()
+    http.get.return_value = _response(
+        {"heatMetrics": {"overallHeat": 0.7, "totalInteractions": 12}}
+    )
+    client._client = http
+
+    metrics = await client.get_heat_metrics("session-1")
+
+    assert metrics == {"overallHeat": 0.7, "totalInteractions": 12}
+
+
+def test_from_env_loads_auth_tenant_and_timeout(monkeypatch):
+    monkeypatch.setenv("ATHENA_URL", "https://athena.example")
+    monkeypatch.setenv("ATHENA_TENANT_ID", "tenant-1")
+    monkeypatch.setenv("ATHENA_HTTP_TIMEOUT", "4.5")
+    monkeypatch.setenv("ATHENA_API_KEY", "api-secret")
+    monkeypatch.setenv("ATHENA_JWT_TOKEN", "jwt-secret")
+
+    client = AthenaClient.from_env()
+
+    assert client is not None
+    assert client._tenant_id == "tenant-1"
+    assert client._timeout == 4.5
+    assert client._api_key == "api-secret"
+    assert client._jwt_token == "jwt-secret"
+
+
+@pytest.mark.asyncio
+async def test_http_recreates_only_a_boolean_closed_client():
+    client = AthenaClient("http://athena.test", api_key="api-secret")
+    closed = MagicMock()
+    closed.is_closed = True
+    client._client = closed
+    replacement = MagicMock()
+
+    with patch("httpx.AsyncClient", return_value=replacement) as constructor:
+        assert await client._http() is replacement
+
+    assert constructor.call_args.kwargs["headers"]["X-API-Key"] == "api-secret"
+
+
+def test_public_factory_uses_environment_auth_fallback(monkeypatch):
+    monkeypatch.setenv("ATHENA_API_KEY", "api-secret")
+    monkeypatch.setenv("ATHENA_JWT_TOKEN", "jwt-secret")
+    settings = SimpleNamespace(
+        athena_url="https://athena.example",
+        athena_tenant_id="tenant-1",
+        athena_http_timeout=3.0,
+        athena_api_key=None,
+        athena_jwt_token=None,
+    )
+
+    client = get_athena_client(settings)
+
+    assert client is not None
+    assert client._api_key == "api-secret"
+    assert client._jwt_token == "jwt-secret"


### PR DESCRIPTION
## Summary

Fixes #127.
Fixes #95.

JarvisCore now exposes Athena v0.1.6's released client surface through one authenticated framework boundary:

- session reads and deletion;
- user-agent interactions;
- query-aware context and optional segments;
- metadata-filtered semantic search;
- topics, heat metrics, segments, and graph analytics;
- binary payloads, MIME types, source timestamps, and durable event IDs;
- optional API-key and JWT headers.

`store_event()` remains boolean for backward compatibility. New consumers that need exact outcome linkage use `store_event_with_id()`. The client also recreates an explicitly closed HTTP transport on the next request.

This is `1.4.0`: the new public methods and settings are additive, backward-compatible API surface and therefore a SemVer minor release.

## Validation

- Athena client + adjacent memory/config tests: 33 passed before final normalization
- Final Athena client + UnifiedMemory: 28 passed
- Every test file run in a fresh process: 90/90 files passed
- Existing fan-out file: 11/12 passed; the unrelated Python 3.12 baseline test calls `asyncio.get_event_loop()` after async tests and fails without this patch
- Ruff on touched Python: clean
- Wheel and sdist built as `1.4.0`; `twine check`: passed
- Editor diagnostics and diff whitespace: clean

## Compatibility

- Existing method names and return contracts remain valid.
- Authentication is opt-in through `ATHENA_API_KEY` or `ATHENA_JWT_TOKEN`.
- Exact event/artifact reads are not simulated; they remain upstream Athena work in issues #34 and #35.
