### PR TITLE
fix: separate Athena user and agent identity

### DIFF
--- a/jarviscore/docs/changelog.md
+++ b/jarviscore/docs/changelog.md
@@ -24,6 +24,19 @@ All notable changes to JarvisCore Framework are documented here. This project fo
 
 <div class="changelog-release" markdown>
 
+## 1.4.1 <span class="changelog-date">2026-09-02</span>
+
+**Fixed**
+
+- Athena session creation now sends distinct `user_id` and `agent_id` fields.
+  Existing callers retain their prior user scope, while applications may opt
+  into a shared user with separate agent memories. Redis session keys now
+  include tenant, user, and agent identity to prevent cross-scope collisions.
+
+</div>
+
+<div class="changelog-release" markdown>
+
 ## 1.4.0 <span class="changelog-date">2026-09-01</span>
 
 **Added**

--- a/jarviscore/memory/athena_client.py
+++ b/jarviscore/memory/athena_client.py
@@ -169,6 +169,8 @@ class AthenaClient:
         self,
         agent_id: str,
         metadata: Optional[Dict[str, str]] = None,
+        *,
+        user_id: Optional[str] = None,
     ) -> Optional[str]:
         """
         Create an Athena memory session for an agent.
@@ -179,6 +181,7 @@ class AthenaClient:
         Args:
             agent_id:  Unique agent identifier (e.g. "researcher", "analyst")
             metadata:  Optional k/v tags (e.g. {"team": "data"})
+            user_id:   Athena user scope. Defaults to ``agent_id`` for compatibility.
 
         Returns:
             Athena session_id string, or None on failure.
@@ -187,7 +190,8 @@ class AthenaClient:
             http = await self._http()
             payload: Dict[str, Any] = {
                 "tenant_id": self._tenant_id,
-                "user_id": agent_id,
+                "user_id": user_id or agent_id,
+                "agent_id": agent_id,
                 "metadata": {
                     "agent_id": agent_id,
                     "origin_service": "jarviscore",
@@ -209,6 +213,8 @@ class AthenaClient:
         agent_id: str,
         redis_store=None,
         metadata: Optional[Dict[str, str]] = None,
+        *,
+        user_id: Optional[str] = None,
     ) -> Optional[str]:
         """
         Return the existing Athena session for this agent, or create one.
@@ -221,16 +227,23 @@ class AthenaClient:
             agent_id:    Unique agent identifier
             redis_store: Optional RedisContextStore for session caching
             metadata:    Tags forwarded to create_session if creating new
+            user_id:     Athena user scope. Defaults to ``agent_id``.
 
         Returns:
             session_id string, or None if creation fails.
         """
-        redis_key = f"athena_session:{agent_id}"
+        resolved_user_id = user_id or agent_id
+        redis_key = f"athena_session:{self._tenant_id}:{resolved_user_id}:{agent_id}"
+        legacy_redis_key = f"athena_session:{agent_id}"
 
         # 1. Try Redis cache
         if redis_store:
             try:
                 cached = redis_store._redis.get(redis_key)
+                if not cached:
+                    cached = redis_store._redis.get(legacy_redis_key)
+                    if cached:
+                        redis_store._redis.set(redis_key, cached, ex=30 * 86400)
                 if cached:
                     logger.debug(f"[Athena] Reusing session for '{agent_id}': {cached}")
                     return cached
@@ -238,7 +251,9 @@ class AthenaClient:
                 pass
 
         # 2. Create new session
-        session_id = await self.create_session(agent_id, metadata)
+        session_id = await self.create_session(
+            agent_id, metadata, user_id=resolved_user_id
+        )
         if not session_id:
             return None
 

--- a/jarviscore/memory/athena_memory.py
+++ b/jarviscore/memory/athena_memory.py
@@ -77,6 +77,8 @@ class AthenaMemory:
         client: AthenaClient,
         redis_store=None,
         metadata: Optional[Dict[str, str]] = None,
+        *,
+        user_id: Optional[str] = None,
     ) -> "AthenaMemory":
         """
         Factory: creates or reuses an Athena session for this agent.
@@ -86,6 +88,7 @@ class AthenaMemory:
             client:      Initialised AthenaClient
             redis_store: Optional — caches session_id so it survives restarts
             metadata:    Tags forwarded to Athena session on creation
+            user_id:     Athena user scope. Defaults to ``agent_id``.
 
         Returns:
             AthenaMemory instance, ready to write/read.
