### PR TITLE
fix: local Nexus vault reachable from agents; trace model/token telemetry; mesh demo examples

### DIFF
--- a/examples/demo_node_1.py
+++ b/examples/demo_node_1.py
@@ -1,0 +1,124 @@
+"""
+Distributed Research Network  |  Node 1: Technology Researcher
+===========================================================================
+Profile  : AutoAgent
+Mode     : Distributed (SWIM P2P + WorkflowEngine)
+Role     : tech_researcher — covers AI chip developments and hardware trends
+
+Run order
+---------
+Start the synthesizer FIRST (it is the SWIM seed), then start nodes 1-3:
+
+    Terminal A: python examples/research_synthesizer.py     # starts on port 7949
+    Terminal B: python examples/research_node_1.py          # connects to 7949
+    Terminal C: python examples/research_node_2.py          # connects to 7949
+    Terminal D: python examples/research_node_3.py          # connects to 7949
+
+The synthesizer submits the 4-step workflow. The Mesh's built-in distributed
+worker scans Redis for pending steps matching each node's capabilities and
+claims them atomically — no manual wiring or step-ID knowledge needed.
+
+Phases exercised (node 1)
+--------------------------
+Phase 2  : SWIM P2P joins synthesizer cluster, ZMQ messaging
+Phase 5  : Prometheus metrics (PROMETHEUS_ENABLED=true in .env)
+Phase 7  : Mesh._run_distributed_worker() claims "tech" step via Redis SETNX
+Phase 8  : UnifiedMemory (EpisodicLedger tracks every search query made)
+Phase 9  : Auto-injected redis + blob + mailbox before setup()
+"""
+
+import asyncio
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from jarviscore import Mesh
+from jarviscore.profiles import AutoAgent
+from jarviscore.memory import UnifiedMemory
+
+WORKFLOW_ID  = "ai-landscape-q1"
+REDIS_URL    = os.getenv("REDIS_URL", "redis://localhost:6379/0")
+BIND_PORT    = 7946  # Node 1 — fixed port (swim.main.load_dotenv() would corrupt os.getenv)
+SEED_NODES   = "127.0.0.1:7949"   # synthesizer is always the seed
+
+
+class TechResearchAgent(AutoAgent):
+    """
+    Researches latest AI chip and hardware developments.
+    Runs as node 1 in the distributed research network.
+    """
+    role = "tech_researcher"
+    capabilities = ["tech_research", "ai_hardware", "research"]
+    system_prompt = """
+    You are a technology research specialist focused on AI infrastructure and chips.
+
+    Research the following topic and produce a structured report using Python:
+
+    result = {
+        "topic": "AI chip developments",
+        "key_findings": [str, ...],    # 3-5 bullet points
+        "notable_companies": [str],    # e.g. NVIDIA, AMD, Intel, Groq, Cerebras
+        "trends": [str],               # e.g. "inference chip market growing 40% YoY"
+        "outlook": str,                # 2-3 sentence forward-looking summary
+        "confidence": float,           # 0.0 - 1.0
+    }
+
+    Use your knowledge to generate realistic, informative findings.
+    Store the result dict in a variable named `result`.
+    """
+
+    async def setup(self):
+        await super().setup()
+        # Phase 9: stores auto-injected before setup() is called
+        self.memory = UnifiedMemory(
+            workflow_id=WORKFLOW_ID,
+            step_id="tech",
+            agent_id=self.role,
+            redis_store=self._redis_store,
+            blob_storage=self._blob_storage,
+        )
+        self._logger.info(
+            f"[{self.role}] ready | redis={'yes' if self._redis_store else 'no'}"
+        )
+
+
+async def main():
+    print("\n" + "=" * 70)
+    print("JarvisCore — Distributed Research Network: Node 1 (Technology Researcher)")
+    print("AutoAgent | Distributed Mode | Port 7946 → Seed 7949")
+    print("=" * 70)
+
+    # P2P mesh auto-activates when bind_port + seed_nodes are set in config.
+    mesh = Mesh(
+        config={
+            "redis_url": REDIS_URL, "kernel_role_profiles": {"researcher": {"thinking_budget": 180000, "action_budget": 120000, "max_total_tokens": 400000, "wall_clock_ms": 900000, "emergency_turn_fuse": 60, "model_tier": "task", "complexity": "standard"}, "communicator": {"thinking_budget": 120000, "action_budget": 80000, "max_total_tokens": 240000, "wall_clock_ms": 600000, "emergency_turn_fuse": 30, "model_tier": "task", "complexity": "standard"}},
+            "p2p_enabled": True,
+            "bind_host": "127.0.0.1",
+            "bind_port": BIND_PORT,
+            "seed_nodes": SEED_NODES,
+            "node_name": "research-node-1",
+        },
+    )
+    mesh.add(TechResearchAgent)
+
+    try:
+        await mesh.start()
+        print(f"\n[Node 1] Online at port {BIND_PORT}, seed={SEED_NODES}")
+        print(f"[Node 1] Redis: {'connected' if mesh._redis_store else 'None'}")
+        print(f"[Node 1] Distributed worker running — will claim 'tech' step automatically")
+        print(f"         (capabilities: tech_researcher, tech_research, ai_hardware, research)\n")
+
+        while True:
+            await asyncio.sleep(1)
+
+    except KeyboardInterrupt:
+        print("\n[Node 1] Shutting down...")
+    finally:
+        await mesh.stop()
+        print("[Node 1] Stopped.")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/demo_node_2.py
+++ b/examples/demo_node_2.py
@@ -1,0 +1,117 @@
+"""
+Distributed Research Network  |  Node 2: Market Researcher
+=======================================================================
+Profile  : AutoAgent
+Mode     : Distributed (SWIM P2P + WorkflowEngine)
+Role     : market_researcher — covers AI investment and venture trends
+
+Run after starting the synthesizer (port 7949):
+    python examples/research_node_2.py
+
+Phases exercised (node 2)
+--------------------------
+Phase 2  : SWIM P2P joins synthesizer cluster
+Phase 7  : Mesh._run_distributed_worker() claims "market" step via Redis SETNX;
+           crash recovery: kill and restart — SETNX prevents double-execution
+Phase 8  : EpisodicLedger tracks research queries per session
+Phase 9  : Auto-injected redis + blob + mailbox
+"""
+
+import asyncio
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from jarviscore import Mesh
+from jarviscore.profiles import AutoAgent
+from jarviscore.memory import UnifiedMemory
+
+WORKFLOW_ID  = "ai-landscape-q1"
+REDIS_URL    = os.getenv("REDIS_URL", "redis://localhost:6379/0")
+BIND_PORT    = 7947  # Node 2 — fixed port (swim.main.load_dotenv() would corrupt os.getenv)
+SEED_NODES   = "127.0.0.1:7949"   # synthesizer is always the seed
+
+
+class MarketResearchAgent(AutoAgent):
+    """
+    Researches AI investment trends and venture capital activity.
+    Runs as node 2 in the distributed research network.
+    """
+    role = "market_researcher"
+    capabilities = ["market_research", "investment_analysis", "research"]
+    system_prompt = """
+    You are a market research specialist covering AI investment and VC activity.
+
+    Research the following topic and produce a structured report using Python:
+
+    result = {
+        "topic": "AI investment trends",
+        "key_findings": [str, ...],        # 3-5 bullet points on VC/PE activity
+        "top_funded_areas": [str],          # e.g. "Inference infrastructure", "AI agents"
+        "market_size_estimate": str,        # e.g. "$500B TAM by 2028"
+        "investor_sentiment": str,          # "bullish" | "cautious" | "mixed"
+        "notable_deals": [                  # 2-3 recent notable investments
+            {"company": str, "amount": str, "stage": str}
+        ],
+        "outlook": str,
+        "confidence": float,
+    }
+
+    Use your knowledge to generate realistic, informative findings.
+    Store the result dict in a variable named `result`.
+    """
+
+    async def setup(self):
+        await super().setup()
+        self.memory = UnifiedMemory(
+            workflow_id=WORKFLOW_ID,
+            step_id="market",
+            agent_id=self.role,
+            redis_store=self._redis_store,
+            blob_storage=self._blob_storage,
+        )
+        self._logger.info(
+            f"[{self.role}] ready | redis={'yes' if self._redis_store else 'no'}"
+        )
+
+
+async def main():
+    print("\n" + "=" * 70)
+    print("JarvisCore — Distributed Research Network: Node 2 (Market Researcher)")
+    print("AutoAgent | Distributed Mode | Port 7947 → Seed 7949")
+    print("=" * 70)
+
+    # P2P mesh auto-activates when bind_port + seed_nodes are set in config.
+    mesh = Mesh(
+        config={
+            "redis_url": REDIS_URL, "kernel_role_profiles": {"researcher": {"thinking_budget": 180000, "action_budget": 120000, "max_total_tokens": 400000, "wall_clock_ms": 900000, "emergency_turn_fuse": 60, "model_tier": "task", "complexity": "standard"}, "communicator": {"thinking_budget": 120000, "action_budget": 80000, "max_total_tokens": 240000, "wall_clock_ms": 600000, "emergency_turn_fuse": 30, "model_tier": "task", "complexity": "standard"}},
+            "p2p_enabled": True,
+            "bind_host": "127.0.0.1",
+            "bind_port": BIND_PORT,
+            "seed_nodes": SEED_NODES,
+            "node_name": "research-node-2",
+        },
+    )
+    mesh.add(MarketResearchAgent)
+
+    try:
+        await mesh.start()
+        print(f"\n[Node 2] Online at port {BIND_PORT}, seed={SEED_NODES}")
+        print(f"[Node 2] Redis: {'connected' if mesh._redis_store else 'None'}")
+        print(f"[Node 2] Distributed worker running — will claim 'market' step automatically")
+        print(f"         (crash recovery: kill and restart — SETNX prevents double-execution)\n")
+
+        while True:
+            await asyncio.sleep(1)
+
+    except KeyboardInterrupt:
+        print("\n[Node 2] Shutting down...")
+    finally:
+        await mesh.stop()
+        print("[Node 2] Stopped.")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/demo_node_3.py
+++ b/examples/demo_node_3.py
@@ -1,0 +1,125 @@
+"""
+Distributed Research Network  |  Node 3: Regulatory Researcher
+===========================================================================
+Profile  : AutoAgent
+Mode     : Distributed (SWIM P2P + WorkflowEngine)
+Role     : reg_researcher — covers AI regulation and policy developments
+
+Run after starting the synthesizer (port 7949):
+    python examples/research_node_3.py
+
+Phases exercised (node 3)
+--------------------------
+Phase 2  : SWIM P2P joins synthesizer cluster
+Phase 7  : Mesh._run_distributed_worker() claims "reg" step via atomic Redis SETNX
+Phase 8  : EpisodicLedger + LTM (policy summaries persist across weekly runs)
+Phase 9  : Auto-injected redis + blob + mailbox
+"""
+
+import asyncio
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from jarviscore import Mesh
+from jarviscore.profiles import AutoAgent
+from jarviscore.memory import UnifiedMemory
+
+WORKFLOW_ID  = "ai-landscape-q1"
+REDIS_URL    = os.getenv("REDIS_URL", "redis://localhost:6379/0")
+BIND_PORT    = 7948  # Node 3 — fixed port (swim.main.load_dotenv() would corrupt os.getenv)
+SEED_NODES   = "127.0.0.1:7949"   # synthesizer is always the seed
+
+
+class RegResearchAgent(AutoAgent):
+    """
+    Researches AI regulatory landscape and policy developments.
+    Runs as node 3 in the distributed research network.
+    """
+    role = "reg_researcher"
+    capabilities = ["regulatory_research", "policy_analysis", "research"]
+    system_prompt = """
+    You are a regulatory research specialist covering AI governance and policy.
+
+    Research the following topic and produce a structured report using Python:
+
+    result = {
+        "topic": "AI regulation and governance",
+        "key_findings": [str, ...],       # 3-5 bullet points on recent regulations
+        "active_regulations": [           # 2-4 key regulations or frameworks
+            {"name": str, "jurisdiction": str, "status": str, "impact": str}
+        ],
+        "risk_areas": [str],              # Areas of high regulatory risk for AI cos
+        "compliance_outlook": str,        # "tightening" | "stable" | "uncertain"
+        "regional_summary": {
+            "EU": str,
+            "US": str,
+            "UK": str,
+            "APAC": str,
+        },
+        "outlook": str,
+        "confidence": float,
+    }
+
+    Use your knowledge to generate realistic, informative findings.
+    Store the result dict in a variable named `result`.
+    """
+
+    async def setup(self):
+        await super().setup()
+        self.memory = UnifiedMemory(
+            workflow_id=WORKFLOW_ID,
+            step_id="reg",
+            agent_id=self.role,
+            redis_store=self._redis_store,
+            blob_storage=self._blob_storage,
+        )
+        # Phase 8: LTM persists regulatory summaries across runs
+        if self.memory.ltm:
+            prior = await self.memory.ltm.load_summary()
+            if prior:
+                self._logger.info(f"[{self.role}] LTM loaded from prior run")
+        self._logger.info(
+            f"[{self.role}] ready | redis={'yes' if self._redis_store else 'no'}"
+        )
+
+
+async def main():
+    print("\n" + "=" * 70)
+    print("JarvisCore — Distributed Research Network: Node 3 (Regulatory Researcher)")
+    print("AutoAgent | Distributed Mode | Port 7948 → Seed 7949")
+    print("=" * 70)
+
+    # P2P mesh auto-activates when bind_port + seed_nodes are set in config.
+    mesh = Mesh(
+        config={
+            "redis_url": REDIS_URL, "kernel_role_profiles": {"researcher": {"thinking_budget": 180000, "action_budget": 120000, "max_total_tokens": 400000, "wall_clock_ms": 900000, "emergency_turn_fuse": 60, "model_tier": "task", "complexity": "standard"}, "communicator": {"thinking_budget": 120000, "action_budget": 80000, "max_total_tokens": 240000, "wall_clock_ms": 600000, "emergency_turn_fuse": 30, "model_tier": "task", "complexity": "standard"}},
+            "p2p_enabled": True,
+            "bind_host": "127.0.0.1",
+            "bind_port": BIND_PORT,
+            "seed_nodes": SEED_NODES,
+            "node_name": "research-node-3",
+        },
+    )
+    mesh.add(RegResearchAgent)
+
+    try:
+        await mesh.start()
+        print(f"\n[Node 3] Online at port {BIND_PORT}, seed={SEED_NODES}")
+        print(f"[Node 3] Redis: {'connected' if mesh._redis_store else 'None'}")
+        print(f"[Node 3] Distributed worker running — will claim 'reg' step automatically\n")
+
+        while True:
+            await asyncio.sleep(1)
+
+    except KeyboardInterrupt:
+        print("\n[Node 3] Shutting down...")
+    finally:
+        await mesh.stop()
+        print("[Node 3] Stopped.")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/demo_synthesizer.py
+++ b/examples/demo_synthesizer.py
@@ -1,0 +1,282 @@
+"""
+Distributed Research Network  |  Synthesizer Node
+==============================================================
+Profile  : AutoAgent
+Mode     : Distributed (SWIM P2P + WorkflowEngine)
+Role     : synthesizer — starts last, defines the full 4-step workflow,
+           waits for all 3 researcher nodes to complete their steps,
+           then synthesises their outputs into a single briefing.
+
+IMPORTANT: Start this script FIRST — it is the SWIM seed node (port 7949).
+Then start nodes 1, 2, 3 in separate terminals.
+
+    Terminal A: python examples/research_synthesizer.py  ← start FIRST
+    Terminal B: python examples/research_node_1.py
+    Terminal C: python examples/research_node_2.py
+    Terminal D: python examples/research_node_3.py
+
+How it works
+------------
+1. Synthesizer starts as SWIM seed (port 7949)
+2. Nodes 1-3 join the SWIM cluster by connecting to port 7949
+3. Synthesizer submits 4-step workflow to Redis
+4. Each researcher node claims its step via atomic SETNX and executes it
+5. DependencyManager._wait_redis() on the "synth" step polls Redis until
+   ALL THREE of "tech", "market", "reg" steps are "completed"
+6. Only then does the synthesizer's WorkflowEngine dispatch "synth"
+7. SynthesizerAgent reads all 3 outputs via context and writes the briefing
+
+Infrastructure features exercised (synthesizer)
+------------------------------------------------
+Mailbox         : MailboxManager pings researcher agents before submitting workflow
+Telemetry       : Prometheus metrics across all 4 nodes (active_workflows gauge)
+Workflow engine : DependencyManager cross-node dependency resolution;
+                  WorkflowState crash recovery — re-run skips completed steps
+Unified memory  : RedisMemoryAccessor reads tech + market + reg outputs;
+                  EpisodicLedger + LTM persist briefing summaries
+Auto-injection  : redis + blob + mailbox injected on all nodes
+
+Success criteria
+----------------
+    - 4 nodes discover each other on the SWIM mesh (log: "peer joined")
+    - 3 researcher steps claimed and completed (log: "CLAIMED step_id=tech/market/reg")
+    - Synthesizer step runs after all 3 complete (log: "CLAIMED step_id=synth")
+    - Final briefing saved to: blob_storage/reports/ai-landscape-q1.md
+    - redis-cli hgetall step_output:ai-landscape-q1:synth  →  status=completed
+"""
+
+import asyncio
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from jarviscore import Mesh
+from jarviscore.profiles import AutoAgent
+from jarviscore.memory import UnifiedMemory
+from jarviscore.context import RedisMemoryAccessor
+
+WORKFLOW_ID = "ai-landscape-q1"
+REDIS_URL   = os.getenv("REDIS_URL", "redis://localhost:6379/0")
+BIND_PORT   = 7949  # Synthesizer is the SWIM seed — always port 7949
+# Note: do NOT use os.getenv("BIND_PORT") — swim.main.load_dotenv() would override it from .env
+# Synthesizer is the seed node — no SEED_NODES needed
+
+
+class SynthesizerAgent(AutoAgent):
+    """
+    Reads outputs from all 3 researcher nodes and writes a unified AI landscape briefing.
+    The "synth" step only dispatches after tech + market + reg are all completed.
+    """
+    role = "synthesizer"
+    capabilities = ["synthesis", "reporting", "research_coordination"]
+    system_prompt = """
+    You are a senior research director. You synthesise findings from three specialist
+    researchers (technology, market, regulatory) into a single coherent briefing.
+
+    You receive their reports in the `context` variable. Combine them into:
+
+    result = {
+        "title": "AI Landscape Q1 2026 — Synthesised Briefing",
+        "executive_summary": str,       # 3-4 sentences covering all 3 angles
+        "technology": {                 # from tech_researcher
+            "headline": str,
+            "key_points": [str],
+        },
+        "market": {                     # from market_researcher
+            "headline": str,
+            "key_points": [str],
+        },
+        "regulatory": {                 # from reg_researcher
+            "headline": str,
+            "key_points": [str],
+        },
+        "cross_cutting_themes": [str],  # themes that appear across all 3 reports
+        "strategic_recommendations": [str],
+        "overall_confidence": float,
+    }
+
+    Store the result dict in a variable named `result`.
+    If individual researcher outputs are not in context, use plausible placeholder data.
+    """
+
+    async def setup(self):
+        await super().setup()
+        # Phase 9: stores already injected
+        self.memory = UnifiedMemory(
+            workflow_id=WORKFLOW_ID,
+            step_id="synth",
+            agent_id=self.role,
+            redis_store=self._redis_store,
+            blob_storage=self._blob_storage,
+        )
+        self._logger.info(
+            f"[{self.role}] ready | redis={'yes' if self._redis_store else 'no'}"
+        )
+
+
+async def main():
+    print("\n" + "=" * 70)
+    print("JarvisCore — Distributed Research Network: Synthesizer (SWIM Seed)")
+    print("AutoAgent | Distributed Mode | Port 7949 (seed)")
+    print("=" * 70)
+    print("""
+Start order:
+  1. This script  (port 7949 — SWIM seed)  ← you are here
+  2. Node 1       (port 7946)
+  3. Node 2       (port 7947)
+  4. Node 3       (port 7948)
+
+Workflow submits after a 75s wait for nodes to join SWIM cluster.
+""")
+
+    # This is the SWIM seed node — p2p_enabled activates P2P, no seed_nodes needed.
+    mesh = Mesh(
+        config={
+            "redis_url": REDIS_URL, "kernel_role_profiles": {"researcher": {"thinking_budget": 180000, "action_budget": 120000, "max_total_tokens": 400000, "wall_clock_ms": 900000, "emergency_turn_fuse": 60, "model_tier": "task", "complexity": "standard"}, "communicator": {"thinking_budget": 120000, "action_budget": 80000, "max_total_tokens": 240000, "wall_clock_ms": 600000, "emergency_turn_fuse": 30, "model_tier": "task", "complexity": "standard"}},
+            "p2p_enabled": True,
+            "bind_host": "127.0.0.1",
+            "bind_port": BIND_PORT,
+            "node_name": "synthesizer-seed",
+            # No seed_nodes — this IS the seed
+        },
+    )
+    synth_agent = mesh.add(SynthesizerAgent)
+
+    try:
+        await mesh.start()
+
+        # ── Phase 9 verification ──────────────────────────────────────────────
+        print(f"[Phase 9] redis_store : {'connected' if mesh._redis_store else 'None'}")
+        print(f"[Phase 9] blob_storage: {type(mesh._blob_storage).__name__}")
+
+        # ── Phase 4: mailbox ping (optional — only works when Redis available) ─
+        if synth_agent.mailbox:
+            print("[Phase 4] Mailbox available — can ping researcher agents by ID")
+
+        # ── Wait for researcher nodes to join SWIM ────────────────────────────
+        print("\n[SWIM] Waiting 75s for researcher nodes to join cluster...")
+        print("       (Start nodes 1-3 in other terminals now)\n")
+        await asyncio.sleep(75)
+
+        # ── Submit workflow ───────────────────────────────────────────────────
+        print(f"[Workflow] Submitting '{WORKFLOW_ID}'")
+        print("  Steps: tech ┐")
+        print("         market ├──→ synth ──→ notify (Slack via Nexus vault)")
+        print("         reg   ┘\n")
+
+        results = await mesh.workflow(WORKFLOW_ID, [
+            {
+                "id": "tech",
+                "agent": "tech_researcher",
+                "task": (
+                    "Do at most 2 web searches: the single biggest AI chip announcement this quarter. 5 bullets in `result`, cite sources. "
+                    
+                ),
+            },
+            {
+                "id": "market",
+                "agent": "market_researcher",
+                "task": (
+                    "Do at most 2 web searches: the single largest AI funding round this quarter. 5 bullets in `result`, cite sources. "
+                    
+                ),
+            },
+            {
+                "id": "reg",
+                "agent": "reg_researcher",
+                "task": (
+                    "Do at most 2 web searches: the most consequential AI regulation news this quarter. 5 bullets in `result`, cite sources. "
+                    
+                ),
+            },
+            {
+                "id": "synth",
+                "agent": "synthesizer",
+                "task": (
+                    "Merge the three research results into one 8 bullet AI landscape briefing in `result`. "
+                    
+                    
+                ),
+                # Phase 7: DependencyManager._wait_redis() polls until ALL 3 are COMPLETED
+                "depends_on": ["tech", "market", "reg"],
+            },
+            {
+                "id": "notify",
+                "agent": "synthesizer",
+                "task": (
+                    "Send the AI landscape briefing from the previous step to the Slack "
+                    "channel #mesh-demo. Use nexus_call to POST "
+                    "https://slack.com/api/chat.postMessage with "
+                    "json={'channel': '#mesh-demo', 'text': <the briefing bullets as plain text, "
+                    "prefixed with the title line 'AI Landscape Q1 2026 — briefing from the mesh'>}. "
+                    "Put the Slack API response dict in `result`."
+                ),
+                # Credentials resolve inside NexusCallProxy from the encrypted local
+                # vault — the agent only ever sees the opaque connection handle.
+                "context": {"system": "slack"},
+                "depends_on": ["synth"],
+            },
+        ], timeout_per_step=900)  # research steps do real web work (issue #137)
+
+        # ── Results ───────────────────────────────────────────────────────────
+        print("\n" + "=" * 70)
+        print("WORKFLOW RESULTS")
+        print("=" * 70)
+
+        step_names = ["tech", "market", "reg", "synth", "notify"]
+        for name, result in zip(step_names, results):
+            status = result.get("status", "unknown")
+            icon = "✓" if status == "success" else "✗"
+            print(f"\n{icon} Step: {name}  (status={status})")
+            if status == "success":
+                output = str(result.get("output", ""))
+                print(f"  Preview: {output[:250]}{'...' if len(output) > 250 else ''}")
+            else:
+                print(f"  Error: {result.get('error', 'unknown')}")
+
+        # ── Phase 1: Save synthesis to blob ───────────────────────────────────
+        synth_result = results[3] if len(results) >= 4 else {}
+        if synth_result.get("status") == "success" and mesh._blob_storage:
+            import json
+            content = json.dumps(synth_result.get("output", {}), indent=2)
+            blob_path = f"reports/{WORKFLOW_ID}.json"
+            await mesh._blob_storage.save(blob_path, content)
+            print(f"\n[Phase 1] Synthesis saved: ./blob_storage/{blob_path}")
+
+        # ── Phase 8: EpisodicLedger ───────────────────────────────────────────
+        if synth_agent.memory and synth_agent.memory.episodic:
+            await synth_agent.memory.episodic.append({
+                "event": "synthesis_completed",
+                "workflow_id": WORKFLOW_ID,
+                "steps_ok": len([r for r in results if r.get("status") == "success"]),
+            })
+            print(f"[Phase 8] Logged to EpisodicLedger")
+            print(f"          Inspect: redis-cli xrange ledgers:{WORKFLOW_ID} - +")
+
+        # ── Redis verification ────────────────────────────────────────────────
+        if mesh._redis_store:
+            print(f"\n[Phase 7] Step outputs in Redis:")
+            for sid in step_names:
+                out = mesh._redis_store.get_step_output(WORKFLOW_ID, sid)
+                print(f"  step_output:{WORKFLOW_ID}:{sid} → {'set ✓' if out else 'missing ✗'}")
+
+        successes = sum(1 for r in results if r.get("status") == "success")
+        print(f"\n{'=' * 70}")
+        print(f"Distributed workflow complete: {successes}/{len(results)} steps")
+        print(f"{'=' * 70}\n")
+
+    except KeyboardInterrupt:
+        print("\n[Synthesizer] Interrupted.")
+    except Exception as exc:
+        print(f"\n[ERROR] {exc}")
+        import traceback
+        traceback.print_exc()
+    finally:
+        await mesh.stop()
+        print("[Synthesizer] Stopped.")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/slack_notify_demo.py
+++ b/examples/slack_notify_demo.py
@@ -1,0 +1,44 @@
+"""Offline test: kernel → coder → sandbox nexus_call → local vault → Slack."""
+import asyncio
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from jarviscore import Mesh
+from jarviscore.profiles import AutoAgent
+
+
+class NotifierAgent(AutoAgent):
+    role = "notifier"
+    capabilities = ["notifications", "slack"]
+    system_prompt = (
+        "You are a notification agent. You send messages to Slack using "
+        "nexus_call() against the Slack Web API (https://slack.com/api/chat.postMessage). "
+        "Set `result` to the Slack API response dict."
+    )
+
+
+async def main():
+    mesh = Mesh(config={"nexus_enabled": True})
+    agent = mesh.add(NotifierAgent)
+    try:
+        await mesh.start()
+        out = await agent.execute_task({
+            "task": (
+                "Send this exact message to the Slack channel #mesh-demo: "
+                "'e2e test: agent -> nexus vault -> slack. reply ok if you see this.' "
+                "Use nexus_call to POST https://slack.com/api/chat.postMessage "
+                "with json={'channel': '#mesh-demo', 'text': ...}. "
+                "Put the API response in `result`."
+            ),
+            "context": {"system": "slack"},
+        })
+        print("STATUS:", out.get("status"))
+        print("OUTPUT:", str(out.get("output"))[:400])
+    finally:
+        await mesh.stop()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/jarviscore/cli/inspect.py
+++ b/jarviscore/cli/inspect.py
@@ -94,7 +94,10 @@ def _run_summary(paths: List[str]) -> Dict[str, Any]:
             etype = event.get("type", "")
             data = event.get("data", {}) or {}
             if etype == "llm_response":
