### PR TITLE
fix(execution): single_response cannot report an unfinished completion as success

### DIFF
--- a/jarviscore/docs/guides/autoagent.md
+++ b/jarviscore/docs/guides/autoagent.md
@@ -186,6 +186,21 @@ The four sub-agents the Kernel routes to are the `CoderSubAgent` for tasks that 
 
 ### Analysis, not code: the `single_response` contract
 
+The answer must contain visible text and must not carry an explicit incomplete,
+filtered, refused, tool-call or unrecognized terminal reason. Otherwise the result
+uses `status="failure"`, retaining any partial `output`/`payload`, `finish_reason`,
+`provider_metadata`, provider/model, tokens and cost for diagnosis. It never retries
+or reports a new warning status. Nonempty responses from older/custom clients with
+no finish reason remain compatible; token counts alone never establish truncation.
+
+To set an output budget for this turn only, include a positive integer
+`max_output_tokens` in the execution contract, for example:
+`{"execution_shape": "single_response", "max_output_tokens": 8192}`.
+This is forwarded as `generate(max_tokens=8192)`. Invalid values fail before an
+LLM call. Omitting it retains the existing configured provider budget; model
+limits still apply. A reasoning model may spend part of that budget on internal
+reasoning rather than visible text.
+
 Many agent tasks need exactly one LLM completion: render the system prompt, ask the question, return the answer. No planner, no routing, no code generation. Declare this shape per task with an execution contract:
 
 ```python

--- a/jarviscore/execution/llm.py
+++ b/jarviscore/execution/llm.py
@@ -15,6 +15,29 @@ from jarviscore.promo import PROMO_MODEL
 
 logger = logging.getLogger(__name__)
 
+def _metadata_value(value: Any) -> Any:
+    """Serialize selected SDK completion fields, not the full provider response."""
+    if isinstance(value, Enum):
+        return value.value
+    if isinstance(value, dict):
+        return {key: _metadata_value(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_metadata_value(item) for item in value]
+    if hasattr(value, "model_dump"):
+        return _metadata_value(value.model_dump(mode="json"))
+    if hasattr(value, "__dict__"):
+        return _metadata_value(vars(value))
+    return value
+
+
+def _completion_fields(finish_reason: Any, **metadata: Any) -> dict[str, Any]:
+    """Expose the native reason and retain provider-specific completion evidence."""
+    reason = _metadata_value(finish_reason)
+    return {
+        "finish_reason": reason,
+        "provider_metadata": _metadata_value({"finish_reason": reason, **metadata}),
+    }
+
 # ─── Global LLM concurrency limiter ──────────────────────────────────────────
 # Shared across ALL UnifiedLLMClient instances in the process.
 # Prevents thundering-herd 429s when many agents fire LLM calls simultaneously.
@@ -314,8 +337,15 @@ class UnifiedLLMClient:
                 "provider": "promo|vllm|azure|gemini|vertex_ai|claude",
                 "tokens": {"input": 100, "output": 200, "total": 300},
                 "cost_usd": 0.015,
-                "model": "gpt-4o"
+                "model": "gpt-4o",
+                "finish_reason": "stop",
+                "provider_metadata": {"finish_reason": "stop", "usage": {}}
             }
+
+            Completion metadata preserves native provider reasons (e.g. Azure
+            ``length``, Claude ``max_tokens``, Gemini ``MAX_TOKENS``). A missing
+            reason is None, not inferred from token counts. A returned generation
+            is not itself a guarantee of a complete answer.
         """
         # Accept max_completion_tokens as an alias (gpt-5.x SDK naming convention)
         # Callers from the integration agent pattern may pass this explicitly.
@@ -489,6 +519,12 @@ class UnifiedLLMClient:
                 return {
                     "content": content,
                     "provider": "vllm",
+                    **_completion_fields(
+                        data['choices'][0].get("finish_reason"),
+                        usage=usage,
+                        refusal=data['choices'][0]['message'].get("refusal"),
+                        tool_calls=data['choices'][0]['message'].get("tool_calls"),
+                    ),
                     "tokens": {
                         "input": usage.get('prompt_tokens', 0),
                         "output": usage.get('completion_tokens', 0),
@@ -659,15 +695,40 @@ class UnifiedLLMClient:
             duration = time.time() - start_time
             if is_responses_only:
                 content = response.output_text
-                prompt_tokens = response.usage.input_tokens
-                completion_tokens = response.usage.output_tokens
-                total_tokens = response.usage.total_tokens
+                usage = getattr(response, "usage", None)
+                prompt_tokens = getattr(usage, "input_tokens", 0) or 0
+                completion_tokens = getattr(usage, "output_tokens", 0) or 0
+                total_tokens = getattr(usage, "total_tokens", 0) or 0
+                details = getattr(response, "incomplete_details", None)
+                status = getattr(response, "status", None)
+                detail_data = _metadata_value(details) or {}
+                output_items = _metadata_value(getattr(response, "output", None)) or []
+                refusals = [
+                    part.get("refusal")
+                    for item in output_items
+                    for part in (item.get("content") or [])
+                    if part.get("type") == "refusal"
+                ]
+                tool_calls = [item for item in output_items if item.get("type") == "function_call"]
+                completion = _completion_fields(
+                    detail_data.get("reason") or status,
+                    status=status, incomplete_details=details,
+                    error=getattr(response, "error", None),
+                    refusal=refusals or None, usage=usage, tool_calls=tool_calls,
+                )
             else:
                 content = response.choices[0].message.content
                 usage = response.usage
                 prompt_tokens = usage.prompt_tokens
                 completion_tokens = usage.completion_tokens
                 total_tokens = usage.total_tokens
+                choice = response.choices[0]
+                completion = _completion_fields(
+                    getattr(choice, "finish_reason", None), usage=usage,
+                    refusal=getattr(choice.message, "refusal", None),
+                    tool_calls=getattr(choice.message, "tool_calls", None),
+                    content_filter_results=getattr(choice, "content_filter_results", None),
+                )
 
             if label == "provider_repaired":
                 logger.info("Azure content filter retry succeeded with opt-in provider prompt repair.")
@@ -680,6 +741,7 @@ class UnifiedLLMClient:
             return {
                 "content": content,
                 "provider": "azure",
+                **completion,
                 "tokens": {
                     "input": prompt_tokens,
                     "output": completion_tokens,
@@ -761,23 +823,43 @@ class UnifiedLLMClient:
         duration = time.time() - start_time
 
         tool_calls = []
-        if response.candidates and response.candidates[0].content.parts:
-            for part in response.candidates[0].content.parts:
+        candidate = response.candidates[0] if response.candidates else None
+        candidate_content = getattr(candidate, "content", None)
+        if candidate_content and candidate_content.parts:
+            for part in candidate_content.parts:
                 if hasattr(part, 'function_call') and part.function_call:
                     tool_calls.append({
                         "name": part.function_call.name,
                         "args": dict(part.function_call.args) if part.function_call.args else {}
                     })
 
-        content = response.text if not tool_calls else ""
+        if candidate_content and candidate_content.parts:
+            content = "".join(
+                part.text for part in candidate_content.parts
+                if getattr(part, "text", None) and not getattr(part, "thought", False)
+            )
+        else:
+            content = response.text
 
         usage_metadata = getattr(response, 'usage_metadata', None)
         if usage_metadata:
-            input_tokens = getattr(usage_metadata, 'prompt_token_count', 0)
-            output_tokens = getattr(usage_metadata, 'candidates_token_count', 0)
+            input_tokens = getattr(usage_metadata, 'prompt_token_count', 0) or 0
+            output_tokens = (
+                (getattr(usage_metadata, 'candidates_token_count', 0) or 0)
+                + (getattr(usage_metadata, 'thoughts_token_count', 0) or 0)
+            )
+            total_tokens = getattr(usage_metadata, 'total_token_count', None)
+            if total_tokens is None:
+                total_tokens = input_tokens + output_tokens
         else:
             input_tokens = int(len(prompt.split()) * 1.3)
             output_tokens = int(len(content.split()) * 1.3) if content else 0
+            total_tokens = input_tokens + output_tokens
+
+        prompt_feedback = getattr(response, "prompt_feedback", None)
+        finish_reason = getattr(candidate, "finish_reason", None)
+        if finish_reason is None:
+            finish_reason = getattr(prompt_feedback, "block_reason", None)
 
         pricing = TOKEN_PRICING.get(model_name, default_pricing)
         cost = (input_tokens * pricing['input'] + output_tokens * pricing['output']) / 1_000_000
@@ -785,11 +867,17 @@ class UnifiedLLMClient:
         return {
             "content": content,
             "provider": provider_label,
+            **_completion_fields(
+                finish_reason, usage=usage_metadata,
+                finish_message=getattr(candidate, "finish_message", None),
+                safety_ratings=getattr(candidate, "safety_ratings", None),
+                prompt_feedback=prompt_feedback,
+            ),
             "tool_calls": tool_calls,
             "tokens": {
                 "input": int(input_tokens),
                 "output": int(output_tokens),
-                "total": int(input_tokens + output_tokens),
+                "total": int(total_tokens),
             },
             "cost_usd": cost,
             "model": model_name,
@@ -899,7 +987,10 @@ class UnifiedLLMClient:
         )
 
         duration = time.time() - start_time
-        content = response.content[0].text
+        content = "".join(
+            block.text for block in (response.content or [])
+            if getattr(block, "text", None)
+        )
 
         # Calculate cost
         pricing = TOKEN_PRICING.get(model, {"input": 3.0, "output": 15.0})
@@ -909,6 +1000,12 @@ class UnifiedLLMClient:
         return {
             "content": content,
             "provider": "claude",
+            **_completion_fields(
+                getattr(response, "stop_reason", None),
+                stop_reason=getattr(response, "stop_reason", None),
+                stop_sequence=getattr(response, "stop_sequence", None),
+                usage=response.usage,
+            ),
             "tokens": {
                 "input": response.usage.input_tokens,
                 "output": response.usage.output_tokens,

--- a/jarviscore/execution/llm.py
+++ b/jarviscore/execution/llm.py
@@ -15,19 +15,44 @@ from jarviscore.promo import PROMO_MODEL
 
 logger = logging.getLogger(__name__)
 
-def _metadata_value(value: Any) -> Any:
+# A provider response is a foreign object graph: it can nest without end, hold a
+# back-reference to its own client, or synthesise attributes on access. Traversal
+# is bounded so serializing the evidence can never outlive the call it describes.
+_METADATA_MAX_DEPTH = 6
+
+
+def _model_dump(value: Any) -> Optional[Dict[str, Any]]:
+    """Return a pydantic dump only when it actually yields a mapping."""
+    dump = getattr(value, "model_dump", None)
+    if not callable(dump):
+        return None
+    try:
+        dumped = dump(mode="json")
+    except Exception:  # noqa: BLE001 - telemetry must not break the generation it describes
+        return None
+    return dumped if isinstance(dumped, dict) else None
+
+
+def _metadata_value(value: Any, _depth: int = 0, _seen: frozenset = frozenset()) -> Any:
     """Serialize selected SDK completion fields, not the full provider response."""
+    if value is None or isinstance(value, (str, int, float, bool)):
+        return value
     if isinstance(value, Enum):
-        return value.value
+        return _metadata_value(value.value, _depth, _seen)
+    if _depth >= _METADATA_MAX_DEPTH or id(value) in _seen:
+        return repr(value)
+    seen = _seen | {id(value)}
     if isinstance(value, dict):
-        return {key: _metadata_value(item) for key, item in value.items()}
+        return {str(key): _metadata_value(item, _depth + 1, seen) for key, item in value.items()}
     if isinstance(value, (list, tuple)):
-        return [_metadata_value(item) for item in value]
-    if hasattr(value, "model_dump"):
-        return _metadata_value(value.model_dump(mode="json"))
-    if hasattr(value, "__dict__"):
-        return _metadata_value(vars(value))
-    return value
+        return [_metadata_value(item, _depth + 1, seen) for item in value]
+    dumped = _model_dump(value)
+    if dumped is not None:
+        return _metadata_value(dumped, _depth + 1, seen)
+    attributes = getattr(value, "__dict__", None)
+    if isinstance(attributes, dict):
+        return _metadata_value(attributes, _depth + 1, seen)
+    return repr(value)
 
 
 def _completion_fields(finish_reason: Any, **metadata: Any) -> dict[str, Any]:

--- a/jarviscore/profiles/autoagent.py
+++ b/jarviscore/profiles/autoagent.py
@@ -693,17 +693,26 @@ class AutoAgent(Profile):
             else self.system_prompt
         )
         try:
+            completion_options = {}
+            if "max_output_tokens" in contract:
+                budget = contract["max_output_tokens"]
+                if isinstance(budget, bool) or not isinstance(budget, int) or budget <= 0:
+                    raise ValueError("execution_contract.max_output_tokens must be a positive integer")
+                completion_options["max_tokens"] = budget
             response = await self.llm.generate(
                 messages=[
                     {"role": "system", "content": effective_system_prompt or ""},
                     {"role": "user", "content": task_desc},
                 ],
                 temperature=0.0,
+                **completion_options,
             )
         except Exception as exc:  # noqa: BLE001 - provider errors become clean failures
             return {
                 "status": "failure",
                 "output": None,
+                "payload": None,
+                "execution_shape": "single_response",
                 "error": f"single_response completion failed: {type(exc).__name__}: {exc}",
                 "agent_id": self.agent_id,
                 "role": self.role,
@@ -711,12 +720,34 @@ class AutoAgent(Profile):
                 "cost_usd": 0.0,
                 "repairs": 0,
             }
-        content = (response.get("content") or "").strip()
+        content = response.get("content") or ""
+        finish_reason = response.get("finish_reason")
+        metadata = response.get("provider_metadata") or {}
+        # This is the terminal boundary for a one-answer contract, not a retry
+        # or routing policy. Unknown explicit reasons cannot certify completion.
+        completed_reasons = {"stop", "end_turn", "stop_sequence", "completed"}
+        reason = str(finish_reason).lower() if finish_reason is not None else None
+        error = None
+        if reason is not None and reason not in completed_reasons:
+            error = f"single_response did not complete: finish_reason={finish_reason}"
+        elif metadata.get("status") not in (None, "completed"):
+            error = f"single_response did not complete: status={metadata['status']}"
+        elif metadata.get("refusal"):
+            error = "single_response provider refused the completion"
+        elif response.get("tool_calls") or metadata.get("tool_calls"):
+            error = "single_response returned tool calls instead of a completed answer"
+        elif not content.strip():
+            error = "single_response returned empty output (completion cause unknown)"
         return {
-            "status": "success",
+            "status": "failure" if error else "success",
             "output": content,
             "payload": content,
-            "error": None,
+            "error": error,
+            "finish_reason": finish_reason,
+            "provider_metadata": metadata,
+            "provider": response.get("provider"),
+            "model": response.get("model"),
+            "tool_calls": response.get("tool_calls", []),
             "agent_id": self.agent_id,
             "role": self.role,
             "execution_shape": "single_response",

--- a/tests/test_completion_metadata.py
+++ b/tests/test_completion_metadata.py
@@ -1,0 +1,369 @@
+"""Offline provider and single-response contracts for #148."""
+
+import asyncio
+import json
+from enum import Enum
+from types import SimpleNamespace as NS
+from typing import ClassVar
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from jarviscore.execution.llm import LLMProvider, UnifiedLLMClient
+from jarviscore.profiles.autoagent import AutoAgent
+
+
+@pytest.fixture(autouse=True)
+def no_network(monkeypatch):
+    """These regressions must never reach a live provider, even on a developer machine."""
+    def blocked(*args, **kwargs):
+        pytest.fail("Network access is forbidden in completion contract tests")
+
+    monkeypatch.setattr("socket.socket.connect", blocked)
+    monkeypatch.setattr("socket.socket.connect_ex", blocked)
+
+
+class MiniAuto(AutoAgent):
+    role = "completion-test"
+    capabilities: ClassVar[list[str]] = ["analysis"]
+    system_prompt = "Answer once."
+
+
+def client(provider):
+    llm = UnifiedLLMClient.__new__(UnifiedLLMClient)
+    llm.config = {"llm_max_retries_429": 0}
+    llm._semaphore = None
+    llm.provider_order = [LLMProvider(provider)]
+    return llm
+
+
+@pytest.mark.parametrize("reason,content", [("stop", "answer"), ("length", "partial"), ("content_filter", None)])
+async def test_azure_chat_preserves_completion(reason, content):
+    llm = client("azure")
+    response = NS(
+        choices=[NS(finish_reason=reason, message=NS(content=content, refusal=None),
+                    content_filter_results={"test": {"filtered": reason == "content_filter"}})],
+        usage=NS(prompt_tokens=10, completion_tokens=4000, total_tokens=4010,
+                 completion_tokens_details={"reasoning_tokens": 3990}),
+    )
+    llm.azure_client = NS(chat=NS(completions=NS(create=AsyncMock(return_value=response))))
+    result = await llm.generate("answer")
+    assert result["finish_reason"] == reason
+    assert result["content"] == content
+    assert result["tokens"]["output"] == 4000
+    assert result["provider_metadata"]["usage"]["completion_tokens_details"]["reasoning_tokens"] == 3990
+    assert result["provider_metadata"]["content_filter_results"] == response.choices[0].content_filter_results
+    json.dumps(result)
+
+
+@pytest.mark.parametrize("status,reason", [("completed", None), ("incomplete", "max_output_tokens"), ("incomplete", "content_filter"), ("failed", None)])
+async def test_azure_responses_preserves_status_and_details(status, reason):
+    llm = client("azure")
+    response = NS(output_text="partial", status=status,
+                  incomplete_details=NS(reason=reason) if reason else None,
+                  usage=NS(input_tokens=10, output_tokens=20, total_tokens=30),
+                  error=NS(code="server_error") if status == "failed" else None)
+    llm.azure_client = NS(responses=NS(create=AsyncMock(return_value=response)))
+    result = await llm.generate("answer", model="gpt-5-codex")
+    assert result["finish_reason"] == (reason or status)
+    assert result["provider_metadata"]["status"] == status
+    assert result["provider_metadata"]["incomplete_details"] == ({"reason": reason} if reason else None)
+    json.dumps(result)
+
+
+@pytest.mark.parametrize("reason,blocks", [
+    ("end_turn", [NS(text="answer")]), ("max_tokens", [NS(text="partial")]),
+    ("refusal", []), ("tool_use", [NS(type="tool_use", name="lookup")]),
+    ("end_turn", [NS(type="thinking", thinking="private"), NS(text="answer")]),
+])
+async def test_claude_preserves_stop_reason_with_empty_or_non_text_blocks(reason, blocks):
+    llm = client("claude")
+    llm.claude_client = NS(messages=NS(create=MagicMock(return_value=NS(
+        content=blocks, stop_reason=reason, stop_sequence=None,
+        usage=NS(input_tokens=10, output_tokens=20),
+    ))))
+    result = await llm.generate("answer")
+    assert result["finish_reason"] == reason
+    assert result["provider_metadata"]["stop_reason"] == reason
+    assert result["content"] == "".join(getattr(block, "text", "") for block in blocks)
+    json.dumps(result)
+
+
+class FinishReason(Enum):
+    STOP = "STOP"
+    MAX_TOKENS = "MAX_TOKENS"
+    SAFETY = "SAFETY"
+
+
+@pytest.mark.parametrize("provider", ["gemini", "vertex_ai"])
+@pytest.mark.parametrize("reason", list(FinishReason))
+async def test_genai_preserves_native_finish_reason_and_usage(provider, reason):
+    llm = client(provider)
+    response = NS(text=None if reason == FinishReason.SAFETY else "answer",
+                  candidates=[NS(finish_reason=reason, content=None, finish_message="terminal",
+                                 safety_ratings=[])],
+                  usage_metadata=NS(prompt_token_count=10, candidates_token_count=None,
+                                    thoughts_token_count=20, total_token_count=30))
+    sdk = NS(aio=NS(models=NS(generate_content=AsyncMock(return_value=response))))
+    setattr(llm, f"{provider}_client", sdk)
+    setattr(llm, f"{provider}_model", "offline-model")
+    result = await llm.generate("answer")
+    assert result["finish_reason"] == reason.value
+    assert result["provider_metadata"]["finish_message"] == "terminal"
+    assert result["provider_metadata"]["usage"]["thoughts_token_count"] == 20
+    assert result["tokens"]["total"] == 30
+    json.dumps(result)
+
+
+async def test_genai_blocked_prompt_has_no_candidates():
+    llm = client("gemini")
+    response = NS(text=None, candidates=[], usage_metadata=None,
+                  prompt_feedback=NS(block_reason="PROHIBITED_CONTENT"))
+    llm.gemini_client = NS(aio=NS(models=NS(generate_content=AsyncMock(return_value=response))))
+    llm.gemini_model = "offline-model"
+    result = await llm.generate("answer")
+    assert result["finish_reason"] == "PROHIBITED_CONTENT"
+    assert result["provider_metadata"]["prompt_feedback"]["block_reason"] == "PROHIBITED_CONTENT"
+
+
+async def test_vllm_preserves_finish_reason(monkeypatch):
+    llm = client("vllm")
+    llm.vllm_endpoint = "http://offline.invalid"
+    response = MagicMock(status=200)
+    response.json = AsyncMock(return_value={
+        "choices": [{"message": {"content": "partial"}, "finish_reason": "length"}],
+        "usage": {"prompt_tokens": 10, "completion_tokens": 20, "total_tokens": 30},
+    })
+    response.__aenter__ = AsyncMock(return_value=response)
+    session = MagicMock()
+    session.__aenter__ = AsyncMock(return_value=session)
+    session.post.return_value = response
+    monkeypatch.setattr("jarviscore.execution.llm.aiohttp.ClientSession", lambda **kw: session)
+    result = await llm.generate("answer")
+    assert result["finish_reason"] == "length"
+    assert result["provider_metadata"]["usage"]["completion_tokens"] == 20
+
+
+def agent_with(response):
+    agent = MiniAuto()
+    agent._kernel = MagicMock()
+    agent.llm = NS(generate=AsyncMock(return_value={
+        "content": "answer", "provider": "fake", "model": "test-model",
+        "tokens": {"input": 10, "output": 4000, "total": 4010}, "cost_usd": 0.1,
+        **response,
+    }))
+    return agent
+
+
+async def execute(agent, **contract):
+    result = await agent.execute_task({"task": "answer", "context": {
+        "execution_contract": {"execution_shape": "single_response", **contract},
+    }})
+    agent._kernel.execute.assert_not_called()
+    return result
+
+
+@pytest.mark.parametrize("content", [None, "", " \n\t"])
+async def test_empty_is_failure_without_claiming_truncation(content):
+    agent = agent_with({"content": content})
+    result = await execute(agent)
+    assert result["status"] == "failure"
+    assert "empty" in result["error"]
+    assert "truncat" not in result["error"]
+    assert result["tokens"]["output"] == 4000
+    agent.llm.generate.assert_awaited_once()
+
+
+@pytest.mark.parametrize("reason", [
+    "length", "max_tokens", "MAX_TOKENS", "max_output_tokens", "content_filter",
+    "SAFETY", "RECITATION", "BLOCKLIST", "PROHIBITED_CONTENT", "SPII", "IMAGE_SAFETY",
+    "MALFORMED_FUNCTION_CALL", "tool_calls", "function_call", "tool_use", "pause_turn",
+    "refusal", "incomplete", "failed", "cancelled", "OTHER",
+])
+async def test_incomplete_preserves_partial_content_and_diagnostics(reason):
+    metadata = {"finish_reason": reason, "usage": {"reasoning_tokens": 3000}}
+    agent = agent_with({"content": "partial", "finish_reason": reason, "provider_metadata": metadata})
+    result = await execute(agent)
+    assert result["status"] == "failure"
+    assert result["output"] == result["payload"] == "partial"
+    assert result["finish_reason"] == reason
+    assert result["provider_metadata"] == metadata
+    assert result["provider"] == "fake" and result["model"] == "test-model"
+    assert result["cost_usd"] == 0.1 and result["tokens"]["output"] == 4000
+    assert result["execution_shape"] == "single_response"
+    agent.llm.generate.assert_awaited_once()
+
+
+@pytest.mark.parametrize("reason", [None, "stop", "STOP", "end_turn", "stop_sequence", "completed"])
+async def test_complete_or_legacy_nonempty_is_success_even_at_token_limit(reason):
+    agent = agent_with({"finish_reason": reason})
+    result = await execute(agent)
+    assert result["status"] == "success"
+    assert result["finish_reason"] == reason
+    assert "max_tokens" not in agent.llm.generate.call_args.kwargs
+
+
+@pytest.mark.parametrize("metadata", [{"refusal": "refused"}, {"status": "incomplete"}])
+async def test_provider_metadata_can_indicate_non_answer(metadata):
+    result = await execute(agent_with({"finish_reason": "stop", "provider_metadata": metadata}))
+    assert result["status"] == "failure"
+
+
+async def test_tool_call_is_not_a_completed_answer():
+    result = await execute(agent_with({"finish_reason": "STOP", "tool_calls": [{"name": "lookup"}]}))
+    assert result["status"] == "failure"
+    assert result["tool_calls"] == [{"name": "lookup"}]
+
+
+async def test_explicit_output_budget_is_forwarded_once():
+    agent = agent_with({"finish_reason": "stop"})
+    assert (await execute(agent, max_output_tokens=8192))["status"] == "success"
+    assert agent.llm.generate.call_args.kwargs["max_tokens"] == 8192
+    agent.llm.generate.assert_awaited_once()
+
+
+@pytest.mark.parametrize("budget", [0, -1, True, "8000", 1.5, None])
+async def test_invalid_output_budget_fails_before_model_call(budget):
+    agent = agent_with({})
+    result = await execute(agent, max_output_tokens=budget)
+    assert result["status"] == "failure"
+    assert "max_output_tokens" in result["error"]
+    agent.llm.generate.assert_not_awaited()
+
+
+async def test_cancellation_is_propagated():
+    agent = agent_with({})
+    agent.llm.generate.side_effect = asyncio.CancelledError()
+    with pytest.raises(asyncio.CancelledError):
+        await execute(agent)
+
+
+@pytest.mark.parametrize("status", ["failed", "cancelled", "incomplete"])
+async def test_responses_without_usage_keeps_failure_diagnostics(status):
+    llm = client("azure")
+    response = NS(output_text="partial", status=status, usage=None,
+                  incomplete_details=None, error=NS(code="server_error"))
+    llm.azure_client = NS(responses=NS(create=AsyncMock(return_value=response)))
+    result = await llm.generate("answer", model="gpt-5-codex")
+    assert result["finish_reason"] == status
+    assert result["provider_metadata"]["error"] == {"code": "server_error"}
+    assert result["provider_metadata"]["usage"] is None
+    assert result["tokens"] == {"input": 0, "output": 0, "total": 0}
+    assert result["content"] == "partial"
+    json.dumps(result)
+
+
+@pytest.mark.parametrize("provider", ["gemini", "vertex_ai"])
+async def test_genai_mixed_tool_call_keeps_partial_text(provider):
+    from google.genai import types
+
+    llm = client(provider)
+    response = types.GenerateContentResponse(
+        candidates=[types.Candidate(
+            finish_reason=types.FinishReason.STOP,
+            content=types.Content(parts=[
+                types.Part(text="partial explanation"),
+                types.Part(function_call=types.FunctionCall(name="lookup", args={"q": "test"})),
+            ]),
+        )],
+    )
+    sdk = NS(aio=NS(models=NS(generate_content=AsyncMock(return_value=response))))
+    setattr(llm, f"{provider}_client", sdk)
+    setattr(llm, f"{provider}_model", "offline-model")
+    agent = agent_with({})
+    agent.llm = llm
+    result = await execute(agent)
+    assert result["status"] == "failure"
+    assert result["output"] == result["payload"] == "partial explanation"
+    assert result["tool_calls"] == [{"name": "lookup", "args": {"q": "test"}}]
+    sdk.aio.models.generate_content.assert_awaited_once()
+    json.dumps(result)
+
+
+async def test_responses_function_call_with_text_is_not_complete():
+    llm = client("azure")
+    response = NS(output_text="partial explanation", status="completed", usage=None,
+                  output=[NS(type="function_call", name="lookup", arguments="{}", call_id="call1")])
+    llm.config["azure_deployment"] = "gpt-5-codex"
+    llm.azure_client = NS(responses=NS(create=AsyncMock(return_value=response)))
+    agent = agent_with({})
+    agent.llm = llm
+    result = await execute(agent)
+    assert result["status"] == "failure"
+    assert result["output"] == "partial explanation"
+    assert result["provider_metadata"]["tool_calls"][0]["name"] == "lookup"
+    json.dumps(result)
+
+
+async def test_partial_output_is_preserved_verbatim():
+    result = await execute(agent_with({"content": "  partial\n", "finish_reason": "length"}))
+    assert result["status"] == "failure"
+    assert result["output"] == result["payload"] == "  partial\n"
+
+
+@pytest.mark.parametrize("provider,reason", [
+    ("azure", "length"), ("azure", "stop"), ("azure", None),
+    ("claude", "max_tokens"), ("claude", "end_turn"), ("claude", None),
+    ("gemini", "MAX_TOKENS"), ("gemini", "STOP"), ("gemini", None),
+    ("vertex_ai", "SAFETY"), ("vertex_ai", "STOP"), ("vertex_ai", None),
+    ("promo", "length"), ("promo", "stop"), ("promo", None),
+])
+async def test_adapter_to_single_response_contract(provider, reason):
+    llm = client(provider)
+    if provider == "azure":
+        response = NS(choices=[NS(finish_reason=reason, message=NS(content="answer"))],
+                      usage=NS(prompt_tokens=10, completion_tokens=20, total_tokens=30))
+        call = AsyncMock(return_value=response)
+        llm.azure_client = NS(chat=NS(completions=NS(create=call)))
+    elif provider == "claude":
+        response = NS(content=[NS(text="answer")], stop_reason=reason,
+                      usage=NS(input_tokens=10, output_tokens=20))
+        call = MagicMock(return_value=response)
+        llm.claude_client = NS(messages=NS(create=call))
+    elif provider == "promo":
+        response = {"content": "answer", "finish_reason": reason, "provider": "promo",
+                    "model": "jarviscore-promo", "tokens": {"input": 10, "output": 20, "total": 30}}
+        call = AsyncMock(return_value=response)
+        llm.promo_client = NS(generate=call)
+    else:
+        response = NS(text="answer", candidates=[NS(content=None, finish_reason=reason)],
+                      usage_metadata=NS(prompt_token_count=10, candidates_token_count=20))
+        call = AsyncMock(return_value=response)
+        sdk = NS(aio=NS(models=NS(generate_content=call)))
+        setattr(llm, f"{provider}_client", sdk)
+        setattr(llm, f"{provider}_model", "offline-model")
+    agent = agent_with({})
+    agent.llm = llm
+    result = await execute(agent, max_output_tokens=8192)
+    expected = "success" if reason in (None, "stop", "STOP", "end_turn") else "failure"
+    assert result["status"] == expected
+    assert result["finish_reason"] == reason
+    assert result["output"] == "answer"
+    assert result["provider"] == provider
+    assert result["tokens"] == {"input": 10, "output": 20, "total": 30}
+    call.assert_called_once()
+    options = call.call_args.kwargs
+    budget = (options.get("max_completion_tokens") if provider == "azure"
+              else options["config"]["max_output_tokens"] if provider in ("gemini", "vertex_ai")
+              else options["max_tokens"])
+    assert budget == 8192
+    json.dumps(result)
+
+
+async def test_provider_exception_is_a_failure_without_retry():
+    agent = agent_with({})
+    agent.llm.generate.side_effect = RuntimeError("offline failure")
+    result = await execute(agent)
+    assert result["status"] == "failure"
+    assert "offline failure" in result["error"]
+    agent.llm.generate.assert_awaited_once()
+
+
+@pytest.mark.parametrize("options,budget", [({}, 1234), ({"max_tokens": 2222}, 2222),
+                                          ({"max_completion_tokens": 3333}, 3333)])
+async def test_generate_preserves_configured_and_explicit_budgets(options, budget):
+    llm = client("promo")
+    llm.config["llm_default_max_tokens"] = 1234
+    llm.promo_client = NS(generate=AsyncMock(return_value={"content": "answer"}))
+    await llm.generate("answer", **options)
+    assert llm.promo_client.generate.call_args.kwargs["max_tokens"] == budget

--- a/tests/test_llm_fallback.py
+++ b/tests/test_llm_fallback.py
@@ -310,6 +310,8 @@ async def test_vertex_ai_generate_returns_correct_shape():
     usage = MagicMock()
     usage.prompt_token_count = 10
     usage.candidates_token_count = 20
+    usage.thoughts_token_count = 0
+    usage.total_token_count = 30
     fake_response.usage_metadata = usage
 
     fake_aio = MagicMock()


### PR DESCRIPTION
`single_response` took whatever content came back, stripped it, and returned `status="success"`. A truncated answer, a refusal, a content-filter block and a genuinely completed answer were **indistinguishable to the caller** — because the one field that separates them, the provider's finish reason, was discarded by every adapter before the profile could see it.

This is the same disease as #150: a result that was not earned reported as success. One layer up.

## What changed

**Adapters carry the evidence out.** `finish_reason` and `provider_metadata` now come back from every path — Azure chat + Responses, vLLM, Gemini, Claude — with native reasons preserved exactly as the provider stated them (`length`, `max_tokens`, `MAX_TOKENS`, `incomplete_details.reason`), alongside refusals, tool calls, usage and content-filter results. `_metadata_value` serialises only selected fields, not the whole provider object.

**A missing reason stays `None`.** It is not inferred from token counts. A generation that stops short of the cap is not evidence that it finished, and guessing there would manufacture exactly the false confidence this PR removes.

**`single_response` requires certification.** Success now needs a terminal reason (`stop`, `end_turn`, `stop_sequence`, `completed`). Any of these becomes a failure that names its own cause:

| condition | error |
|---|---|
| explicit reason outside the terminal set | `did not complete: finish_reason=length` |
| status not `completed` | `did not complete: status=incomplete` |
| provider refusal | `provider refused the completion` |
| tool calls instead of an answer | `returned tool calls instead of a completed answer` |
| empty content | `returned empty output (completion cause unknown)` |

An unknown explicit reason cannot certify completion. This is the terminal boundary for a one-answer contract — not a retry policy and not routing.

## Also fixed, found while reading the adapters

- **Gemini undercounted output tokens**: `thoughts_token_count` was omitted, so spend on thinking models was reported low, and total was recomputed by addition instead of using the provider's `total_token_count`.
- **Gemini content used `response.text`**, which raises or concatenates thought parts on thinking models. Parts are now joined with thoughts excluded.
- **Azure Responses usage** was read through attribute access assuming `usage` is always present.
- **`execution_contract.max_output_tokens` was silently ignored** — now honoured, and validated as a positive integer.
- The failure branch returns `payload` and `execution_shape` so both outcomes have the same shape.

## Verification

`tests/test_completion_metadata.py` — **87 passed**. Every provider path with mocked SDK responses, each terminal and non-terminal reason, refusals, tool calls, thinking-model token accounting, and the contract validation. Fully offline.

Closes #148
