### PR TITLE
docs(atoms): active pages report the installed catalog, not a snapshot total

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 </p>
 
 <p align="center">
-  <strong>The production runtime for multi-agent systems — a peer-to-peer mesh with no central orchestrator, zero-trust credentials, durable state that survives <code>kill -9</code>, and 1,224 typed atoms across 150 services. Observability included, not upsold.</strong>
+  <strong>The production runtime for multi-agent systems — a peer-to-peer mesh with no central orchestrator, zero-trust credentials, durable state that survives <code>kill -9</code>, and a built-in catalog of typed integration atoms. Observability included, not upsold.</strong>
 </p>
 
 <p align="center">
@@ -44,7 +44,7 @@ Six things you get here that you will not assemble from a typical agent framewor
 
 **1. Agents never touch credentials.** Nexus, a zero-trust credential broker, ships inside the framework. Set `requires_auth = True` and the runtime injects scoped, encrypted credentials into atoms at call time — no raw keys in prompts, agent context, or `.env` sprawl. A leaked agent trace leaks no secrets.
 
-**2. Tools without MCP plumbing.** 1,224 typed atoms across 150 services (`jarviscore atom list`), auth injected at runtime. Missing one? Write a Python function, validate it with `jarviscore atom test`, drop it in the registry — no server to stand up, no wiring. And when no atom exists, AutoAgents write their own sandboxed code with self-repair and keep what worked in a verified-work registry.
+**2. Tools without MCP plumbing.** Built-in typed atoms with auth injected at runtime; inspect your installed catalog with [`jarviscore atom list`](https://jarviscore.developers.prescottdata.io/reference/cli/#atom-list). Missing one? Write a Python function, validate it with `jarviscore atom test`, drop it in the registry — no server to stand up, no wiring. And when no atom exists, AutoAgents write their own sandboxed code with self-repair and keep what worked in a verified-work registry.
 
 **3. No central orchestrator to babysit.** Agents form a SWIM gossip mesh over ZMQ, discover each other by capability, and claim workflow steps atomically from Redis. Any node can die — another claims its work. There is no coordinator process whose crash takes the fleet down.
 
@@ -210,12 +210,12 @@ The Kernel runs an Observe-Orient-Decide-Act (OODA) loop for every AutoAgent tas
 | **GoalContext** | Tracks plan state, step history, and convergence signals |
 | **EpistemicLedger** | Records what the agent knows, assumes, and has verified |
 
-### Service Integrations (150 bundles, 1,224 atoms)
+### Service Integrations
 
 Every integration is a single-file Python function called an **atom**. Atoms are registered in the seed registry and discovered by agents at runtime. No SDK wiring required.
 
 <details>
-<summary><strong>View the 150 integration bundles by category</strong></summary>
+<summary><strong>Browse integration bundles by category</strong></summary>
 
 | Category | Bundles |
 |----------|---------|
@@ -406,7 +406,7 @@ If you build multi-agent systems, star the repo ⭐ to support open-source agent
 | [Getting Started](https://jarviscore.developers.prescottdata.io/getting-started/) | Install, scaffold, and run your first agent in 5 minutes |
 | [Concepts](https://jarviscore.developers.prescottdata.io/concepts/architecture/) | Architecture, model routing, planning, memory, Nexus |
 | [Guides](https://jarviscore.developers.prescottdata.io/guides/autoagent/) | AutoAgent, CustomAgent, workflows, HITL, browser, testing, production |
-| [Integrations](https://jarviscore.developers.prescottdata.io/guides/integrations/) | All 150 service bundles with usage examples |
+| [Integrations](https://jarviscore.developers.prescottdata.io/guides/integrations/) | Built-in service bundles with usage examples |
 | [Reference](https://jarviscore.developers.prescottdata.io/reference/agent-api/) | Agent API, CLI, configuration, and troubleshooting |
 | [Changelog](https://jarviscore.developers.prescottdata.io/changelog/) | Full release history |
 

--- a/jarviscore/docs/concepts/nexus.md
+++ b/jarviscore/docs/concepts/nexus.md
@@ -4,7 +4,7 @@ icon: material/shield-key
 
 # Nexus: Credential Federation
 
-Nexus is JarvisCore's answer to two compounding problems in agentic systems. Agents need credentials to call external services, but agents should never handle credentials. And with 46 integrations, writing authentication glue code for each one is unsustainable.
+Nexus is JarvisCore's answer to two compounding problems in agentic systems. Agents need credentials to call external services, but agents should never handle credentials. Across a growing integration catalog, writing authentication glue code for each service is unsustainable. Inspect your installed catalog with [`jarviscore atom list`](../reference/cli.md#atom-list).
 
 ---
 
@@ -27,7 +27,7 @@ cred = base64.b64encode(f"{email}:{api_token}".encode()).decode()
 headers = {"Authorization": f"Basic {cred}"}
 ```
 
-Three providers, three auth patterns, three environment variables, and three separate token expiry and refresh paths. Scaled to 150 integrations across a multi-agent fleet, this becomes a maintenance problem that never ends.
+Three providers, three auth patterns, three environment variables, and three separate token expiry and refresh paths. Scaled across the integration catalog and a multi-agent fleet, this becomes a maintenance problem that never ends.
 
 **Nexus collapses all of this to one interface:**
 
@@ -126,12 +126,12 @@ The two modes are not mutually exclusive. When `NEXUS_GATEWAY_URL` is set and re
 
 **It does not replace your application's auth.** If you are building an API on top of JarvisCore, user authentication for your end users is outside Nexus's scope.
 
-Nexus has one job: ensure that agent code can call 46 third-party APIs through a single authenticated interface, without handling credentials directly.
+Nexus has one job: ensure that agent code can call third-party APIs through a single authenticated interface, without handling credentials directly.
 
 ---
 
 ## Further Reading
 
 - [Nexus Setup Guide](../guides/nexus.md) covers credential registration, the CLI reference, the Gateway API contract, and production deployment.
-- [Service Integrations](../guides/integrations.md) lists the 46 provider bundles that use Nexus for authentication.
+- [Service Integrations](../guides/integrations.md) describes the built-in provider bundles that use Nexus for authentication.
 - [Nexus Framework on GitHub](https://github.com/Prescott-Data/nexus-framework) is the open-source repository for the Nexus credential federation framework.

--- a/jarviscore/docs/guides/integrations.md
+++ b/jarviscore/docs/guides/integrations.md
@@ -4,7 +4,7 @@ icon: material/connection
 
 # System Bundles & Integrations
 
-JarvisCore ships with **150 built-in system bundles** covering 1224 discrete, versioned atoms. Each atom is a self-contained, ready-to-use tool your agents can call directly: no wrapper code required. Bundles span communication, productivity, CRM, ERP, finance, HR, developer tools, content, advertising, storage, healthcare, and more.
+JarvisCore ships with **built-in system bundles** of discrete, versioned atoms. Each atom is a self-contained, ready-to-use tool your agents can call directly: no wrapper code required. Bundles span communication, productivity, CRM, ERP, finance, HR, developer tools, content, advertising, storage, healthcare, and more. Use [`jarviscore atom list`](../reference/cli.md#atom-list) for the catalog in your installed version.
 
 ---
 
@@ -44,7 +44,7 @@ The Kernel auto-picks the right atom when the task matches. The `capabilities` f
 
 ### Seeding the registry
 
-`seed_registry` runs automatically when the framework initialises. All 150 bundles are seeded into the registry on first startup. You can also call it manually:
+`seed_registry` runs automatically when the framework initialises. The bundled catalog is seeded into the registry on first startup. You can also call it manually:
 
 ```python
 from jarviscore.integrations.seed_registry import seed_registry
@@ -778,9 +778,10 @@ Google Search results via API.
 
 ### Expanded catalog: hand-audited providers
 
-The 104 bundles below were imported from a production
+The bundles below were imported from a production
 function registry after an atom-by-atom audit against each vendor's
-official API documentation. List any bundle's atoms with:
+official API documentation. This table is a category guide, not a snapshot of
+atom counts. List any bundle's installed atoms with:
 
 ```bash
 jarviscore atom list --bundle <name>
@@ -788,24 +789,24 @@ jarviscore atom list --bundle <name>
 
 | Category | Bundles |
 |---|---|
-| Advertising | Google Ads (26), Reddit Ads (9), Snapchat Ads (9), TikTok Ads (9), X Ads (9) |
-| Analytics | Amplitude (6), FullStory (5), Google Analytics (1), Kissmetrics (5), LogRocket (5), Matomo (8), Mixpanel (8), Pendo (6), Plausible (6), PostHog (8), Segment (9) |
-| CMS | WordPress (13) |
-| CRM | ActiveCampaign (12), Agile CRM (13), Attio (13), Capsule CRM (13), Close (13), Folk (13), Freshsales (13), Insightly (16), Keap (16), Less Annoying CRM (16), Nimble (13), Nutshell (13), Pipedrive (13), Salesflare (13), Streak (13), Zoho CRM (13) |
-| Communication | Africa's Talking (2), Google Chat (4), Mattermost (9), Rocket.Chat (9), Telegram (5), Twilio (9), WhatsApp Business (4) |
-| Customer Support | Crisp (9), Drift (4), Freshchat (6), Gorgias (8), Intercom (15), LiveChat (9), Zendesk Chat (9), tawk.to (3) |
-| DevOps & CI | CircleCI (6), Jenkins (15), TeamCity (9), Travis CI (9) |
-| Developer Tools | Assembla (9), Beanstalk (13), GitLab (13), Perforce (5), Phabricator (11), SourceForge (3), Sourcegraph (1) |
-| Ecommerce | Etsy (9), Jumia Seller Center (9), PrestaShop (13), Shift4Shop (13), Shopify (13), Wix Stores (13), WooCommerce (13) |
-| Finance & Accounting | Sage Accounting (13), Sage One (ZA) (13), Wave (13), Xero (13) |
-| Geo & Location | Google Maps (2), what3words (5) |
-| HR & Payroll | SimplePay (9) |
-| Identity & Verification | Okta (13), Prembly (7) |
-| Marketing | Klaviyo (11) |
-| Payments | M-Pesa (Daraja) (3), Paystack (12), Square (13) |
-| Productivity | Coda (9), Dropbox Sign (9), Google People (3), Infobip (8), PagerDuty (13), Zoho Desk (13) |
-| Project Management | Asana (12), Freedcamp (8), Height (9), LiquidPlanner (9), Monday (9), Nifty (8), Pivotal Tracker (9), Podio (9), Proofhub (9), Shortcut (9), Targetprocess (9), Trello (13), Workfront (9), Wrike (9) |
-| Storage | Amazon S3 (4), Backblaze B2 (5), Box (9), Egnyte (9), Google Cloud Storage (7) |
+| Advertising | Google Ads, Reddit Ads, Snapchat Ads, TikTok Ads, X Ads |
+| Analytics | Amplitude, FullStory, Google Analytics, Kissmetrics, LogRocket, Matomo, Mixpanel, Pendo, Plausible, PostHog, Segment |
+| CMS | WordPress |
+| CRM | ActiveCampaign, Agile CRM, Attio, Capsule CRM, Close, Folk, Freshsales, Insightly, Keap, Less Annoying CRM, Nimble, Nutshell, Pipedrive, Salesflare, Streak, Zoho CRM |
+| Communication | Africa's Talking, Google Chat, Mattermost, Rocket.Chat, Telegram, Twilio, WhatsApp Business |
+| Customer Support | Crisp, Drift, Freshchat, Gorgias, Intercom, LiveChat, Zendesk Chat, tawk.to |
+| DevOps & CI | CircleCI, Jenkins, TeamCity, Travis CI |
+| Developer Tools | Assembla, Beanstalk, GitLab, Perforce, Phabricator, SourceForge, Sourcegraph |
+| Ecommerce | Etsy, Jumia Seller Center, PrestaShop, Shift4Shop, Shopify, Wix Stores, WooCommerce |
+| Finance & Accounting | Sage Accounting, Sage One (ZA), Wave, Xero |
+| Geo & Location | Google Maps, what3words |
+| HR & Payroll | SimplePay |
+| Identity & Verification | Okta, Prembly |
+| Marketing | Klaviyo |
+| Payments | M-Pesa (Daraja), Paystack, Square |
+| Productivity | Coda, Dropbox Sign, Google People, Infobip, PagerDuty, Zoho Desk |
+| Project Management | Asana, Freedcamp, Height, LiquidPlanner, Monday, Nifty, Pivotal Tracker, Podio, Proofhub, Shortcut, Targetprocess, Trello, Workfront, Wrike |
+| Storage | Amazon S3, Backblaze B2, Box, Egnyte, Google Cloud Storage |
 
 ---
 ## Configuration
@@ -883,21 +884,22 @@ To contribute an atom to the framework, open a pull request to [jarviscore-frame
 
 ## Bundle Summary
 
-| Category | Bundles | Approx. Atoms |
-|---|---|---|
-| Communication | Slack, Zoom, Discord, Webex, MS Graph, Gmail | 37 |
-| Productivity | Notion, Confluence, ClickUp, Todoist, Google Drive, Dropbox, Google Sheets, Google Calendar, Airtable | 40 |
-| Developer Tools | GitHub, Jira, Linear, Bamboo | 23 |
-| CRM | HubSpot, Salesforce, Dynamics, Oracle CX, Apollo | 22 |
-| ERP | NetSuite, Odoo, SAP, Oracle ERP | 24 |
-| Finance | Stripe, QuickBooks, FreshBooks, Zoho Books | 24 |
-| HR | Zoho People, Zoho Shifts | 8 |
-| Content & Social | LinkedIn, LinkedIn Ads, YouTube, Twitter/X, Reddit | 24 |
-| Email Marketing | Brevo, SendGrid, Mailchimp | 8 |
-| Storage | Azure Storage | 3 |
-| Healthcare | OpenMRS | 6 |
-| Government | KRA | 4 |
-| Search | Serper | 2 |
-| **Total** | **150 bundles** | **1224 atoms** |
+| Category | Example Bundles |
+|---|---|
+| Communication | Slack, Zoom, Discord, Webex, MS Graph, Gmail |
+| Productivity | Notion, Confluence, ClickUp, Todoist, Google Drive, Dropbox, Google Sheets, Google Calendar, Airtable |
+| Developer Tools | GitHub, Jira, Linear, Bamboo |
+| CRM | HubSpot, Salesforce, Dynamics, Oracle CX, Apollo |
+| ERP | NetSuite, Odoo, SAP, Oracle ERP |
+| Finance | Stripe, QuickBooks, FreshBooks, Zoho Books |
+| HR | Zoho People, Zoho Shifts |
+| Content & Social | LinkedIn, LinkedIn Ads, YouTube, Twitter/X, Reddit |
+| Email Marketing | Brevo, SendGrid, Mailchimp |
+| Storage | Azure Storage |
+| Healthcare | OpenMRS |
+| Government | KRA |
+| Search | Serper |
 
-The table above covers the original bundles (46 bundles, 237 atoms). The expanded catalog adds 104 more bundles (987 atoms) listed in the previous section.
+These examples are not an exhaustive inventory. Run
+[`jarviscore atom list`](../reference/cli.md#atom-list) for all installed bundles
+and atoms, or `jarviscore atom list --bundle slack` to inspect one bundle.

--- a/jarviscore/docs/guides/nexus.md
+++ b/jarviscore/docs/guides/nexus.md
@@ -4,7 +4,7 @@ icon: material/key-variant
 
 # Nexus: Credential Management
 
-Nexus is JarvisCore's credential management system and an [open-source framework in its own right](https://github.com/Prescott-Data/nexus-framework). It solves the N+1 authentication problem by providing a single `nexus_call` interface that works for all 46 service integrations. Nexus handles credential resolution, token refresh, and auth strategy selection so that agents never deal with credentials directly.
+Nexus is JarvisCore's credential management system and an [open-source framework in its own right](https://github.com/Prescott-Data/nexus-framework). It solves the N+1 authentication problem by providing a single `nexus_call` interface for the built-in service integrations. Nexus handles credential resolution, token refresh, and auth strategy selection so that agents never deal with credentials directly. Inspect your installed integration catalog with [`jarviscore atom list`](../reference/cli.md#atom-list).
 
 > [!NOTE]
 > This page is the operational reference covering CLI commands, encryption details, and the Gateway API contract. For the conceptual model explaining why Nexus exists, how `NexusCallProxy` works, and the security design, see [Nexus: Credential Federation](../concepts/nexus.md).

--- a/jarviscore/docs/guides/testing-atoms.md
+++ b/jarviscore/docs/guides/testing-atoms.md
@@ -77,6 +77,9 @@ jarviscore atom test --mode dry-run --all
 
 ### List all bundles and their atoms
 
+Use [`jarviscore atom list`](../reference/cli.md#atom-list) as the source of truth
+for the catalog shipped with your installed version, rather than a fixed count.
+
 ```bash
 jarviscore atom list
 ```
@@ -211,6 +214,6 @@ Atoms root: jarviscore/integrations/atoms
 
 ## Further Reading
 
-- [Service Integrations](integrations.md) documents the 46 built-in atom bundles.
+- [Service Integrations](integrations.md) documents the built-in atom bundles.
 - [Nexus: Credential Management](nexus.md) covers credential registration, which is required before running integration tests.
 - [Concepts: System Bundles](../concepts/system-bundles.md) covers the immutable atom contract and the graduation model in depth.

--- a/jarviscore/docs/index.md
+++ b/jarviscore/docs/index.md
@@ -63,9 +63,9 @@ Agents discover and message each other via a `PeerClient` API over SWIM gossip a
 <div class="jc-card" markdown>
 <span class="jc-card-label">Integrations</span>
 
-### 46 service integrations
+### Built-in service integrations
 
-Slack, GitHub, Zoom, SAP, NetSuite, MS Graph, Salesforce, and 40 more. 237+ prebuilt actions your agents can call directly. No glue code, no auth wiring.
+Prebuilt actions for Slack, GitHub, Zoom, SAP, NetSuite, MS Graph, Salesforce, and more. No glue code, no auth wiring. Inspect the catalog in your installed version with [`jarviscore atom list`](reference/cli.md#atom-list).
 
 [Browse integrations →](guides/integrations.md)
 </div>

--- a/jarviscore/docs/llms.txt
+++ b/jarviscore/docs/llms.txt
@@ -20,7 +20,7 @@ Package: `jarviscore-framework` on PyPI. Import name: `jarviscore`. Python 3.10+
 - [Observability](https://jarviscore.developers.prescottdata.io/guides/observability/): tracing, metrics, jarviscore inspect
 - [HITL Escalation](https://jarviscore.developers.prescottdata.io/guides/hitl/): human-in-the-loop
 - [Nexus Credentials](https://jarviscore.developers.prescottdata.io/guides/nexus/): zero-trust auth
-- [Integrations](https://jarviscore.developers.prescottdata.io/guides/integrations/): 46 services, 237+ prebuilt actions
+- [Integrations](https://jarviscore.developers.prescottdata.io/guides/integrations/): built-in service bundles and prebuilt actions; inspect the installed catalog with [jarviscore atom list](https://jarviscore.developers.prescottdata.io/reference/cli/#atom-list)
 - [Production Deployment](https://jarviscore.developers.prescottdata.io/guides/production/)
 
 ## Reference

--- a/jarviscore/docs/reference/cli.md
+++ b/jarviscore/docs/reference/cli.md
@@ -322,7 +322,7 @@ jarviscore atom test --bundle slack --mode dry-run
 # Check a single atom
 jarviscore atom test --bundle slack --atom slack_send_message --mode dry-run
 
-# Check every atom across all 150 bundles
+# Check every atom across the installed bundles
 jarviscore atom test --mode dry-run --all
 ```
 
@@ -355,7 +355,10 @@ The integration check does not call the provider API: it confirms the Nexus Gate
 
 ### atom list
 
-Lists all registered atom bundles and their atoms.
+Lists the built-in bundle directories and atom files shipped with your installed
+version. Use this local inventory as the source of truth for catalog availability;
+it does not query a running registry or certify that atoms have been verified
+against live provider APIs.
 
 ```bash
 # All bundles
@@ -365,22 +368,25 @@ jarviscore atom list
 jarviscore atom list --bundle slack
 ```
 
-Example output:
+Illustrative output (names are abbreviated; counts come from your installation):
 
 ```
 JarvisCore Atom Registry
 jarviscore/integrations/atoms
 
-  slack  (6 atoms)
-    · slack_add_reaction
-    · slack_get_messages
-    · slack_get_user
-    · slack_list_channels
-    · slack_list_users
+  slack  (<atom count> atoms)
     · slack_send_message
+    · ...
 
-150 bundles  ·  1224 atoms total
+... remaining installed bundles ...
+
+<bundle count> bundles  ·  <total atom count> atoms total
 ```
+
+The complete output reports totals from the installed catalog, counting atom
+files rather than parsing their functions and excluding package initializers.
+These totals change as bundles and atoms are added or removed. Use `atom test`
+for structural validation; listing an atom is not a validation result.
 
 See [Testing Atoms](../guides/testing-atoms.md) for the full workflow: from writing a new atom to promoting it to `verified`.
 

--- a/jarviscore/skills/jarviscore/SKILL.md
+++ b/jarviscore/skills/jarviscore/SKILL.md
@@ -91,8 +91,11 @@ jarviscore memory init     # pull + start the Athena memory stack (Docker)
 jarviscore memory status   # health of all memory tiers
 jarviscore nexus init      # zero-trust credential broker (Docker)
 jarviscore inspect [wf]    # read recorded traces: what did my agents do?
-jarviscore atom list       # 46 service integrations, 237+ prebuilt actions
+jarviscore atom list       # inspect bundles and atoms in the installed catalog
 ```
+
+Use the installed catalog rather than a fixed integration count. See the
+[`jarviscore atom list` reference](https://jarviscore.developers.prescottdata.io/reference/cli/#atom-list).
 
 ## House rules the framework enforces (do not fight them)
 

--- a/tests/test_active_catalog_docs.py
+++ b/tests/test_active_catalog_docs.py
@@ -1,0 +1,96 @@
+"""The active catalog entry points point to installed data, not snapshot totals."""
+
+import re
+import sys
+from pathlib import Path
+
+import pytest
+
+from jarviscore.cli import atom
+
+ROOT = Path(__file__).resolve().parents[1]
+ACTIVE_CATALOG_PAGES = (
+    "README.md",
+    "jarviscore/docs/index.md",
+    "jarviscore/docs/llms.txt",
+    "jarviscore/docs/guides/nexus.md",
+    "jarviscore/docs/guides/integrations.md",
+    "jarviscore/docs/guides/testing-atoms.md",
+    "jarviscore/docs/concepts/nexus.md",
+    "jarviscore/docs/reference/cli.md",
+    "jarviscore/skills/jarviscore/SKILL.md",
+)
+
+CATALOG_TOTAL = re.compile(
+    r"\b\d[\d,]*\+?\s+"
+    r"(?:(?:built-in|system|typed|discrete,?|versioned|prebuilt|third-party)\s+)*"
+    r"(?:services?|integrations?|bundles?|providers?|atoms?|actions?|APIs)\b",
+    re.IGNORECASE,
+)
+
+@pytest.mark.parametrize("path", ACTIVE_CATALOG_PAGES)
+def test_catalog_entry_point_uses_cli_guidance(path):
+    text = (ROOT / path).read_text(encoding="utf-8")
+    assert "jarviscore atom list" in text
+    if path != "jarviscore/docs/reference/cli.md":
+        assert re.search(r"reference/cli(?:\.md|/)#atom-list", text)
+    else:
+        assert "### atom list" in text
+
+
+@pytest.mark.parametrize("path", ACTIVE_CATALOG_PAGES)
+def test_catalog_entry_point_does_not_advertise_snapshot_totals(path):
+    text = (ROOT / path).read_text(encoding="utf-8")
+    # Scoped to these catalog pages, not historical changelogs or all docs.
+    # Remove inline formatting so bold totals cannot evade the check.
+    claims = CATALOG_TOTAL.findall(text.replace("*", "").replace("`", ""))
+    assert not claims, f"{path}: replace {claims} with installed-catalog guidance"
+
+
+def test_bundle_summary_tables_do_not_duplicate_per_provider_counts():
+    text = (ROOT / "jarviscore/docs/guides/integrations.md").read_text(encoding="utf-8")
+    rows = "\n".join(line for line in text.splitlines() if line.startswith("|"))
+    assert not re.search(r"\(\d[\d,]*\+?\)|\|\s*\d[\d,]*\+?\s*\|", rows)
+
+
+@pytest.mark.parametrize(
+    "claim",
+    (
+        "46 service integrations",
+        "150 built-in system bundles",
+        "237+ prebuilt actions",
+        "1224 discrete, versioned atoms",
+        "1,218 typed atoms",
+        "999 provider bundles",
+        "46 third-party APIs",
+    ),
+)
+def test_snapshot_guard_is_not_tied_to_a_particular_catalog_total(claim):
+    assert CATALOG_TOTAL.search(claim)
+
+
+@pytest.mark.parametrize("bundle", (None, "slack"))
+def test_documented_list_command_reports_the_installed_catalog(bundle, monkeypatch, capsys):
+    """Exercise the documented CLI without seeding, credentials, or fixed totals."""
+    root = ROOT / "jarviscore/integrations/atoms"
+    assert atom._atoms_root().resolve() == root.resolve()
+    bundles = (
+        [root / bundle]
+        if bundle
+        else sorted(p for p in root.iterdir() if p.is_dir() and not p.name.startswith("_"))
+    )
+    expected = {
+        path.name: sorted(p.stem for p in path.glob("*.py") if p.stem != "__init__")
+        for path in bundles
+    }
+    monkeypatch.setattr(
+        sys, "argv", ["jarviscore atom", "list"] + (["--bundle", bundle] if bundle else [])
+    )
+    atom.main()
+    output = re.sub(r"\x1b\[[0-9;]*m", "", capsys.readouterr().out)
+    total_atoms = sum(len(names) for names in expected.values())
+    assert f"{len(expected)} bundles  ·  {total_atoms} atoms total" in output
+    for bundle_name, atoms in expected.items():
+        assert f"  {bundle_name}  ({len(atoms)} atoms)" in output
+        for atom_name in atoms:
+            assert f"    · {atom_name}\n" in output


### PR DESCRIPTION
README, the docs site and the packaged skill each stated an atom count as a literal number. Those numbers were true on the day the page was written; the catalog has grown since. An operator reading the docs was told a total their installation does not have — and the skill handed the same stale figure to **agents**, as fact.

## What changed

Counts are now expressed in terms of the installed catalog, with the command that reports it. Where a page needs a concrete figure it points at `jarviscore atom list` instead of restating one, so the page cannot drift from the package between releases.

Touched: [README.md](README.md), `docs/index.md`, `docs/llms.txt`, `docs/concepts/nexus.md`, `docs/guides/nexus.md`, `docs/guides/integrations.md`, `docs/guides/testing-atoms.md`, `docs/reference/cli.md`, and `jarviscore/skills/jarviscore/SKILL.md`.

`tests/test_active_catalog_docs.py` holds the line: it reads the active pages and fails when one reintroduces a hardcoded total, so this cannot silently rot again the next time the catalog changes.

## Verification

**28 passed.** No runtime code touched.

Closes #149