-                tokens += int(data.get("tokens", 0) or 0)
+                try:
+                    tokens += int(data.get("tokens", 0) or 0)
+                except (ValueError, TypeError):
+                    pass  # legacy traces may carry scrubbed placeholders
             elif etype in ("step_failed", "error_recovery"):
                 failures += 1
             elif etype == "workflow_complete":
@@ -143,7 +146,9 @@ _RENDERERS = {
     "subagent_yield": lambda d: f"subagent {d.get('subagent', '?')} yielded: {_clip(d.get('reason', ''))}",
     "tool_start": lambda d: f"tool {d.get('tool_name', d.get('tool', '?'))} {_clip(d.get('params', ''))}",
     "tool_result": lambda d: f"  -> {_clip(d.get('result', d))}",
-    "llm_request": lambda d: f"llm call ({d.get('provider', '?')}/{d.get('model', '?')})",
+    "llm_request": lambda d: (
+        f"llm call ({d['model']})" if d.get("model") else "llm call"
+    ),
     "llm_response": lambda d: (
         f"  -> {d.get('tokens', '?')} tokens in {d.get('latency_ms', '?')}ms"
     ),

--- a/jarviscore/kernel/kernel.py
+++ b/jarviscore/kernel/kernel.py
@@ -759,14 +759,34 @@ class Kernel:
 
             # Wire Nexus connection — agents receive connection_id only, never credentials.
             # NexusCallProxy (injected into CoderSandbox) is the sole credential boundary.
-            if role == "coder" and self.auth_manager:
+            if role == "coder":
                 system_name = (
                     enriched_context.get("system")
                     or (context.get("system") if context else None)
                 )
                 if system_name:
-                    try:
-                        conn_id = await self.auth_manager.get_connection_id(system_name)
+                    conn_id = None
+                    if self.auth_manager:
+                        try:
+                            conn_id = await self.auth_manager.get_connection_id(system_name)
+                        except Exception as auth_exc:
+                            logger.debug(
+                                "[Kernel] Nexus gateway unavailable for system=%s — "
+                                "trying local vault: %s",
+                                system_name, auth_exc,
+                            )
+                    if conn_id is None:
+                        # Local-vault mode: connection_id IS the provider name —
+                        # NexusCallProxy resolves it from NexusLocalStore at call time.
+                        try:
+                            from jarviscore.nexus.store import get_store
+                            if get_store().get(system_name):
+                                conn_id = system_name
+                        except Exception as store_exc:
+                            logger.debug(
+                                "[Kernel] Nexus local vault unavailable: %s", store_exc
+                            )
+                    if conn_id is not None:
                         # Only the opaque handle goes into context — NEVER tokens or keys
                         enriched_context["_nexus_connection_id"] = conn_id
                         enriched_context["_nexus_provider"] = system_name
@@ -774,11 +794,12 @@ class Kernel:
                             "[Kernel] Nexus connection_id tagged for system=%s",
                             system_name,
                         )
