### PR TITLE
feat(search): configurable per-provider deadlines with named failures

### DIFF
--- a/jarviscore/core/search_deadlines.py
+++ b/jarviscore/core/search_deadlines.py
@@ -1,0 +1,16 @@
+"""Shared deadline configuration for the two public InternetSearch clients."""
+
+import math
+import os
+
+
+def search_deadline(value: float | None, env_name: str, default: float) -> float:
+    """Resolve constructor override before environment; reject unbounded waits."""
+    raw = value if value is not None else os.environ.get(env_name, default)
+    try:
+        resolved = float(raw)
+    except (TypeError, ValueError):
+        raise ValueError(f"{env_name} must be a positive finite number of seconds") from None
+    if isinstance(raw, bool) or not math.isfinite(resolved) or resolved <= 0:
+        raise ValueError(f"{env_name} must be a positive finite number of seconds")
+    return resolved

--- a/jarviscore/docs/reference/configuration.md
+++ b/jarviscore/docs/reference/configuration.md
@@ -183,6 +183,21 @@ AZURE_STORAGE_CONNECTION_STRING=DefaultEndpointsProtocol=https;AccountName=...
 
 ## Search
 
+### Provider deadlines
+
+| Variable | Default | Description |
+|---|---|---|
+| `RESEARCH_GROUNDED_TIMEOUT_SECONDS` | `45` | Per-call deadline for Google Grounded (generative search) |
+| `RESEARCH_SEARCH_TIMEOUT_SECONDS` | `15` | Per-call deadline for each other search provider |
+
+Both `InternetSearch` implementations accept `grounded_timeout_seconds` and
+`search_timeout_seconds` keyword arguments, which take precedence over these
+environment variables. Values must be positive finite seconds. For example,
+`InternetSearch(grounded_timeout_seconds=60, search_timeout_seconds=20)`.
+These deadlines bound each provider including its retries; existing HTTP-request
+timeouts still apply. They do not change agent leases or the overall task budget.
+Timeout diagnostics identify the provider, exception type and configured deadline.
+
 JarvisCore runs multiple search providers in parallel and merges results. All providers have circuit breakers: a failing provider is skipped automatically. See the [Internet Search guide](../guides/internet-search.md) for provider details, ranking logic, and usage patterns.
 
 ### Google Grounded Search <span class="jc-badge jc-badge-primary">Primary</span>

--- a/jarviscore/execution/search.py
+++ b/jarviscore/execution/search.py
@@ -8,7 +8,7 @@ Provider hierarchy (by relevance weight):
   4. Wikipedia REST API                 (weight 0.6) — academic fallback
 
 All providers run in parallel (asyncio.gather) with per-provider circuit breakers
-and 6-second timeouts so a slow provider never blocks the others.
+and configurable deadlines (45s grounded, 15s other providers by default).
 
 Required env vars (Gemini grounded — primary):
   GEMINI_API_KEY            or GEMINI_GROUNDING_API_KEY   (API key mode)
@@ -28,6 +28,8 @@ from typing import Any, Dict, List, Optional
 from urllib.parse import quote_plus, urlparse
 
 import aiohttp
+
+from jarviscore.core.search_deadlines import search_deadline
 
 logger = logging.getLogger(__name__)
 
