### PR TITLE
fix(kernel): agent identity reaches the LLM in every sub-agent dispatch

### DIFF
--- a/jarviscore/kernel/subagent.py
+++ b/jarviscore/kernel/subagent.py
@@ -432,8 +432,23 @@ class BaseSubAgent(ABC):
     # ──────────────────────────────────────────────────────────────────────
 
     def _build_system_prompt(self) -> str:
-        """Build the full system prompt including tool descriptions and protocol."""
-        parts = [
+        """Build the full system prompt including tool descriptions and protocol.
+
+        The calling agent's identity leads: a sub-agent prompt is an execution
+        harness, not a persona, and an application that trains its agent through
+        ``system_prompt`` must not lose that the moment work enters the kernel.
+        """
+        state = getattr(self, "_current_state", None)
+        identity = ((getattr(state, "context", None) or {}).get("system_prompt") or "").strip()
+        parts = []
+        if identity:
+            parts += [
+                identity,
+                "",
+                "═══ EXECUTION HARNESS (how you operate this turn) ═══",
+                "",
+            ]
+        parts += [
             self.get_system_prompt(),
             "",
             self.get_tool_descriptions(),

--- a/tests/test_kernel.py
+++ b/tests/test_kernel.py
@@ -233,14 +233,43 @@ class TestKernelExecuteSuccess:
             system_prompt="You are a data processor.",
         )
         assert output.status == "success"
-        # Verify context data reached the LLM — it appears in the user message
-        # (messages[1]) since the subagent injects context into the task prompt.
-        # The system message (messages[0]) is the subagent's own hardcoded persona.
+        # Context data reaches the LLM in the user message; the agent's identity
+        # leads the system message (issue #91).
         all_content = " ".join(
             str(m.get("content", "")) for m in mock_llm.calls[1]["messages"]
         )
         assert "data" in all_content
         assert "Process data" in all_content
+        assert mock_llm.calls[1]["messages"][0]["content"].startswith("You are a data processor.")
+
+    @pytest.mark.asyncio
+    async def test_agent_identity_leads_the_system_message(self, kernel, mock_llm):
+        """issue #91 — a sub-agent prompt is an execution harness, not a persona."""
+        mock_llm.responses = [
+            _router_response("communicator"),
+            _llm_response("THOUGHT: Answered\nDONE: Answered\nRESULT: {\"who\": \"Acme\"}"),
+        ]
+        await kernel.execute(
+            task="Who are you and what company do you work for?",
+            system_prompt="You are the VP of Marketing at Acme.",
+        )
+        system = mock_llm.calls[1]["messages"][0]["content"]
+        assert system.startswith("You are the VP of Marketing at Acme.")
+        assert system.index("Acme") < system.index("EXECUTION HARNESS")
+        # The harness still ships in full: role prompt, tools and protocol.
+        assert "COMMUNICATION SPECIALIST" in system.upper()
+        assert "Available tools:" in system and "Protocol:" in system
+
+    @pytest.mark.asyncio
+    async def test_callers_passing_no_identity_are_unchanged(self, kernel, mock_llm):
+        mock_llm.responses = [
+            _router_response("communicator"),
+            _llm_response("THOUGHT: Drafted\nDONE: Drafted\nRESULT: {}"),
+        ]
+        await kernel.execute(task="Draft a status report")
+        system = mock_llm.calls[1]["messages"][0]["content"]
+        assert "EXECUTION HARNESS" not in system
+        assert "Available tools:" in system
 
 
 # ── Execute: Failure + Retry ──────────────────────────────────────────


### PR DESCRIPTION
Closes #91.

## What was wrong

`AutoAgent.execute_task` composes an agent's identity — persona, domain doctrine, guardrails — and passes it to `Kernel.execute(system_prompt=...)`. The kernel stores it in `enriched_context`, `ContextManager` deliberately skips the key, and `BaseSubAgent` builds its prompt from `get_system_prompt()` alone. The only reader anywhere was `defaults/coder.py`, using it for a `blob_path` keyword check rather than for prompting.

So every researcher, communicator and browser dispatch ran as a generic stub. Asking a four-role GTM desk "who are you and what do you do?" returned *"I'm the Communicator Agent"* — every line of authored doctrine was inert.

## The fix

Compose it inside `_build_system_prompt()` rather than patching `run()`. That single site feeds both the main OODA loop and the landing turn, and every present and future sub-agent inherits it:

```
<agent identity>

═══ EXECUTION HARNESS (how you operate this turn) ═══

<role prompt + tools + protocol>
```

Identity leads, harness follows — a sub-agent prompt is an execution protocol, not a persona, and reads naturally as a subsection.

`ContextManager` continues to skip the key on purpose: identity is not state, and rendering it there would pay for the same tokens twice.

## Tests

- the identity leads the system message and precedes the harness banner, while the role prompt, tool list and protocol still ship in full
- a caller passing no `system_prompt` gets an unchanged prompt with no banner
- corrected `test_context_passed_to_subagent`, whose comment documented the bug as intended behaviour ("The system message (messages[0]) is the subagent's own hardcoded persona")

161 tests pass across `test_kernel*`, `test_autoagent_kernel` and `test_epistemic_ledger`.

## Verified end to end

The same agent that introduced itself as the Communicator now answers with its own ICP qualification, evidence handling and propose-only doctrine. Live traces show `llm_request.system_preview` opening with the agent's own prompt.

Token cost is bounded by the caller, who authored the prompt. Applications passing nothing see no change.