-                    except Exception as auth_exc:
+                    else:
                         logger.warning(
-                            "[Kernel] Nexus connection unavailable for system=%s "
-                            "(set NEXUS_GATEWAY_URL): %s",
-                            system_name, auth_exc,
+                            "[Kernel] No Nexus credentials for system=%s — "
+                            "register with: jarviscore nexus register %s (local vault) "
+                            "or set NEXUS_GATEWAY_URL (gateway)",
+                            system_name, system_name,
                         )
 
 

--- a/jarviscore/kernel/subagent.py
+++ b/jarviscore/kernel/subagent.py
@@ -681,7 +681,7 @@ class BaseSubAgent(ABC):
                 messages.append({"role": "user", "content": hist_entry["observation"]})
             messages.append({"role": "user", "content": user_prompt})
 
-            _trace.log_llm_request(system_prompt[:300], user_prompt[:500])
+            _trace.log_llm_request(system_prompt[:300], user_prompt[:500], model=model)
 
             kwargs = {}
             if model:
@@ -712,7 +712,12 @@ class BaseSubAgent(ABC):
             total_tokens["output"] += tokens.get("output", 0)
             total_tokens["total"] += tokens.get("total", 0)
             total_cost += llm_result.get("cost_usd", 0.0)
-            _trace.log_llm_response(content[:500], round((__import__('time').monotonic() - _llm_t0) * 1000, 1))
+            _trace.log_llm_response(
+                content[:500],
+                round((__import__('time').monotonic() - _llm_t0) * 1000, 1),
+                tokens=tokens.get("total", 0),
+                model=llm_result.get("model") or model,
+            )
             llm_tokens_this_turn = tokens.get("total", 0)
             state.tokens_used = total_tokens["total"]
 

