### PR TITLE
fix(kernel): missing credentials for a declared system yield for access

### DIFF
--- a/jarviscore/kernel/kernel.py
+++ b/jarviscore/kernel/kernel.py
@@ -795,11 +795,36 @@ class Kernel:
                             system_name,
                         )
                     else:
+                        # Deterministic: the task named a provider and neither the
+                        # gateway nor the vault has it. Ask for access instead of
+                        # spending a dispatch on code that cannot authenticate.
                         logger.warning(
                             "[Kernel] No Nexus credentials for system=%s — "
-                            "register with: jarviscore nexus register %s (local vault) "
+                            "yielding for human access grant. Register with: "
+                            "jarviscore nexus register %s (local vault) "
                             "or set NEXUS_GATEWAY_URL (gateway)",
                             system_name, system_name,
+                        )
+                        await self._cleanup_step(step_id)
+                        return AgentOutput(
+                            status="yield",
+                            summary=(
+                                f"No credentials for system={system_name}. A human must "
+                                f"grant access before this task can run: "
+                                f"jarviscore nexus register {system_name} (local vault) "
+                                f"or set NEXUS_GATEWAY_URL (gateway)."
+                            ),
+                            trajectory=[],
+                            metadata={
+                                "tokens": total_tokens,
+                                "cost_usd": total_cost,
+                                "dispatches": dispatches,
+                                "yield_pending": True,
+                                "escalation_reason": "auth_required",
+                                "system": system_name,
+                                "hitl_type": "auth",
+                                "typed_outcome": "YIELD_AUTH_REQUIRED",
+                            },
                         )
 
 

--- a/tests/test_kernel.py
+++ b/tests/test_kernel.py
@@ -342,6 +342,58 @@ class TestKernelHITL:
 
 # ── Dispatch Records ──────────────────────────────────────────────────
 
+class TestDeclaredSystemCredentials:
+    """issue #151 — a declared provider with no credentials is a human decision."""
+
+    @pytest.mark.asyncio
+    async def test_missing_credentials_yield_before_spending_a_dispatch(
+        self, kernel, mock_llm, monkeypatch
+    ):
+        monkeypatch.setattr(
+            "jarviscore.nexus.store.get_store",
+            lambda: type("EmptyVault", (), {"get": staticmethod(lambda name: None)})(),
+        )
+        mock_llm.responses = [_router_response("coder"), _coder_write_response()]
+        output = await kernel.execute(task="Read our CRM contacts", context={"system": "hubspot"})
+
+        assert output.status == "yield"
+        assert output.metadata["typed_outcome"] == "YIELD_AUTH_REQUIRED"
+        assert output.metadata["escalation_reason"] == "auth_required"
+        assert output.metadata["system"] == "hubspot"
+        assert output.metadata["yield_pending"] is True
+        assert "jarviscore nexus register hubspot" in output.summary
+        # Routing costs one call; the dispatch that could not authenticate never ran.
+        assert len(mock_llm.calls) == 1
+        assert output.metadata["dispatches"] == []
+
+    @pytest.mark.asyncio
+    async def test_registered_provider_still_dispatches(
+        self, kernel, mock_llm, mock_sandbox, monkeypatch
+    ):
+        monkeypatch.setattr(
+            "jarviscore.nexus.store.get_store",
+            lambda: type("Vault", (), {"get": staticmethod(lambda name: {"auth_type": "oauth2"})})(),
+        )
+        mock_sandbox.responses = [{"status": "success", "output": {"contacts": 2}}]
+        mock_llm.responses = [
+            _router_response("coder"),
+            _coder_write_response('result = {"contacts": 2}'),
+        ]
+        output = await kernel.execute(task="Read our CRM contacts", context={"system": "hubspot"})
+        assert output.status == "success"
+        assert output.payload == {"contacts": 2}
+
+    @pytest.mark.asyncio
+    async def test_a_task_naming_no_system_is_unaffected(self, kernel, mock_llm, mock_sandbox):
+        mock_sandbox.responses = [{"status": "success", "output": {"v": 1}}]
+        mock_llm.responses = [
+            _router_response("coder"),
+            _coder_write_response('result = {"v": 1}'),
+        ]
+        output = await kernel.execute(task="Add two numbers")
+        assert output.status == "success"
+
+
 class TestDispatchRecords:
 
     @pytest.mark.asyncio


### PR DESCRIPTION
Closes #151.

## What was wrong

When a task declared `context["system"]` and neither the gateway nor the local vault could resolve credentials for it, `Kernel.execute` logged a warning and dispatched anyway:

```python
else:
    logger.warning(
        "[Kernel] No Nexus credentials for system=%s — "
        "register with: jarviscore nexus register %s (local vault) "
        "or set NEXUS_GATEWAY_URL (gateway)",
        system_name, system_name,
    )
```

At that point the kernel already knows, deterministically and before spending a token, that the task named a provider and that nothing can authenticate to it. The agent then burned a dispatch writing code against an unreachable API and reported a failure whose stated cause was usually wrong — a 401 body, a "blocked" envelope, or a fallback to browser automation.

The warning goes to logs, which end users of a hosted product never see. Applications with a HITL queue got no entry, so the desk looked idle while the work was actually blocked on a credential grant.

## The fix

Yield the contract the framework already defines for this. The kernel returns `YIELD_AUTH_REQUIRED` for a 401 mid-dispatch; this returns the same shape at the deterministic detection point, naming the provider and carrying the remediation the warning already knew.

No new concept, no new metadata shape for consumers to learn — the difference is that it now costs nothing and asks the human the only useful question.

## Relationship to #45

#45 asks for classification so system failures stop leaking into the human decision queue. This is the opposite direction: a genuine `auth_required` decision that never reached the queue at all. They are complementary.

## Tests

- missing credentials yield before spending a dispatch: `typed_outcome`, `escalation_reason`, `system` and `yield_pending` are set, the summary carries the exact remediation, and the LLM is called once for routing only
- a registered provider still dispatches and succeeds
- a task naming no system is unaffected

101 tests pass across `test_kernel`, `test_kernel_hitl`, `test_kernel_defaults`, `test_autoagent_kernel` and `test_autoagent`.

## Behaviour change

A task that declares a system it cannot authenticate to now yields instead of running. Deployments that declare a system they do not actually call would see a yield where they previously saw a run; declaring a provider is a statement of intent, so that surfaces a mis-declaration rather than hiding it.
