### PR TITLE
fix(kernel): a coder run that returns nothing no longer completes the task

### DIFF
--- a/jarviscore/kernel/defaults/coder.py
+++ b/jarviscore/kernel/defaults/coder.py
@@ -59,6 +59,27 @@ def classify_auth_error(error_msg: str) -> Optional[str]:
     return None
 
 
+def _produced_output(output: Any) -> bool:
+    """Did the run leave anything a caller could read?
+
+    The sandbox envelope (marked by ``success``) always reports its own
+    bookkeeping — timings, file lists — so its presence says only that code ran.
+    Answering requires a returned value, stdout, or a written file. Anything the
+    sandbox hands back that is not that envelope is already the result itself.
+    """
+    if output is None:
+        return False
+    if not isinstance(output, dict):
+        return str(output).strip() != ""
+    if "success" not in output:
+        return bool(output)
+    return (
+        output.get("data") is not None
+        or bool(str(output.get("stdout") or "").strip())
+        or bool(output.get("files_created") or output.get("files_modified"))
+    )
+
+
 # ─────────────────────────────────────────────────────────────────
 # CoderSubAgent
 # ─────────────────────────────────────────────────────────────────
@@ -445,10 +466,20 @@ proves it — that is the entire job.
         if execution_result.get("status") == "success":
             merged["status"] = "success"
             merged["output"] = execution_result.get("output")
-            merged["_auto_complete"] = True
             merged["message"] = (
                 f"Code validated and executed successfully (candidate_id={result['candidate_id']})."
             )
+            if _produced_output(execution_result.get("output")):
+                merged["_auto_complete"] = True
+            else:
+                # Running is not answering: let the loop continue so the agent can
+                # return a value or say plainly that there was nothing to report.
+                merged["message"] += (
+                    " The run returned no value and printed nothing, so there is no "
+                    "result to report yet. Return your findings from main() (or print "
+                    "them), then finish — or, if the task genuinely has no output, "
+                    "finish with DONE and say so explicitly."
+                )
         else:
             merged["status"] = "error"
             merged["error"] = execution_result.get("error", "Code execution failed.")

--- a/tests/test_kernel_defaults.py
+++ b/tests/test_kernel_defaults.py
@@ -109,6 +109,48 @@ class TestCoderSubAgent:
         assert "No sandbox" in result["error"]
 
     @pytest.mark.asyncio
+    async def test_a_run_that_returns_nothing_does_not_complete_the_task(self, mock_llm, mock_sandbox):
+        """issue #150 — running is not answering."""
+        mock_sandbox.responses = [{
+            "status": "success", "error": None, "execution_time": 1.8,
+            "output": {"success": True, "data": None, "stdout": "",
+                       "files_created": [], "files_modified": []},
+        }]
+        coder = CoderSubAgent(agent_id="c1", llm_client=mock_llm, sandbox=mock_sandbox)
+        result = await coder._execute_tool("write_code", {"code": "result = None"})
+        assert result["status"] == "success"
+        assert "_auto_complete" not in result
+        assert "returned no value and printed nothing" in result["message"]
+
+    @pytest.mark.asyncio
+    async def test_a_run_that_returns_a_value_still_completes_the_task(self, mock_llm, mock_sandbox):
+        mock_sandbox.responses = [{
+            "status": "success", "error": None, "execution_time": 0.2,
+            "output": {"success": True, "data": {"contacts": 1412}, "stdout": ""},
+        }]
+        coder = CoderSubAgent(agent_id="c1", llm_client=mock_llm, sandbox=mock_sandbox)
+        result = await coder._execute_tool("write_code", {"code": "result = 1"})
+        assert result["_auto_complete"] is True
+        assert result["output"]["data"] == {"contacts": 1412}
+
+    @pytest.mark.parametrize("output, produced", [
+        ({"success": True, "data": None, "stdout": ""}, False),
+        ({"success": True, "data": None, "stdout": "1,412 contacts"}, True),
+        ({"success": True, "data": 0}, True),
+        ({"success": True, "data": None, "files_created": ["report.md"]}, True),
+        ({"success": True}, False),
+        # A plain returned value is the result, not sandbox bookkeeping.
+        ({"answer": 42}, True),
+        ({}, False),
+        ("plain output", True),
+        (None, False),
+    ])
+    def test_only_a_readable_result_counts_as_output(self, output, produced):
+        from jarviscore.kernel.defaults.coder import _produced_output
+
+        assert _produced_output(output) is produced
+
+    @pytest.mark.asyncio
     async def test_execute_code_classifies_auth_error(self, mock_llm, mock_sandbox):
         mock_sandbox.responses = [
             {"status": "failure", "output": None, "error": "Token expired for API", "execution_time": 0.1}


### PR DESCRIPTION
Closes #150.

## What was wrong

`CoderSubAgent._execute_tool` set `_auto_complete` whenever the sandbox exited cleanly, regardless of whether the program produced anything. `BaseSubAgent.run` honours that flag by returning immediately with `status="success"`, bypassing the DONE gate entirely.

A real run: an agent asked to read HubSpot contacts wrote correct code, executed it, and the sandbox returned

```
{'success': True, 'files_created': [], 'stdout': '', 'data': None,
 'error': None, 'execution_time': 1.83}
```

`data: None`, nothing on stdout. The dispatch was reported as a success and the human's answer was `Success: True, execution time 1.83`. A question was asked; runtime bookkeeping came back.

## The fix

Auto-complete only when the run left something a caller could read — a returned value, stdout, or a written file.

The sandbox envelope is recognised by its `success` marker, so a plain returned value such as `{"answer": 42}` still completes the task; only the envelope's own bookkeeping is discounted. When nothing was produced, the message tells the agent to return its findings from `main()` — the usual cause is generated code that computes a result and forgets to return it, which the model repairs in one more turn once it is told.

## Why not the neighbours

- #37 (closed) covered a payload *explicitly reporting failure* wrapped as success. Here the payload reports nothing, and the mismatch is created earlier, in the coder's gate.
- #148 covers `single_response` and LLM adapter finish reasons; this path has no completion metadata, the sandbox is the source.
- #87/#99 concern DONE-gate rejections, which `_auto_complete` never reaches.

## Tests

- a run returning nothing does not complete the task and carries the guidance
- a run returning a value still auto-completes
- a parametrised table for the predicate: empty envelope, stdout only, `data: 0`, files created, bare `success`, a plain returned dict, `{}`, a plain string, `None`

133 tests pass across `test_kernel_defaults`, `test_kernel`, `test_autoagent_kernel`, `test_kernel_cognition` and `test_epistemic_ledger`.

## Behaviour change

A dispatch whose code returns nothing now continues instead of ending, so such a run costs at least one more turn. That is the point: the alternative is answering a person with a timing figure.