--- a/jarviscore/kernel/tracing.py
+++ b/jarviscore/kernel/tracing.py
@@ -55,10 +55,10 @@ class _NoOpTrace:
     ) -> None:
         pass
 
-    def log_llm_request(self, system_preview: str, user_preview: str) -> None:
+    def log_llm_request(self, system_preview: str, user_preview: str, model: Optional[str] = None) -> None:
         pass
 
-    def log_llm_response(self, content_preview: str, latency_ms: float) -> None:
+    def log_llm_response(self, content_preview: str, latency_ms: float, tokens: Optional[int] = None, model: Optional[str] = None) -> None:
         pass
 
     def log_step_complete(self, success: bool, summary: str) -> None:
@@ -205,8 +205,13 @@ class TraceManager:
     def _scrub(self, value: Any) -> Any:
         """Recursively redact secrets from trace data."""
         if isinstance(value, dict):
+            # Only string values can be credentials — numeric fields like
+            # "tokens" (a count) must survive scrubbing.
             return {
-                k: "***" if any(s in str(k).lower() for s in self._SENSITIVE_KEYS) else self._scrub(v)
+                k: "***"
+                if isinstance(v, (str, bytes))
+                and any(s in str(k).lower() for s in self._SENSITIVE_KEYS)
+                else self._scrub(v)
                 for k, v in value.items()
             }
         if isinstance(value, list):
