### PR TITLE
fix(memory): Athena writes keep the fidelity the other tiers already get

### DIFF
--- a/jarviscore/memory/athena_memory.py
+++ b/jarviscore/memory/athena_memory.py
@@ -156,7 +156,7 @@ class AthenaMemory:
         """Emit an observation event when a task is completed."""
         content = f"Task completed: {title}"
         if output_summary:
-            content += f" — {output_summary[:300]}"
+            content += f" — {output_summary}"
         await self.record_observation(
             content,
             metadata={"task_id": task_id, "event": "task_completed"},
@@ -168,7 +168,7 @@ class AthenaMemory:
         """Emit an observation event when a meeting note is created."""
         content = f"Meeting recorded: {title}"
         if summary:
-            content += f" — {summary[:300]}"
+            content += f" — {summary}"
         await self.record_observation(
             content,
             metadata={"meeting_id": meeting_id, "event": "meeting_noted"},
@@ -180,7 +180,7 @@ class AthenaMemory:
         """Emit an observation event when a HITL request is resolved."""
         content = f"HITL resolved: {decision.upper()} — request {request_id}"
         if note:
-            content += f" (note: {note[:200]})"
+            content += f" (note: {note})"
         await self.record_observation(
             content,
             metadata={"request_id": request_id, "decision": decision, "event": "hitl_resolved"},

--- a/jarviscore/memory/unified.py
+++ b/jarviscore/memory/unified.py
@@ -146,12 +146,14 @@ class UnifiedMemory:
             await self.episodic.append(entry)
 
         # ── Tier 4: Athena STM write ──────────────────────────────────────────
+        # Full fidelity, as written to the scratchpad and ledger above: Athena
+        # summarises into MTM chains, and it cannot summarise what it never saw.
         am = await self._get_athena_memory()
         if am:
             try:
                 if thought:
-                    await am.record_thought(thought[:500])
-                outcome = f"{action}: {result[:300]}" if result else action
+                    await am.record_thought(thought)
+                outcome = f"{action}: {result}" if result else action
                 await am.record_action(outcome)
             except Exception as exc:
                 logger.debug("[UnifiedMemory] Athena log_turn write failed (non-fatal): %s", exc)

--- a/tests/test_memory_unified.py
+++ b/tests/test_memory_unified.py
@@ -76,6 +76,29 @@ class TestTierAvailability:
 
 class TestLogTurn:
     @pytest.mark.asyncio
+    async def test_athena_receives_the_same_fidelity_as_the_other_tiers(self, store, blob):
+        """issue #153 — a clipped write destroys the original; only reads may abridge."""
+        recorded = {}
+
+        class RecordingAthena:
+            async def record_thought(self, content, metadata=None):
+                recorded["thought"] = content
+
+            async def record_action(self, content, metadata=None):
+                recorded["action"] = content
+
+        mem = UnifiedMemory("wf-1", "step1", "analyst", store, blob)
+        mem._athena_memory = RecordingAthena()
+        thought = "Reasoned about the account. " * 60      # ~1680 chars
+        result = "Found the renewal evidence. " * 40       # ~1120 chars
+        await mem.log_turn("t1", thought, "search", result)
+
+        assert recorded["thought"] == thought
+        assert result in recorded["action"]
+        # The ledger already stored it whole; Athena must not be the lossy tier.
+        assert (await mem.episodic.tail(1))[0]["thought"] == thought
+
+    @pytest.mark.asyncio
     async def test_log_turn_writes_to_scratchpad(self, mem, blob):
         await mem.log_turn("t1", "thinking", "search", "found 10 results")
         entries = await mem.working.read_all()


### PR DESCRIPTION
Closes #153.

## What was wrong

`UnifiedMemory.log_turn` wrote the same turn to three tiers at two different fidelities:

```python
if self.working:
    await self.working.write("turn", entry)      # full thought + result
if self.episodic:
    await self.episodic.append(entry)            # full thought + result

am = await self._get_athena_memory()
if am:
    if thought:
        await am.record_thought(thought[:500])   # clipped
    outcome = f"{action}: {result[:300]}" if result else action
    await am.record_action(outcome)              # clipped
```

The tier meant to survive longest received the only damaged copy — and MTM chains are summarised *from* that copy, so the loss compounded at every consolidation.

The domain hooks clipped too: `on_task_completed` at 300 characters, `on_meeting_noted` at 300, `on_hitl_resolved` at 200. A task outcome, a meeting summary and a human's decision note are precisely the content worth remembering.

## Why this is not #98

#98 is the read side. Those clips are recoverable: raise the budget, or call `read_turn_result`, and the full value is still in storage. These were on the write side. Once `thought[:500]` is stored, character 501 does not exist anywhere. It is the failure mode #59 closed for evidence, reappearing one tier over.

## The fix

Remove all six clips. The same values already reach Redis and blob storage unclipped in the same function, so this restores consistency rather than introducing a new risk. Athena's summarisation is the component designed to compress, and it cannot compress what it never received.

## Tests

A recording double asserts Athena receives byte-identical content to the episodic ledger for a ~1.7k-character thought and a ~1.1k-character result.

67 tests pass across `test_memory_unified`, `test_memory_episodic`, `test_memory_ltm`, `test_memory_scratchpad` and `test_athena_client`.

## Verified against a live Athena

Before this change a stored thought could not exceed 500 characters. A live desk run now stores 665.