@@ -99,8 +101,20 @@ class InternetSearch:
         content = await search.extract_content(results[0]["url"])
     """
 
-    def __init__(self, user_agent: Optional[str] = None):
+    def __init__(
+        self,
+        user_agent: Optional[str] = None,
+        *,
+        search_timeout_seconds: float | None = None,
+        grounded_timeout_seconds: float | None = None,
+    ):
         self.session: Optional[aiohttp.ClientSession] = None
+        self.search_timeout_seconds = search_deadline(
+            search_timeout_seconds, "RESEARCH_SEARCH_TIMEOUT_SECONDS", 15.0,
+        )
+        self.grounded_timeout_seconds = search_deadline(
+            grounded_timeout_seconds, "RESEARCH_GROUNDED_TIMEOUT_SECONDS", 45.0,
+        )
         self.user_agent = user_agent or (
             "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
             "AppleWebKit/537.36 (KHTML, like Gecko) "
@@ -193,35 +207,46 @@ class InternetSearch:
         skip = set(exclude_providers or ())
 
         provider_tasks = []
+        providers = []
 
         # 1. Gemini Grounded (primary — highest weight)
         if "google_grounded" not in skip and (self._gcp_project or self._gemini_api_key):
+            providers.append("google_grounded")
             provider_tasks.append(
                 self._search_google_grounded(query, max_results=max_results)
             )
 
         # 2. Serper (secondary)
         if self.serper_api_key and "serper" not in skip:
+            providers.append("serper")
             provider_tasks.append(self._search_serper(query, max_results=max_results))
 
         # 3. SearXNG (free metasearch fallback)
         if "searxng" not in skip:
+            providers.append("searxng")
             provider_tasks.append(self._search_searxng(query, max_results=max_results))
 
         # 4. Wikipedia (academic fallback)
         if "wikipedia" not in skip:
+            providers.append("wikipedia")
             provider_tasks.append(self._search_wikipedia(query, max_results=max_results))
 
-        # Run all providers in parallel — 6s timeout per provider
+        # Preserve parallel scheduling with a separate budget for generative grounding.
         provider_results = await asyncio.gather(
-            *(asyncio.wait_for(t, timeout=6) for t in provider_tasks),
+            *(
+                asyncio.wait_for(task, timeout=self._provider_timeout(provider))
+                for provider, task in zip(providers, provider_tasks)
+            ),
             return_exceptions=True,
         )
 
         results: List[Dict[str, Any]] = []
-        for batch in provider_results:
+        for provider, batch in zip(providers, provider_results):
             if isinstance(batch, Exception):
-                logger.warning("Search provider failed: %s", batch)
+                logger.warning(
+                    "Search provider=%s failed error_type=%s deadline_seconds=%s",
+                    provider, type(batch).__name__, self._provider_timeout(provider),
+                )
                 continue
             if isinstance(batch, list):
                 results.extend(batch)
@@ -229,6 +254,12 @@ class InternetSearch:
         ranked = self._rank_results(query, results)
         logger.info("Search '%s': %d results from %d providers", query, len(ranked), len(provider_tasks))
         return ranked[:max_results]
+
+    def _provider_timeout(self, provider: str) -> float:
+        return (
+            self.grounded_timeout_seconds if provider == "google_grounded"
+            else self.search_timeout_seconds
+        )
 
     # ──────────────────────────────────────────────────────────────────────
     # Provider: Google Grounded Search (Gemini)

--- a/jarviscore/search/internet_search.py
+++ b/jarviscore/search/internet_search.py
@@ -17,6 +17,8 @@ from io import BytesIO
 from typing import Dict, Any, List, Optional, Tuple
 from urllib.parse import quote_plus, urlparse, urljoin
 
+from jarviscore.core.search_deadlines import search_deadline
+
 # beautifulsoup4 — required for HTML→Markdown extraction.
 # Part of [web] or [research] extras.
 try:
@@ -91,8 +93,17 @@ class InternetSearch:
         user_agent: Optional[str] = None,
         pdf_timeout_seconds: Optional[int] = None,
         pdf_max_retries: Optional[int] = None,
+        *,
+        search_timeout_seconds: float | None = None,
+        grounded_timeout_seconds: float | None = None,
     ):
         self.session = None
+        self.search_timeout_seconds = search_deadline(
+            search_timeout_seconds, "RESEARCH_SEARCH_TIMEOUT_SECONDS", 15.0,
+        )
+        self.grounded_timeout_seconds = search_deadline(
+            grounded_timeout_seconds, "RESEARCH_GROUNDED_TIMEOUT_SECONDS", 45.0,
+        )
         self.user_agent = user_agent or "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36"
         self.pdf_timeout_seconds = pdf_timeout_seconds or int(
             os.environ.get("RESEARCH_PDF_TIMEOUT_SECONDS", "90")
@@ -197,16 +208,19 @@ class InternetSearch:
                 *(
                     asyncio.wait_for(
                         self._run_search_provider(provider, query, max_results),
-                        timeout=6,
+                        timeout=self._provider_timeout(provider),
                     )
                     for provider in providers
                 ),
                 return_exceptions=True,
             )
             results: List[Dict[str, Any]] = []
-            for batch in provider_results:
+            for provider, batch in zip(providers, provider_results):
                 if isinstance(batch, Exception):
-                    logger.warning("Search provider failed in tier %s: %s", tier_name, batch)
+                    logger.warning(
+                        "Search provider=%s tier=%s failed error_type=%s deadline_seconds=%s",
+                        provider, tier_name, type(batch).__name__, self._provider_timeout(provider),
+                    )
                     continue
                 if isinstance(batch, list):
                     results.extend(batch)
@@ -214,6 +228,12 @@ class InternetSearch:
             if ranked:
                 return ranked[:max_results]
         return []
+
+    def _provider_timeout(self, provider: str) -> float:
+        return (
+            self.grounded_timeout_seconds if provider == "google_grounded"
+            else self.search_timeout_seconds
+        )
 
     def _provider_tiers(self, skip: set) -> List[Tuple[str, List[str]]]:
         """Return ordered provider tiers from authoritative to fallback."""

--- a/tests/test_search_deadlines.py
+++ b/tests/test_search_deadlines.py
@@ -1,0 +1,134 @@
+"""Offline deadline contracts for both public search implementations (#147)."""
+
+import asyncio
+import logging
+from unittest.mock import AsyncMock
+
+import pytest
+
+from jarviscore.execution.search import InternetSearch as ExecutionSearch
+from jarviscore.search.internet_search import InternetSearch
+
+
+@pytest.fixture(params=[InternetSearch, ExecutionSearch])
+def search_class(request, monkeypatch):
+    for key in (
+        "GOOGLE_CLOUD_PROJECT", "GEMINI_API_KEY", "GEMINI_GROUNDING_API_KEY",
+        "GOOGLE_GENAI_API_KEY", "SERPER_API_KEY", "RESEARCH_SEARCH_TIMEOUT_SECONDS",
+        "RESEARCH_GROUNDED_TIMEOUT_SECONDS", "RESEARCH_ALLOW_WIKIPEDIA_FALLBACK",
+    ):
+        monkeypatch.delenv(key, raising=False)
+    return request.param
+
+
+def result(provider):
+    return [{"title": "Example", "url": "https://example.org", "source": provider}]
+
+
+@pytest.mark.parametrize("duration", [6.47, 7.86])
+async def test_grounded_duration_is_not_cancelled_at_six_seconds(search_class, monkeypatch, duration):
+    search = search_class()
+    search.initialize = AsyncMock()
+    search._gemini_api_key = "offline-test"
+    search._search_google_grounded = AsyncMock(return_value=result("google_grounded"))
+    deadlines = []
+
+    async def virtual_wait_for(coro, timeout):
+        deadlines.append(timeout)
+        if duration > timeout:
+            coro.close()
+            raise TimeoutError()
+        return await coro
+
+    monkeypatch.setattr(asyncio, "wait_for", virtual_wait_for)
+    rows = await search.search("example", exclude_providers={
+        "searxng", "serper", "wikipedia", "arxiv", "crossref",
+    })
+    assert rows[0]["source"] == "google_grounded"
+    assert deadlines == [45.0]
+
+
+async def test_deadline_environment_and_constructor_override(search_class, monkeypatch):
+    monkeypatch.setenv("RESEARCH_SEARCH_TIMEOUT_SECONDS", "23.5")
+    monkeypatch.setenv("RESEARCH_GROUNDED_TIMEOUT_SECONDS", "61")
+    search = search_class()
+    assert search.search_timeout_seconds == 23.5
+    assert search.grounded_timeout_seconds == 61
+    search = search_class(search_timeout_seconds=12, grounded_timeout_seconds=32)
+    assert search.search_timeout_seconds == 12
+    assert search.grounded_timeout_seconds == 32
+    monkeypatch.delenv("RESEARCH_SEARCH_TIMEOUT_SECONDS")
+    assert search_class().search_timeout_seconds == 15
+
+
+@pytest.mark.parametrize("value", [0, -1, float("nan"), float("inf"), True, "bad"])
+@pytest.mark.parametrize("name", ["search_timeout_seconds", "grounded_timeout_seconds"])
+def test_invalid_deadlines_fail_at_construction(search_class, name, value):
+    with pytest.raises(ValueError, match="positive finite"):
+        search_class(**{name: value})
+
+
+def test_invalid_environment_deadline(search_class, monkeypatch):
+    monkeypatch.setenv("RESEARCH_GROUNDED_TIMEOUT_SECONDS", "nan")
+    with pytest.raises(ValueError, match="RESEARCH_GROUNDED_TIMEOUT_SECONDS"):
+        search_class()
+
+
+async def test_timeout_cancels_provider_preserves_other_results_and_logs_type(search_class, caplog):
+    search = search_class(search_timeout_seconds=0.01, grounded_timeout_seconds=0.01)
+    search.initialize = AsyncMock()
+    search._gemini_api_key = "offline-test"
+    cancelled = asyncio.Event()
+
+    async def blocked(*args, **kwargs):
+        try:
+            await asyncio.Event().wait()
+        finally:
+            cancelled.set()
+
+    search._search_google_grounded = blocked
+    search._search_searxng = AsyncMock(return_value=result("searxng"))
+    with caplog.at_level(logging.WARNING):
+        rows = await search.search("private query", exclude_providers={"wikipedia", "arxiv", "crossref"})
+    assert rows[0]["source"] == "searxng"
+    assert cancelled.is_set()
+    assert "provider=google_grounded" in caplog.text
+    assert "TimeoutError" in caplog.text
+    assert "0.01" in caplog.text
+    assert "private query" not in caplog.text
+
+
+async def test_exception_type_and_provider_are_logged(search_class, caplog):
+    search = search_class()
+    search.initialize = AsyncMock()
+    search._search_searxng = AsyncMock(side_effect=LookupError())
+    with caplog.at_level(logging.WARNING):
+        assert await search.search("example", exclude_providers={
+            "google_grounded", "wikipedia", "arxiv", "crossref",
+        }) == []
+    assert "provider=searxng" in caplog.text
+    assert "LookupError" in caplog.text
+
+
+async def test_caller_cancellation_is_not_swallowed(search_class):
+    search = search_class()
+    search.initialize = AsyncMock()
+    started = asyncio.Event()
+    cancelled = asyncio.Event()
+
+    async def blocked(*args, **kwargs):
+        started.set()
+        try:
+            await asyncio.Event().wait()
+        finally:
+            cancelled.set()
+
+    search._search_searxng = blocked
+    task = asyncio.create_task(search.search("example", exclude_providers={
+        "google_grounded", "wikipedia", "arxiv", "crossref",
+    }))
+    await started.wait()
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    assert cancelled.is_set()


### PR DESCRIPTION
Search wrapped every provider in `asyncio.wait_for(task, timeout=6)`. Gemini grounded search performs a *generative* call and routinely needs longer than that, so healthy requests were cancelled mid-flight and the run quietly lost its highest-weight provider. The evidence that came back was assembled from the fallbacks — a quality change the caller never sees.

The failure was also anonymous. `asyncio.gather` returned exceptions positionally and the handler logged `Search provider failed: %s`, so a provider that times out on every call looked exactly like a transient error.

## What changed

Deadlines resolve per provider — **45s** for `google_grounded`, **15s** for the rest — each overridable by constructor argument or environment (`RESEARCH_GROUNDED_TIMEOUT_SECONDS`, `RESEARCH_SEARCH_TIMEOUT_SECONDS`). Providers are now tracked alongside their tasks, so a failure logs which provider, the error type, and the deadline it exceeded:

```
Search provider=serper failed error_type=TimeoutError deadline_seconds=15.0
```

Parallel scheduling is unchanged — still one `asyncio.gather`, still no provider blocking another. Only the budget differs per provider.

`search_deadline()` rejects zero, negative, non-finite, boolean and non-numeric values instead of resolving them to an unbounded wait. A deadline that never fires is worse than one that is too short: the caller waits forever with no signal at all.

The helper lives in `jarviscore/core/search_deadlines.py` and is shared by `jarviscore.execution.search` and `jarviscore.search.internet_search`, so the two public clients cannot drift apart on the same contract.

## Verification

`tests/test_search_deadlines.py` — **38 passed**, parametrised across both public clients. Covers constructor-over-env precedence, every rejected value shape, per-provider budget selection, and that a failing provider is named in the log.

Fully offline; no provider is contacted.

Closes #147