@@ -254,25 +259,27 @@ class TraceManager:
                 payload["screenshot_path"] = result["screenshot_path"]
         self.log_event("tool_result", payload)
 
-    def log_llm_request(self, system_preview: str, user_preview: str) -> None:
+    def log_llm_request(self, system_preview: str, user_preview: str, model: Optional[str] = None) -> None:
         """LLM API call dispatched."""
-        self.log_event(
-            "llm_request",
-            {
-                "system_preview": self._scrub(system_preview[:300]),
-                "user_preview": self._scrub(user_preview[:500]),
-            },
-        )
+        data = {
+            "system_preview": self._scrub(system_preview[:300]),
+            "user_preview": self._scrub(user_preview[:500]),
+        }
+        if model:
+            data["model"] = model
+        self.log_event("llm_request", data)
 
-    def log_llm_response(self, content_preview: str, latency_ms: float) -> None:
+    def log_llm_response(self, content_preview: str, latency_ms: float, tokens: Optional[int] = None, model: Optional[str] = None) -> None:
         """LLM API call returned."""
-        self.log_event(
-            "llm_response",
-            {
-                "content_preview": self._scrub(content_preview[:500]),
-                "latency_ms": round(latency_ms, 1),
-            },
-        )
+        data = {
+            "content_preview": self._scrub(content_preview[:500]),
+            "latency_ms": round(latency_ms, 1),
+        }
+        if tokens is not None:
+            data["tokens"] = tokens
+        if model:
+            data["model"] = model
+        self.log_event("llm_response", data)
 
     def log_step_complete(self, success: bool, summary: str) -> None:
         """

--- a/jarviscore/profiles/autoagent.py
+++ b/jarviscore/profiles/autoagent.py
@@ -198,7 +198,17 @@ class AutoAgent(Profile):
         # 4. Initialize coder sandbox (file-capable runtime for CoderSubAgent)
         timeout = config.get('execution_timeout', 300)
         self._logger.info(f"Initializing coder sandbox ({timeout}s timeout)...")
-        self.sandbox = create_coder_sandbox(timeout=timeout)
+        # nexus_call() must work in gateway mode AND local-vault mode: the
+        # proxy tries the gateway first and falls back to NexusLocalStore.
+        nexus_proxy = None
+        try:
+            from jarviscore.auth.manager import AuthenticationManager
+            from jarviscore.nexus.call_proxy import NexusCallProxy
+            auth_mgr = getattr(self, '_auth_manager', None) or AuthenticationManager(config)
+            nexus_proxy = NexusCallProxy(auth_mgr)
+        except Exception as _nexus_exc:
+            self._logger.debug("Nexus call proxy unavailable: %s", _nexus_exc)
+        self.sandbox = create_coder_sandbox(timeout=timeout, nexus_call_proxy=nexus_proxy)
 
         # 5. Initialize autonomous repair
         max_repairs = config.get('max_repair_attempts', 3)


### PR DESCRIPTION
Fixes #142, fixes #143. Demo files for the mesh video included so the run is reproducible.

## What

**Nexus local vault now reachable from agents (#142)**
- `AutoAgent.setup()` builds a `NexusCallProxy` backed by `AuthenticationManager(config)` (gateway optional) and passes it to `create_coder_sandbox` — `nexus_call()` in the sandbox is real in both gateway and local-vault modes
- Kernel connection tagging: gateway first; when unavailable, tags `_nexus_connection_id = <provider>` if the local vault has the provider (matches the call proxy's existing local fallback contract). Agents only ever see the opaque handle; the vault decrypts at the call boundary

**Flight recorder telemetry (#143)**
- `log_llm_request/log_llm_response` accept and emit `model` and `tokens`; subagent passes real values
- `_scrub` only redacts string/bytes values under sensitive keys — token *counts* survive, secrets still become `***`
- `jarviscore inspect` renders `llm call (<model>)` and tolerates legacy scrubbed placeholders instead of crashing

**Demo examples**
- `examples/demo_synthesizer.py` + `examples/demo_node_{1,2,3}.py`: the 4-process distributed research demo from the video — SWIM discovery, ledger claiming, live web research, synthesis, and a Slack notify step that resolves credentials through the vault
- `examples/slack_notify_demo.py`: minimal single-agent vault→Slack e2e

## Verification

- Full offline suite: **1,509 passed, 40 skipped, 1 xfailed**
- Telemetry suite (41 tests) green against the scrubber change; secrets still redacted (`api_key`/`access_token` → `***`), numeric counts preserved
- End-to-end on camera: 4 processes, 5/5 steps, briefing delivered to Slack via `nexus_call` with the token never visible to agent code; `jarviscore inspect` shows per-call model/token/latency (176,658 tokens across the run)

Found while filming the mesh demo. #144 (done-gate rejection loop) observed in the same runs and stays open for investigation.