@@ -96,7 +99,10 @@ class AthenaMemory:
             **(metadata or {}),
         }
         session_id = await client.get_or_create_session(
-            agent_id, redis_store=redis_store, metadata=merged_meta
+            agent_id,
+            redis_store=redis_store,
+            metadata=merged_meta,
+            user_id=user_id,
         )
         if not session_id:
             raise RuntimeError(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "jarviscore-framework"
-version = "1.4.0"
+version = "1.4.1"
 description = "Orchestrate multi-agent systems with peer-to-peer coordination, unified memory, and built-in auth."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/test_athena_client.py
+++ b/tests/test_athena_client.py
@@ -1,6 +1,6 @@
 from datetime import datetime, timezone
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, call, patch
 
 import pytest
 
@@ -248,6 +248,92 @@ async def test_http_recreates_only_a_boolean_closed_client():
         assert await client._http() is replacement
 
     assert constructor.call_args.kwargs["headers"]["X-API-Key"] == "api-secret"
+
+
+@pytest.mark.asyncio
+async def test_create_session_sends_distinct_user_and_agent_identity():
+    client = AthenaClient("http://athena.test", tenant_id="tenant-1")
+    http = AsyncMock()
+    http.post.return_value = _response({"sessionId": "session-1"})
+    client._client = http
+
+    session_id = await client.create_session(
+        "billy-conversation", {"channel": "telegram"}, user_id="owner"
+    )
+
+    assert session_id == "session-1"
+    assert http.post.await_args.kwargs["json"] == {
+        "tenant_id": "tenant-1",
+        "user_id": "owner",
+        "agent_id": "billy-conversation",
+        "metadata": {
+            "agent_id": "billy-conversation",
+            "origin_service": "jarviscore",
+            "channel": "telegram",
+        },
+    }
+
+
+@pytest.mark.asyncio
+async def test_create_session_defaults_user_to_agent_for_compatibility():
+    client = AthenaClient("http://athena.test")
+    http = AsyncMock()
+    http.post.return_value = _response({"sessionId": "session-1"})
+    client._client = http
+
+    await client.create_session("researcher")
+
+    request = http.post.await_args.kwargs["json"]
+    assert request["user_id"] == "researcher"
+    assert request["agent_id"] == "researcher"
+
+
+@pytest.mark.asyncio
+async def test_session_cache_key_isolates_tenant_user_and_agent():
+    client = AthenaClient("http://athena.test", tenant_id="tenant-1")
+    redis = MagicMock()
+    redis._redis.get.return_value = None
+    redis._redis.set = MagicMock()
+    client.create_session = AsyncMock(return_value="session-1")
+
+    session_id = await client.get_or_create_session(
+        "analyst", redis_store=redis, user_id="owner"
+    )
+
+    assert session_id == "session-1"
+    assert redis._redis.get.call_args_list == [
+        call("athena_session:tenant-1:owner:analyst"),
+        call("athena_session:analyst"),
+    ]
+    redis._redis.set.assert_called_once_with(
+        "athena_session:tenant-1:owner:analyst", "session-1", ex=30 * 86400
+    )
+    client.create_session.assert_awaited_once_with(
+        "analyst", None, user_id="owner"
+    )
+
+
+@pytest.mark.asyncio
+async def test_session_cache_promotes_legacy_agent_key():
+    client = AthenaClient("http://athena.test", tenant_id="tenant-1")
+    redis = MagicMock()
+    redis._redis.get.side_effect = [None, "legacy-session"]
+    redis._redis.set = MagicMock()
+
+    session_id = await client.get_or_create_session(
+        "analyst", redis_store=redis, user_id="owner"
+    )
+
+    assert session_id == "legacy-session"
+    assert redis._redis.get.call_args_list == [
+        call("athena_session:tenant-1:owner:analyst"),
+        call("athena_session:analyst"),
+    ]
+    redis._redis.set.assert_called_once_with(
+        "athena_session:tenant-1:owner:analyst",
+        "legacy-session",
+        ex=30 * 86400,
+    )
 
 
 def test_public_factory_uses_environment_auth_fallback(monkeypatch):


### PR DESCRIPTION
## Summary

Fixes #132.

Athena session creation now sends distinct `user_id` and `agent_id` fields. Existing callers remain compatible because `user_id` defaults to the prior `agent_id` value, while applications can place multiple agents under one stable user scope.

Redis session cache keys now include tenant, user, and agent identity. Existing `athena_session:{agent}` entries are read once and promoted into the scoped key so upgrades retain memory continuity.

This is released as `1.4.1`, a backward-compatible patch over `1.4.0`.

## Validation

- Athena client + adjacent UnifiedMemory: 32 passed
- Ruff on touched Python files: clean
- Wheel and sdist built as `1.4.1`; `twine check`: passed
- Diff whitespace check and editor diagnostics: clean

## Compatibility

`create_session(agent_id)` and `get_or_create_session(agent_id)` retain their existing behavior. `user_id` is keyword-only and optional. `AthenaMemory.create()` exposes the same additive option.
