### PR TITLE
feat(context): evict and reference by priority instead of clipping values

### DIFF
--- a/jarviscore/context/context_manager.py
+++ b/jarviscore/context/context_manager.py
@@ -28,6 +28,19 @@ import time
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional, Tuple, TYPE_CHECKING
 
+from jarviscore.context.pressure import (
+    LADDER,
+    PRESSURE_STATE_KEY,
+    PressureState,
+    PressureTier,
+    filter_input_context_keys,
+    format_pressure_notice,
+    format_step_references,
+    prior_step_mode,
+    set_pressure,
+    should_render_block,
+)
+
 if TYPE_CHECKING:
     from jarviscore.kernel.state import KernelState
 
@@ -66,24 +79,20 @@ class BudgetConfig:
         history_limit:             Max tokens to spend on tool history.
         summarization_threshold:   Fraction of total_tokens at which
                                    auto-summarisation is triggered.
-        prior_step_value_limit:    Chars of each prior step output shown inline.
-        context_value_limit:       Chars of each input-context value shown inline.
-        belief_value_limit:        Chars of each belief-state value shown inline.
-        memory_item_limit:         Chars of each finding / LTM item shown inline.
-        internal_var_limit:        Chars of each internal variable shown inline.
-        history_value_limit:       Chars of each tool-history input/output shown inline.
-        state_keys_limit:          Max keys rendered per state dict (overflow is
-                                   announced by name, never silently dropped).
 
-    All char limits default to the historical values; every cut they cause
-    is marked in the rendered context (see issue #55) — an agent that KNOWS
-    data is missing asks for the rest; one that doesn't confabulates.
+    Values are never cut to fit (issue #154). When the budget cannot hold
+    everything, whole blocks stop being inlined in priority order and the
+    withheld records are named, so the agent can retrieve them from the store
+    they still live in. The per-value character limits below are retained for
+    backward compatibility and no longer affect rendering.
     """
     total_tokens: int = 80_000
     output_reserve: int = 4_000
     system_reserve: int = 8_000
     history_limit: int = 20_000
     summarization_threshold: float = 0.8
+    # Deprecated (issue #154): retained so existing configs keep importing.
+    # Rendering no longer cuts values, so these have no effect.
     prior_step_value_limit: int = 2000
     context_value_limit: int = 800
     belief_value_limit: int = 200
@@ -91,9 +100,6 @@ class BudgetConfig:
     internal_var_limit: int = 200
     history_value_limit: int = 600
     state_keys_limit: int = 10
-    # Chars of each turn's output shown to the summarizer LLM. 100 chars was
-    # not a summarizable evidence base — the "summary" was confabulation by
-    # construction (issue #59).
     summary_evidence_limit: int = 800
     # How many compressed-away turns stay retrievable in the archive.
     archive_window: int = 50
@@ -102,7 +108,7 @@ class BudgetConfig:
     # fidelity. Incremental accumulation, never monolithic rewrite — the
     # context-collapse failure mode identified by ACE (arXiv:2510.04618).
     ltm_window: int = 20
-    # How many LTM entries the context block renders (was a silent [-5:]).
+    # How many LTM entries the context block renders.
     ltm_render_limit: int = 5
     # Token budget for the GOAL STATE block (issue #72) — the accumulated
     # facts and step history of a goal execution, rendered structured.
@@ -207,78 +213,29 @@ class ContextManager:
         if goal:
             revision = context.get("_plan_revision", 0)
             rev_note = f" (plan revision {revision})" if revision else ""
-            lines.append(f"**Goal:** {self._clip(goal, 300)}{rev_note}")
+            lines.append(f"**Goal:** {goal}{rev_note}")
 
         if isinstance(facts, dict) and facts:
             high_conf = context.get("_goal_facts_high_confidence") or {}
             lines.append(f"**Established facts ({len(facts)}):**")
             # High-confidence facts first — they are the plan's load-bearing truth
             ordered = sorted(facts.items(), key=lambda kv: kv[0] not in high_conf)
-            visible, overflow = self._visible_items(dict(ordered), self.config.state_keys_limit * 2)
-            for key, value in visible:
+            for key, value in ordered:
                 marker = " ✓" if key in high_conf else ""
-                lines.append(f"- `{key}`{marker}: {self._clip(value, self.config.belief_value_limit)}")
-            if overflow:
-                lines.append(overflow.rstrip())
+                lines.append(f"- `{key}`{marker}: {value}")
 
         if isinstance(completed, list) and completed:
             lines.append(f"**Completed steps ({len(completed)}):**")
-            for cs in completed[-8:]:
+            for cs in completed:
                 if isinstance(cs, dict):
                     sid = cs.get("step_id", "?")
                     verdict = cs.get("verdict", cs.get("status", "?"))
-                    summary = self._clip(cs.get("summary") or cs.get("task", ""), 160)
-                    lines.append(f"- [{verdict}] `{sid}`: {summary}")
+                    lines.append(f"- [{verdict}] `{sid}`: {cs.get('summary') or cs.get('task', '')}")
                 else:
-                    lines.append(f"- {self._clip(cs, 160)}")
-            hidden = len(completed) - 8
-            if hidden > 0:
-                lines.append(f"…and {hidden} earlier steps not shown")
+                    lines.append(f"- {cs}")
 
         return "\n".join(lines)
 
-
-    @staticmethod
-    def _clip(value: Any, limit: int) -> str:
-        """Render a value for the context window — cut honestly, never silently.
-
-        Values within the limit render byte-identical to ``str(value)``.
-        Longer values are cut WITH an explicit marker, because the agent
-        reads these blocks as its world state: a model that knows data is
-        missing asks for the rest; a model that doesn't confabulates.
-        """
-        text = str(value)
-        if len(text) <= limit:
-            return text
-        return f"{text[:limit]}…[truncated: showing {limit} of {len(text)} chars]"
-
-    @staticmethod
-    def _visible_items(
-        data: Dict[str, Any], limit: int
-    ) -> Tuple[List[Tuple[str, Any]], str]:
-        """Cap a state dict at *limit* keys — recency wins, overflow is named.
-
-        Returns (visible_items, overflow_notice). The MOST RECENTLY inserted
-        keys survive (dicts preserve insertion order; the newest state is the
-        most likely to matter). Hidden keys are announced BY NAME so the agent
-        keeps an index of its own state even when the values don't fit —
-        silent key loss decided by insertion order was issue #56.
-        """
-        items = list(data.items())
-        if len(items) <= limit:
-            return items, ""
-        visible = items[-limit:]
-        hidden = [k for k, _ in items[:-limit]]
-        notice = (
-            f"…and {len(hidden)} earlier key(s) not shown: "
-            + ", ".join(f"`{k}`" for k in hidden)
-            + " (values hidden — re-derive or ask if needed)\n"
-        )
-        return visible, notice
-
-    # ------------------------------------------------------------------
-    # Context building — KernelState input (preferred)
-    # ------------------------------------------------------------------
 
     def build_context(self, state: Any) -> str:
         """
@@ -294,32 +251,58 @@ class ContextManager:
         return self._build_context_from_state(state)
 
     def _build_context_from_state(self, state: "KernelState") -> str:
-        """Build context from a KernelState Pydantic model."""
+        """Build context from a KernelState Pydantic model.
+
+        Blocks are composed once at full fidelity, then the least aggressive
+        pressure tier that fits the budget is chosen. Values are never cut.
+        """
         budget = self.config.usable_tokens
-        blocks: List[str] = []
-        used = 0
+        candidates = self._compose_blocks(state)
+        full_cost = sum(self.count_tokens(text) for _, text in candidates)
 
-        def _add_block(block: str, max_tokens: Optional[int] = None) -> bool:
-            """Add a block if it fits within budget. Returns True if added."""
-            nonlocal used
-            cost = self.count_tokens(block)
-            limit = min(budget - used, max_tokens) if max_tokens else budget - used
-            if cost <= 0 or limit <= 0:
-                return False
-            if cost > limit:
-                # Truncate to fit — honestly (issue #55)
-                char_limit = int(limit * 4)  # ~4 chars per token
-                original_len = len(block)
-                block = (
-                    block[:char_limit]
-                    + f"\n…[block truncated to fit budget: showing {char_limit} of {original_len} chars]"
-                )
-                cost = self.count_tokens(block)
-            blocks.append(block)
-            used += cost
-            return True
+        for tier in LADDER:
+            blocks = self._render_at_tier(state, candidates, tier)
+            used = sum(self.count_tokens(text) for text in blocks)
+            if used <= budget or tier is LADDER[-1]:
+                break
 
-        # ═══ BLOCK 1: MISSION (Fixed — Never Trimmed) ═══
+        evicted = [key for key, _ in candidates if not should_render_block(key, tier)]
+        pressure = PressureState(tier=tier, evicted=evicted, tokens=full_cost, budget=budget)
+        if isinstance(state.internal_variables, dict):
+            set_pressure(state.internal_variables, pressure)
+        if tier is not PressureTier.NORMAL:
+            blocks.insert(1, format_pressure_notice(pressure))
+
+        blocks.append(
+            f"\n---\n**Context Budget:** {used}/{budget} tokens "
+            f"({100 * used // budget if budget else 0}% used)"
+        )
+        return "\n\n".join(blocks)
+
+    def _render_at_tier(self, state: "KernelState", candidates, tier) -> List[str]:
+        """Keep every block this tier allows, whole; reference the rest."""
+        rendered: List[str] = []
+        for key, text in candidates:
+            if key == "input_context" and tier is not PressureTier.NORMAL:
+                text = self._compose_input_context(state, tier)
+                if not text:
+                    continue
+            if should_render_block(key, tier):
+                rendered.append(text)
+        if prior_step_mode(tier) == "references":
+            prior = (state.context or {}).get("previous_step_results") or {}
+            if prior:
+                rendered.append(format_step_references(state.workflow_id, prior.keys()))
+        return rendered
+
+    def _compose_blocks(self, state: "KernelState") -> List[tuple]:
+        """Every block the turn could show, at full fidelity, in priority order."""
+        blocks: List[tuple] = []
+
+        def add(key: str, text: str) -> None:
+            if text and text.strip():
+                blocks.append((key, text))
+
         mission = f"""## MISSION
 **Workflow:** {state.workflow_id}
 **Step:** {state.step_id}
@@ -329,164 +312,117 @@ class ContextManager:
 """
         if state.last_error:
             mission += f"**CRITICAL ERROR TO FIX:** {state.last_error}\n"
-        _add_block(mission)
+        add("mission", mission)
+        add("goal_state", self._build_goal_state_block(state.context or {}))
 
-        # ═══ BLOCK 1b: GOAL STATE (High Priority — issue #72) ═══
-        # A goal execution's accumulated truth used to reach each step as ONE
-        # generic `_goal_facts: {...}` line clipped at the value limit — the
-        # plan's entire memory in 800 chars. Goal state is mission-level
-        # context: structured, one fact per line, honest overflow.
-        goal_block = self._build_goal_state_block(state.context or {})
-        if goal_block:
-            _add_block(goal_block, max_tokens=self.config.goal_state_budget)
-
-        # ═══ BLOCK 2: FAILURE MEMORY (High Priority) ═══
         if state.failure_ledger:
             lines = ["## FAILURE MEMORY (Do Not Repeat)"]
             for entry in state.failure_ledger[-5:]:
                 tool = entry.get("tool", "unknown")
                 err_type = entry.get("error_type", "UNKNOWN")
-                err_msg = self._clip(entry.get("error", ""), 180)
-                lines.append(f"- `{tool}` → `{err_type}`: {err_msg}")
+                lines.append(f"- `{tool}` → `{err_type}`: {entry.get('error', '')}")
             lines.append("Rule: if tool+params already failed recently, choose a different strategy.")
-            _add_block("\n".join(lines))
+            add("failure_memory", "\n".join(lines))
 
-        # ═══ BLOCK 3: KNOWLEDGE ACCUMULATOR (High Priority) ═══
-        # Surfaces accumulated research findings and API specs so the agent
-        # can see what it has already discovered — prevents blind re-searching.
         findings = state.internal_variables.get("research_findings", [])
         api_specs_accum = state.internal_variables.get("api_specs", [])
         if findings or api_specs_accum:
             kb_block = "## WHAT I KNOW SO FAR\n"
             if isinstance(api_specs_accum, list) and api_specs_accum:
                 kb_block += f"**API Specs Extracted:** {len(api_specs_accum)} endpoint(s)\n"
-                for spec in api_specs_accum[-8:]:
+                for spec in api_specs_accum:
                     if not isinstance(spec, dict):
                         continue
                     method = spec.get("method", "?")
                     path = spec.get("path") or spec.get("url") or "?"
-                    summary_text = self._clip(spec.get("summary", ""), 80)
-                    kb_block += f"  - `{method} {path}` — {summary_text}\n"
+                    kb_block += f"  - `{method} {path}` — {spec.get('summary', '')}\n"
             if isinstance(findings, list) and findings:
                 kb_block += f"**Research Findings:** {len(findings)} item(s)\n"
-                for finding in findings[-5:]:
+                for finding in findings:
                     if isinstance(finding, dict):
-                        kb_block += f"  - {self._clip(finding.get('summary', finding.get('content_preview', finding)), self.config.memory_item_limit)}\n"
+                        kb_block += f"  - {finding.get('summary', finding.get('content_preview', finding))}\n"
                     else:
-                        kb_block += f"  - {self._clip(finding, self.config.memory_item_limit)}\n"
-            _add_block(kb_block, max_tokens=4000)
+                        kb_block += f"  - {finding}\n"
+            add("knowledge", kb_block)
 
-        # ═══ BLOCK 4: INPUT CONTEXT (High Priority) ═══
-        if state.context:
-            input_block = "## INPUT CONTEXT\n"
-            # Prior step outputs get highest priority
-            prior = state.context.get("previous_step_results", {})
-            if prior:
-                for step_id, step_result in prior.items():
-                    output = step_result.get("output", step_result) if isinstance(step_result, dict) else step_result
-                    output_str = self._clip(output, self.config.prior_step_value_limit)
-                    input_block += f"**[Prior Step: {step_id}]**\n{output_str}\n\n"
+        add("input_context", self._compose_input_context(state, PressureTier.NORMAL))
 
-            # Other context fields (skip internal keys; goal keys are
-            # PROMOTED to the GOAL STATE block, not dropped)
-            skip_keys = {"previous_step_results", "workflow_id", "step_id",
-                          "system_prompt", "_jarvis_context", "_auth_credentials",
-                          "_agent_default_kernel_role",
-                          "_goal", "_goal_id", "_goal_facts",
-                          "_goal_facts_high_confidence", "_completed_steps",
-                          "_plan_revision"}
-            other = {k: v for k, v in state.context.items() if k not in skip_keys}
-            if other:
-                cleaned = self._scrub_dict(other)
-                visible, overflow = self._visible_items(cleaned, self.config.state_keys_limit)
-                for k, v in visible:
-                    if hasattr(v, "model_json_schema"):
-                        # Render Pydantic BaseModels as JSON schemas for the LLM
-                        try:
-                            import json
-                            val_str = json.dumps(v.model_json_schema(), indent=2)
-                        except Exception:
-                            val_str = self._clip(v, self.config.context_value_limit)
-                    else:
-                        val_str = self._clip(v, self.config.context_value_limit)
-                    input_block += f"- `{k}`: {val_str}\n"
-                input_block += overflow
-            _add_block(input_block, max_tokens=8000)
-
-        # ═══ BLOCK 5: BELIEF STATE (Medium Priority) ═══
         if state.belief_state:
             belief_block = "## BELIEF STATE\n"
-            visible, overflow = self._visible_items(state.belief_state, self.config.state_keys_limit)
-            for k, v in visible:
-                belief_block += f"- `{k}`: {self._clip(v, self.config.belief_value_limit)}\n"
-            belief_block += overflow
-            _add_block(belief_block, max_tokens=1000)
+            for key, value in state.belief_state.items():
+                belief_block += f"- `{key}`: {value}\n"
+            add("belief_state", belief_block)
 
-        # ═══ BLOCK 6: SCRATCHPAD / THOUGHTS (Medium Priority) ═══
         thoughts_content = ""
         if state.thoughts:
-            thoughts_content = "\n".join(f"- {t}" for t in state.thoughts[-10:])
+            thoughts_content = "\n".join(f"- {thought}" for thought in state.thoughts[-10:])
         if state.scratchpad_notes:
             thoughts_content += f"\n{state.scratchpad_notes}"
         if thoughts_content.strip():
-            _add_block(f"## WORKING MEMORY\n{thoughts_content.strip()}", max_tokens=3000)
+            add("working_memory", f"## WORKING MEMORY\n{thoughts_content.strip()}")
 
-        # ═══ BLOCK 7: LONG-TERM MEMORY (Medium Priority) ═══
         ltm = state.internal_variables.get("long_term_memory", [])
         if ltm:
             ltm_block = "## LONG-TERM MEMORY (Compressed History)\n"
             render_limit = self.config.ltm_render_limit
             for item in ltm[-render_limit:]:
-                if isinstance(item, dict):
-                    ltm_block += f"- {self._clip(item.get('summary', str(item)), self.config.memory_item_limit)}\n"
-                else:
-                    ltm_block += f"- {self._clip(item, self.config.memory_item_limit)}\n"
+                ltm_block += f"- {item.get('summary', item) if isinstance(item, dict) else item}\n"
             hidden = len(ltm) - render_limit
             if hidden > 0:
-                ltm_block += f"…and {hidden} older memories not shown\n"
-            _add_block(ltm_block, max_tokens=2000)
+                ltm_block += f"…and {hidden} older memories held in long-term memory\n"
+            add("long_term_memory", ltm_block)
 
-        # ═══ BLOCK 8: TOOL HISTORY (Sliding Window) ═══
-        history_budget = min(self.config.history_limit, budget - used - 2000)
-        if history_budget > 0 and state.tool_history:
-            history_block, history_tokens = self._format_tool_history(
-                state.tool_history, history_budget
+        if state.tool_history:
+            history_block, _ = self._format_tool_history(
+                state.tool_history, self.config.history_limit
             )
-            if history_block:
-                blocks.append(history_block)
-                used += history_tokens
+            add("tool_history", history_block)
 
-        # ═══ BLOCK 9: VARIABLES (Fill Remaining) ═══
-        remaining = budget - used
-        if remaining > 500 and state.internal_variables:
-            vars_block = "## INTERNAL STATE\n"
-            # Skip keys that are surfaced by dedicated blocks above.
-            # Filter FIRST, then cap — skipped keys must not consume the
-            # visibility budget of real ones (issue #56).
-            skip_var_keys = {"long_term_memory", "research_findings", "api_specs", "failure_ledger"}
+        if state.internal_variables:
+            skip_var_keys = {"long_term_memory", "research_findings", "api_specs",
+                             "failure_ledger", PRESSURE_STATE_KEY}
             renderable = {
                 key: value
                 for key, value in state.internal_variables.items()
                 if key not in skip_var_keys and not key.startswith("_")
             }
-            visible, overflow = self._visible_items(renderable, self.config.state_keys_limit)
-            for key, value in visible:
-                value_str = self._clip(self._scrub_value(key, value), self.config.internal_var_limit)
-                vars_block += f"- `{key}`: {value_str}\n"
-            vars_block += overflow
-            vars_cost = self.count_tokens(vars_block)
-            if vars_cost < remaining:
-                blocks.append(vars_block)
-                used += vars_cost
+            if renderable:
+                vars_block = "## INTERNAL STATE\n"
+                for key, value in renderable.items():
+                    vars_block += f"- `{key}`: {self._scrub_value(key, value)}\n"
+                add("internal_variables", vars_block)
 
-        # ═══ BUDGET STATUS ═══
-        budget_line = (
-            f"\n---\n"
-            f"**Context Budget:** {used}/{budget} tokens ({100*used//budget if budget else 0}% used)"
-        )
-        blocks.append(budget_line)
+        return blocks
 
-        return "\n\n".join(blocks)
+    def _compose_input_context(self, state: "KernelState", tier) -> str:
+        """Input context, whole values only; bulk keys drop entirely under pressure."""
+        if not state.context:
+            return ""
+        input_block = "## INPUT CONTEXT\n"
+        prior = state.context.get("previous_step_results", {})
+        if prior and prior_step_mode(tier) == "full":
+            for step_id, step_result in prior.items():
+                output = (step_result.get("output", step_result)
+                          if isinstance(step_result, dict) else step_result)
+                input_block += f"**[Prior Step: {step_id}]**\n{output}\n\n"
+
+        skip_keys = {"previous_step_results", "workflow_id", "step_id",
+                     "system_prompt", "_jarvis_context", "_auth_credentials",
+                     "_agent_default_kernel_role",
+                     "_goal", "_goal_id", "_goal_facts",
+                     "_goal_facts_high_confidence", "_completed_steps",
+                     "_plan_revision"}
+        other = {key: value for key, value in state.context.items() if key not in skip_keys}
+        allowed = set(filter_input_context_keys(other.keys(), tier))
+        cleaned = self._scrub_dict({k: v for k, v in other.items() if k in allowed})
+        for key, value in cleaned.items():
+            if hasattr(value, "model_json_schema"):
+                try:
+                    value = json.dumps(value.model_json_schema(), indent=2)
+                except Exception:
+                    pass
+            input_block += f"- `{key}`: {value}\n"
+        return input_block if input_block.strip() != "## INPUT CONTEXT" else ""
 
     def _format_tool_history(
         self,
@@ -495,36 +431,37 @@ class ContextManager:
     ) -> Tuple[str, int]:
         """Format recent tool history to fit within budget.
 
-        Works backwards (most recent first), then reverses for
-        chronological output. Each entry is truncated to prevent
-        a single large output from consuming the entire budget.
+        Works backwards (most recent first), then reverses for chronological
+        output. Entries are whole: a turn that does not fit is left out and
+        stays retrievable via ``read_turn_result``, rather than being cut.
         """
         header = "## RECENT ACTIONS\n"
         header_tokens = self.count_tokens(header)
         formatted = []
         current = header_tokens
+        withheld = 0
 
         # Process most-recent first (max 20 entries)
         for turn in reversed(history[-20:]):
             if hasattr(turn, "tool_name"):
                 # KernelState.ToolResult model
-                output_str = self._clip(turn.tool_output, self.config.history_value_limit)
                 entry = (
                     f"**{turn.tool_name}** [{turn.status}]\n"
-                    f"  Input: {self._clip(json.dumps(turn.tool_input, default=str), self.config.history_value_limit)}\n"
-                    f"  Output: {output_str}"
+                    f"  Input: {json.dumps(turn.tool_input, default=str)}\n"
+                    f"  Output: {turn.tool_output}"
                 )
                 if turn.error:
-                    entry += f"\n  Error: {self._clip(turn.error, 200)}"
+                    entry += f"\n  Error: {turn.error}"
             elif isinstance(turn, dict):
                 # Legacy dict format
-                entry = f"- {json.dumps(turn, default=str)[:500]}"
+                entry = f"- {json.dumps(turn, default=str)}"
             else:
                 continue
 
             cost = self.count_tokens(entry)
             if current + cost > budget:
-                break
+                withheld += 1
+                continue
             formatted.append(entry)
             current += cost
 
@@ -533,6 +470,11 @@ class ContextManager:
 
         # Restore chronological order
         formatted.reverse()
+        if withheld:
+            formatted.append(
+                f"…{withheld} earlier action(s) not inlined this turn — "
+                "call TOOL: read_turn_result to read any of them in full."
+            )
         return header + "\n\n".join(formatted), current
 
     # ------------------------------------------------------------------
@@ -683,14 +625,14 @@ class ContextManager:
                 "Focus on WHAT was discovered and WHAT was attempted:\n"
             )
             for tr in old_entries:
-                evidence = self._clip(tr.tool_output, self.config.summary_evidence_limit)
+                evidence = tr.tool_output
                 summary_prompt += f"- {tr.tool_name}: {evidence}\n"
 
             if hasattr(llm, "generate"):
                 result = await llm.generate(
                     messages=[{"role": "user", "content": summary_prompt}]
                 )
-                summary_text = self._clip(result.get("content", ""), 1000)
+                summary_text = result.get("content", "")
             else:
                 # No LLM attached: mechanical summary, but the originals are
                 # archived below — nothing is destroyed.
@@ -787,7 +729,7 @@ class ContextManager:
             result = await llm.generate(
                 messages=[{"role": "user", "content": merge_prompt}]
             )
-            epoch_text = self._clip(result.get("content", ""), 2000)
+            epoch_text = result.get("content", "")
         except Exception as e:
             # A failed merge must not cost memory — keep entries, retry later.
             logger.warning(f"LTM epoch merge failed ({e}) — keeping entries for retry")

--- a/jarviscore/context/pressure.py
+++ b/jarviscore/context/pressure.py
@@ -1,0 +1,179 @@
+"""Context pressure — how a turn stays inside its budget without losing data.
+
+Context grows roughly linearly with turns while model capacity is fixed. The
+tempting fix is to cut inside values, but a character limit decides what an
+agent may know by counting bytes: a clipped JSON payload is not a smaller
+payload, it is an invalid one, and the part that was cut is simply gone.
+
+So nothing here trims. Under pressure the manager decides *which blocks are
+rendered this turn*, in priority order, and replaces what it cannot inline with
+a pointer to the canonical record. Every value that appears, appears whole.
+
+The ladder, applied only as far as needed to fit:
+
+  NORMAL     everything renders
+  COMPRESS   oldest history is summarised into long-term memory (a derived
+             artifact; the original stays in its store)
+  EVICT_P3   stop inlining P3 blocks
+  EVICT_P2   stop inlining P2 blocks; prior step outputs become references
+  RECOVERY   P0 only, plus a notice telling the agent what it is missing
+
+Priorities:
+
+  P0  never evicted — mission, goal state, the pressure notice itself
+  P1  kept if possible — failure memory, findings, beliefs, working memory
+  P2  stop inlining first — input context, long-term memory, tool history
+  P3  stop inlining — internal variables
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Dict, Iterable, List, MutableMapping, Optional
+
+PRESSURE_STATE_KEY = "context_pressure"
+
+
+class PressureTier(str, Enum):
+    NORMAL = "normal"
+    COMPRESS = "compress"
+    EVICT_P3 = "evict_p3"
+    EVICT_P2 = "evict_p2"
+    RECOVERY = "recovery"
+
+
+LADDER: tuple[PressureTier, ...] = (
+    PressureTier.NORMAL,
+    PressureTier.COMPRESS,
+    PressureTier.EVICT_P3,
+    PressureTier.EVICT_P2,
+    PressureTier.RECOVERY,
+)
+
+BLOCK_PRIORITY: Dict[str, int] = {
+    "mission": 0,
+    "goal_state": 0,
+    "context_pressure": 0,
+    "budget": 0,
+    "failure_memory": 1,
+    "knowledge": 1,
+    "belief_state": 1,
+    "working_memory": 1,
+    "input_context": 2,
+    "long_term_memory": 2,
+    "tool_history": 2,
+    "internal_variables": 3,
+}
+
+# Identity and instruction: without these the agent does not know what it was
+# asked, so they survive every tier.
+INPUT_CONTEXT_ALWAYS_KEYS = frozenset({
+    "task", "description", "objective", "human_response",
+    "action_type", "step_id", "workflow_id", "system", "provider",
+})
+
+# Bulk carried for convenience; the canonical copy lives in the workflow store.
+INPUT_CONTEXT_BULK_KEYS = frozenset({
+    "context_variables", "injected_context", "previous_output", "previous_outputs",
+})
+
+
+@dataclass
+class PressureState:
+    tier: PressureTier = PressureTier.NORMAL
+    evicted: List[str] = field(default_factory=list)
+    tokens: int = 0
+    budget: int = 0
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "tier": self.tier.value,
+            "evicted": list(self.evicted),
+            "tokens": self.tokens,
+            "budget": self.budget,
+        }
+
+    @classmethod
+    def from_dict(cls, raw: Any) -> "PressureState":
+        if not isinstance(raw, dict):
+            return cls()
+        try:
+            tier = PressureTier(str(raw.get("tier") or PressureTier.NORMAL.value))
+        except ValueError:
+            tier = PressureTier.NORMAL
+        evicted = raw.get("evicted")
+        return cls(
+            tier=tier,
+            evicted=[str(item) for item in evicted] if isinstance(evicted, list) else [],
+            tokens=int(raw.get("tokens") or 0),
+            budget=int(raw.get("budget") or 0),
+        )
+
+
+def get_pressure(internal_variables: Optional[MutableMapping[str, Any]]) -> PressureState:
+    if not isinstance(internal_variables, dict):
+        return PressureState()
+    return PressureState.from_dict(internal_variables.get(PRESSURE_STATE_KEY))
+
+
+def set_pressure(internal_variables: MutableMapping[str, Any], pressure: PressureState) -> None:
+    internal_variables[PRESSURE_STATE_KEY] = pressure.to_dict()
+
+
+def should_render_block(block_key: str, tier: PressureTier) -> bool:
+    priority = BLOCK_PRIORITY.get(block_key, 2)
+    if tier == PressureTier.RECOVERY:
+        return priority == 0
+    if tier == PressureTier.EVICT_P2:
+        return priority <= 1
+    if tier == PressureTier.EVICT_P3:
+        return priority <= 2
+    return True
+
+
+def prior_step_mode(tier: PressureTier) -> str:
+    """``full`` or ``references`` — never a fragment of a payload."""
+    if tier in (PressureTier.EVICT_P2, PressureTier.RECOVERY):
+        return "references"
+    return "full"
+
+
+def filter_input_context_keys(keys: Iterable[str], tier: PressureTier) -> List[str]:
+    """Drop whole keys, never part of a value."""
+    keys = list(keys)
+    if tier == PressureTier.RECOVERY:
+        return [key for key in keys if key in INPUT_CONTEXT_ALWAYS_KEYS]
+    if tier in (PressureTier.EVICT_P2, PressureTier.EVICT_P3):
+        return [key for key in keys if key not in INPUT_CONTEXT_BULK_KEYS]
+    return keys
+
+
+def format_step_references(workflow_id: str, step_ids: Iterable[str]) -> str:
+    """Where the full upstream payloads are, since they were not inlined."""
+    lines = [
+        "## PRIOR STEP REFERENCES",
+        "Upstream outputs were not inlined this turn because the context budget "
+        "could not hold them whole. They are unchanged in the workflow store:",
+        "",
+    ]
+    lines += [f"- `{step_id}` → `step_output:{workflow_id}:{step_id}`" for step_id in step_ids]
+    return "\n".join(lines)
+
+
+def format_pressure_notice(pressure: PressureState) -> str:
+    """What the agent is missing, in its own prompt, so it can act accordingly."""
+    lines = [
+        "## CONTEXT PRESSURE",
+        f"Tier: **{pressure.tier.value}** "
+        f"({pressure.tokens} of {pressure.budget} tokens at full fidelity).",
+    ]
+    if pressure.evicted:
+        lines.append(
+            "Not inlined this turn: " + ", ".join(f"`{name}`" for name in pressure.evicted) + "."
+        )
+    lines.append(
+        "Nothing was truncated — every value shown is whole. Withheld records are "
+        "unchanged in their stores; retrieve what you need rather than assuming it is gone."
+    )
+    return "\n".join(lines)

--- a/tests/test_context_manager.py
+++ b/tests/test_context_manager.py
@@ -215,35 +215,21 @@ def big_cm():
     return ContextManager(BudgetConfig())
 
 
-class TestHonestTruncation:
-    """Every value cut for the agent's eyes carries an explicit marker (#55)."""
+class TestNoTruncation:
+    """Values render whole; the budget is managed by eviction, not by cutting (#154)."""
 
-    def test_clip_within_limit_is_byte_identical(self):
-        assert ContextManager._clip("short value", 100) == "short value"
-
-    def test_clip_at_exact_limit_is_byte_identical(self):
-        text = "x" * 100
-        assert ContextManager._clip(text, 100) == text
-
-    def test_clip_over_limit_carries_marker(self):
-        text = "y" * 250
-        out = ContextManager._clip(text, 100)
-        assert out.startswith("y" * 100)
-        assert "…[truncated: showing 100 of 250 chars]" in out
-
-    def test_prior_step_output_truncation_is_marked(self, big_cm):
-        state = _kernel_state(context={
-            "previous_step_results": {
-                "step_a": {"output": "Z" * 5000},
-            },
-        })
+    def test_prior_step_output_renders_whole(self, big_cm):
+        payload = "Z" * 5000
+        state = _kernel_state(context={"previous_step_results": {"step_a": {"output": payload}}})
         rendered = big_cm.build_context(state)
-        assert "…[truncated: showing 2000 of 5000 chars]" in rendered
+        assert payload in rendered
+        assert "truncated" not in rendered
 
-    def test_belief_value_truncation_is_marked(self, big_cm):
+    def test_belief_value_renders_whole(self, big_cm):
         state = _kernel_state(belief_state={"hypothesis": "B" * 900})
         rendered = big_cm.build_context(state)
-        assert "…[truncated: showing 200 of 900 chars]" in rendered
+        assert "B" * 900 in rendered
+        assert "truncated" not in rendered
 
     def test_short_values_render_without_markers(self, big_cm):
         state = _kernel_state(
@@ -253,58 +239,75 @@ class TestHonestTruncation:
         rendered = big_cm.build_context(state)
         assert "…[truncated" not in rendered
 
-    def test_limits_are_configurable(self):
-        cm = ContextManager(BudgetConfig(belief_value_limit=50))
-        state = _kernel_state(belief_state={"h": "C" * 120})
+    def test_tool_output_renders_whole(self, big_cm):
+        state = _kernel_state()
+        state.add_tool_result("read_file", {"path": "/x"}, "D" * 1500)
+        rendered = big_cm.build_context(state)
+        assert "D" * 1500 in rendered
+        assert "truncated" not in rendered
+
+
+class TestPressureTiers:
+    """Under pressure whole blocks stop being inlined, and the agent is told (#154)."""
+
+    def _crowded_state(self):
+        state = _kernel_state(
+            context={"previous_step_results": {"step_a": {"output": "Z" * 20000}}},
+            belief_state={"hypothesis": "B" * 2000},
+            internal_variables={"scratch_detail": "S" * 20000},
+        )
+        return state
+
+    def test_low_priority_blocks_are_evicted_before_high(self):
+        cm = ContextManager(BudgetConfig(total_tokens=3000))
+        rendered = cm.build_context(self._crowded_state())
+        assert "## MISSION" in rendered
+        assert "## INTERNAL STATE" not in rendered
+
+    def test_evicted_prior_steps_become_retrievable_references(self):
+        cm = ContextManager(BudgetConfig(total_tokens=1200))
+        rendered = cm.build_context(self._crowded_state())
+        assert "## PRIOR STEP REFERENCES" in rendered
+        assert "`step_output:wf:step_a`" in rendered
+        assert "Z" * 20000 not in rendered
+
+    def test_pressure_is_visible_to_the_agent_and_recorded(self):
+        cm = ContextManager(BudgetConfig(total_tokens=1200))
+        state = self._crowded_state()
         rendered = cm.build_context(state)
-        assert "…[truncated: showing 50 of 120 chars]" in rendered
+        assert "## CONTEXT PRESSURE" in rendered
+        assert "Nothing was truncated" in rendered
+        assert state.internal_variables["context_pressure"]["tier"] != "normal"
+        assert state.internal_variables["context_pressure"]["evicted"]
+
+    def test_a_comfortable_budget_shows_no_pressure(self, big_cm):
+        state = _kernel_state(context={"note": "small"})
+        rendered = big_cm.build_context(state)
+        assert "## CONTEXT PRESSURE" not in rendered
 
 
-class TestKeyOverflowNotices:
-    """Past the key cap, hidden keys are announced by name — recency wins (#56)."""
+class TestEveryKeyRenders:
+    """Keys are dropped whole under pressure, never silently capped (#154)."""
 
-    def test_overflow_names_the_hidden_keys(self, big_cm):
+    def test_all_belief_keys_render(self, big_cm):
         beliefs = {f"belief_{i:02d}": f"value {i}" for i in range(14)}
         rendered = big_cm.build_context(_kernel_state(belief_state=beliefs))
-        assert "…and 4 earlier key(s) not shown" in rendered
-        for hidden in ["belief_00", "belief_01", "belief_02", "belief_03"]:
-            assert f"`{hidden}`" in rendered
+        for i in range(14):
+            assert f"- `belief_{i:02d}`: value {i}" in rendered
 
-    def test_most_recent_keys_survive(self, big_cm):
-        beliefs = {f"belief_{i:02d}": f"value {i}" for i in range(14)}
-        rendered = big_cm.build_context(_kernel_state(belief_state=beliefs))
-        # Newest key renders with its value; oldest only in the overflow notice
-        assert "- `belief_13`: value 13" in rendered
-        assert "- `belief_00`:" not in rendered
+    def test_all_input_context_keys_render(self, big_cm):
+        ctx = {f"key_{i:02d}": f"val {i}" for i in range(13)}
+        rendered = big_cm.build_context(_kernel_state(context=ctx))
+        for i in range(13):
+            assert f"- `key_{i:02d}`: val {i}" in rendered
 
-    def test_at_or_under_cap_renders_identically_with_no_notice(self, big_cm):
-        beliefs = {f"b{i}": "v" for i in range(10)}
-        rendered = big_cm.build_context(_kernel_state(belief_state=beliefs))
-        assert "not shown" not in rendered
-
-    def test_internal_variable_skip_keys_do_not_consume_the_cap(self, big_cm):
-        # 4 dedicated/underscore keys + 10 real ones: all 10 real keys must render
+    def test_internal_variable_skip_keys_are_still_skipped(self, big_cm):
         vars_ = {"long_term_memory": [], "research_findings": [], "_private": 1, "api_specs": []}
         vars_.update({f"var_{i}": f"value {i}" for i in range(10)})
         rendered = big_cm.build_context(_kernel_state(internal_variables=vars_))
         for i in range(10):
             assert f"- `var_{i}`: value {i}" in rendered
-        assert "not shown" not in rendered
-
-    def test_input_context_overflow_named(self, big_cm):
-        ctx = {f"key_{i:02d}": f"val {i}" for i in range(13)}
-        rendered = big_cm.build_context(_kernel_state(context=ctx))
-        assert "…and 3 earlier key(s) not shown" in rendered
-
-
-class TestToolHistoryMarkers:
-    """The tool-history window uses the same honest markers."""
-
-    def test_history_output_truncation_is_marked(self, big_cm):
-        state = _kernel_state()
-        state.add_tool_result("read_file", {"path": "/x"}, "D" * 1500)
-        rendered = big_cm.build_context(state)
-        assert "…[truncated: showing 600 of" in rendered
+        assert "`_private`" not in rendered
 
 
 # ======================================================================
@@ -536,13 +539,13 @@ class TestLtmRenderOverflow:
         state = _kernel_state()
         state.internal_variables["long_term_memory"] = [_ltm_entry(i) for i in range(9)]
         rendered = big_cm.build_context(state)
-        assert "…and 4 older memories not shown" in rendered
+        assert "…and 4 older memories held in long-term memory" in rendered
 
     def test_no_notice_at_or_under_render_limit(self, big_cm):
         state = _kernel_state()
         state.internal_variables["long_term_memory"] = [_ltm_entry(i) for i in range(5)]
         rendered = big_cm.build_context(state)
-        assert "older memories not shown" not in rendered
+        assert "older memories held" not in rendered
 
 
 # ======================================================================
@@ -598,18 +601,21 @@ class TestGoalStateBlock:
         rendered = big_cm.build_context(_kernel_state(context={"plain": "ctx"}))
         assert "## GOAL STATE" not in rendered
 
-    def test_fact_overflow_is_announced_by_name(self, big_cm):
+    def test_every_fact_renders(self, big_cm):
         ctx = _goal_context(n_facts=25)
         rendered = big_cm.build_context(_kernel_state(context=ctx))
-        assert "earlier key(s) not shown" in rendered
+        for i in range(25):
+            assert f"- `fact_{i}`" in rendered
 
-    def test_step_overflow_is_announced(self, big_cm):
+    def test_every_completed_step_renders(self, big_cm):
         ctx = _goal_context(n_steps=12)
         rendered = big_cm.build_context(_kernel_state(context=ctx))
-        assert "…and 4 earlier steps not shown" in rendered
+        assert "- [pass] `step_00`: did thing 0" in rendered
+        assert "- [pass] `step_11`: did thing 11" in rendered
 
-    def test_long_fact_values_carry_markers(self, big_cm):
+    def test_long_fact_values_render_whole(self, big_cm):
         ctx = _goal_context()
         ctx["_goal_facts"]["huge"] = "H" * 900
         rendered = big_cm.build_context(_kernel_state(context=ctx))
-        assert "…[truncated: showing 200 of 900 chars]" in rendered
+        assert "H" * 900 in rendered
+        assert "truncated" not in rendered

--- a/tests/test_epistemic_reasoning.py
+++ b/tests/test_epistemic_reasoning.py
@@ -101,10 +101,9 @@ class TestKnowledgeAccumulator:
             internal_section = context[internal_idx:internal_idx + 500]
             assert "some_other_var" in internal_section
 
-    def test_knowledge_accumulator_budget_cap(self):
-        """Knowledge Accumulator should be capped at 4000 tokens."""
+    def test_knowledge_accumulator_keeps_every_item(self):
+        """Findings are evicted as a block under pressure, never silently trimmed (#154)."""
         state = _make_state()
-        # Create a very large set of findings
         state.internal_variables["research_findings"] = [
             {"summary": f"Finding {i}: " + "x" * 200} for i in range(50)
         ]
@@ -112,14 +111,14 @@ class TestKnowledgeAccumulator:
             {"method": "GET", "path": f"/v1/resource_{i}", "summary": f"Resource {i}"} for i in range(50)
         ]
 
-        cm = ContextManager()
-        context = cm.build_context(state)
+        context = ContextManager().build_context(state)
 
-        # Block should exist but be bounded (not explode the context)
         assert "WHAT I KNOW SO FAR" in context
-        # Only last 8 specs and last 5 findings should be shown
+        # The oldest discovery is as retrievable as the newest.
         assert "resource_49" in context
-        assert "resource_0" not in context  # Too old, should be trimmed
+        assert "resource_0" in context
+        assert "Finding 0:" in context
+        assert "truncated" not in context
 
 
 # ──────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
Closes #154.

## What was wrong

The context manager kept a turn inside its budget by cutting inside values — 22 `_clip()` sites bounded by `context_value_limit=800`, `history_value_limit=600`, `memory_item_limit=200`, `belief_value_limit=200`, `internal_var_limit=200`, `prior_step_value_limit=2000`, plus a mid-block cut in `_add_block`.

#55/#56/#57 made those cuts honest and added `read_turn_result`. #98 proposed making the numbers configurable. Both improve the wrong primitive: a character limit decides what an agent may know by counting bytes. A 900-character API response and a 900-character log line are cut identically, and a JSON payload cut at 800 characters is not a smaller payload — it is an invalid one. Agents then re-fetch what is sitting clipped in their own history.

## The design

Blocks are composed once at full fidelity, then the least aggressive tier that fits the budget is chosen. Nothing is ever cut.

| Tier | Effect |
|---|---|
| `NORMAL` | everything renders |
| `COMPRESS` | oldest history summarises into long-term memory (a derived artifact; the original stays in its store) |
| `EVICT_P3` | internal variables stop being inlined |
| `EVICT_P2` | input context, long-term memory and tool history stop being inlined; prior step outputs become references |
| `RECOVERY` | mission and goal state only, plus a notice |

Priorities: **P0** mission, goal state, the notice itself — never evicted. **P1** failure memory, findings, beliefs, working memory. **P2** input context, long-term memory, tool history. **P3** internal variables.

**References instead of fragments.** A prior step that cannot be inlined renders as `step_output:{workflow_id}:{step_id}`, and withheld tool history points at `read_turn_result`. The agent retrieves a whole artifact instead of reasoning from the first 2000 characters of one. This generalises the escape hatch the observation channel already proved.

**Whole keys, never partial values.** Input context degrades by dropping named bulk keys, while task, objective, `human_response`, `step_id`, `workflow_id`, `system` and `provider` survive every tier.

**Pressure is visible.** The tier, what was withheld, and the measured cost are rendered into the prompt and recorded in `internal_variables["context_pressure"]`, so the agent knows it is holding references — and the condition is observable in traces instead of inferred from odd behaviour.

## Compatibility

The per-value character limits remain on `BudgetConfig` so existing configuration keeps importing, and are documented as no longer affecting rendering. `total_tokens` still scales from the lease profile. The dead `_clip` and `_visible_items` helpers are removed.

## Tests

Rewritten to the new contract:

- long prior step outputs, belief values, tool outputs and goal facts render whole, with no truncation marker anywhere
- low-priority blocks are evicted before high-priority ones under a tight budget
- evicted prior steps become retrievable references naming the store key
- pressure is visible in the prompt and recorded in state; a comfortable budget shows none
- every belief and input-context key renders; skip keys are still skipped
- the knowledge accumulator keeps its oldest discovery as well as its newest

Full suite: **1466 passed, 38 failed** — the same 38 failures as `main` on this machine (P2P and fanout suites needing extras). Failure sets diffed identical, so no regression.

## Follow-up, not included

`planning/planner.py` and `planning/evaluator.py` clip their own prompts the same way. They have no pressure ladder yet, so removing those caps without one risks hard provider failures; extending the ladder to them is separate work.
