### PR TITLE
fix(kernel): the done gate returns evidence instead of a verdict

### DIFF
--- a/jarviscore/docs/guides/custom-subagents.md
+++ b/jarviscore/docs/guides/custom-subagents.md
@@ -129,16 +129,36 @@ Both are `async`. The base class defaults are no-ops; you do not need to call `s
 
 Override these to intervene inside the loop without modifying it.
 
-### `_can_complete(state, parsed) -> tuple[bool, str]`
+### `_can_complete(state, parsed) -> tuple[bool, GateEvidence | str]`
 
-Called when the LLM emits `DONE`. Return `(True, "")` to allow, or `(False, "reason")` to reject and keep the loop running:
+Called when the LLM emits `DONE`. Return `(True, "")` to allow, or `(False, evidence)` to reject and keep the loop running.
+
+Report what the agent produced, not a verdict on it:
 
 ```python
+from jarviscore.kernel.gate import GateEvidence
+
 def _can_complete(self, state, parsed) -> tuple:
-    if not parsed.get("result", {}).get("rows"):
-        return False, "No rows returned. Run a query before finishing."
+    rows = parsed.get("result", {}).get("rows")
+    if not rows:
+        return False, GateEvidence(
+            check="rows_returned",
+            requirement="at least one row in the result",
+            observed={
+                "rows": len(rows or []),
+                "query_calls": sum(1 for t in state.tool_history if t.tool_name == "query"),
+            },
+        )
     return True, ""
 ```
+
+A verdict — *"No rows returned. Run a query before finishing."* — restates your rule in your vocabulary. The agent cannot map it onto anything it did, so its next attempt tends to be the last one reworded, and the gate becomes a loop. Counts move only when the work moves, so evidence gives the agent something it can act on and cannot talk its way past.
+
+Leave the advice out. Naming the missing fact is the gate's job; deciding what to do about it is the agent's.
+
+The harness watches for attempts that carry no new information — the same check failing on the same values, the same result submitted, and no tool run in between. It tells the agent when its last attempt changed nothing, and ends the step after `max_identical_done_attempts` (default 3) of them rather than letting a gate it cannot satisfy consume the lease. An agent that is still changing its output is never cut off, however many rejections it takes.
+
+A plain string is still accepted, and is passed through as a verdict with no observations behind it.
 
 ### `_pre_execute_hook(tool_name, params, state) -> Optional[dict]`
 

--- a/jarviscore/kernel/defaults/coder.py
+++ b/jarviscore/kernel/defaults/coder.py
@@ -21,6 +21,7 @@ import time
 from typing import Any, Dict, List, Optional
 
 from jarviscore.kernel.subagent import BaseSubAgent
+from jarviscore.kernel.gate import GateEvidence
 from jarviscore.kernel.state import KernelState
 
 logger = logging.getLogger(__name__)
@@ -332,7 +333,13 @@ proves it — that is the entire job.
         # Scan history for execution proof
         has_executed = False
         last_success_output = None
+        execute_calls = 0
+        write_calls = 0
         for tool_res in state.tool_history:
+            if tool_res.tool_name == "execute_code":
+                execute_calls += 1
+            elif tool_res.tool_name == "write_code":
+                write_calls += 1
             if tool_res.tool_name == "execute_code" and tool_res.succeeded:
                 has_executed = True
                 last_success_output = tool_res.tool_output
@@ -349,9 +356,19 @@ proves it — that is the entire job.
         if not has_executed:
             return (
                 False,
-                "PROOF OF WORK REQUIRED: You cannot call DONE without executing code first.\n"
-                "You must use the `write_code` or `execute_code` tool to write and run actual Python code.\n"
-                "Do NOT just output the answer in the RESULT block. You MUST execute a Python script that sets the `result` variable."
+                GateEvidence(
+                    check="proof_of_work",
+                    requirement=(
+                        "one execute_code call that succeeded, or one write_code call "
+                        "whose execution_result reports success"
+                    ),
+                    observed={
+                        "tool_calls": len(state.tool_history),
+                        "execute_code_calls": execute_calls,
+                        "write_code_calls": write_calls,
+                        "successful_executions": 0,
+                    },
+                ),
             )
 
         # Force the payload to be the actual sandbox execution result.

--- a/jarviscore/kernel/defaults/researcher.py
+++ b/jarviscore/kernel/defaults/researcher.py
@@ -27,6 +27,7 @@ from typing import Dict, Any, List, Optional, Literal, cast, Set, Tuple
 from urllib.parse import urlparse
 
 from jarviscore.kernel.subagent import BaseSubAgent
+from jarviscore.kernel.gate import GateEvidence
 from jarviscore.kernel.state import KernelState
 from jarviscore.kernel.defaults.research_flow import ResearchFlow, ResearchPhase
 from jarviscore.kernel.cognition import AgentPhase
@@ -554,8 +555,21 @@ CRITICAL EPISTEMIC CONTRACT: You CANNOT exit your turn by saying "I need to rese
             }
         return None
 
-    def _can_complete(self, state, parsed: Dict[str, Any]) -> Tuple[bool, str]:
-        """Reject premature DONE if no meaningful research has been done."""
+    #: What each named done-payload check reads, stated once for the agent.
+    _DONE_REQUIREMENTS = {
+        "summary": "a non-empty summary",
+        "evidence": "at least one evidence entry, or a recorded research finding",
+        "evidence_pointers": "every evidence entry carries a pointer or url",
+        "api_specs": "every api_spec entry carries a method and a url or path",
+    }
+
+    _CONTENT_TOOLS = frozenset({
+        "read_web_content", "browser_get_text", "browser_get_page_text",
+        "rag_query", "read_file", "extract_api_details",
+    })
+
+    def _can_complete(self, state, parsed: Dict[str, Any]) -> Tuple[bool, Any]:
+        """Reject premature DONE, reporting what the result actually contains."""
         base_ok, base_reason = super()._can_complete(state, parsed)
         if not base_ok:
             return base_ok, base_reason
@@ -563,15 +577,38 @@ CRITICAL EPISTEMIC CONTRACT: You CANNOT exit your turn by saying "I need to rese
         params = parsed.get("result") or {}
         if not isinstance(params, dict):
             params = {}
-        meaningful_research = any(
-            t.status == "success" and t.tool_name in {"read_web_content", "browser_get_text", "browser_get_page_text", "rag_query", "read_file", "extract_api_details"}
-            for t in state.tool_history
+        evidence_items = params.get("evidence")
+        content_successes = sum(
+            1 for t in state.tool_history
+            if t.status == "success" and t.tool_name in self._CONTENT_TOOLS
         )
-        if not meaningful_research and not (params.get("evidence") or params.get("summary")):
-            return False, "Research completion requires at least one successful content/evidence tool result"
-        valid, reason, _ = self._validate_done_payload(state, params)
+        if not content_successes and not (evidence_items or params.get("summary")):
+            return False, GateEvidence(
+                check="research_performed",
+                requirement=(
+                    "one successful content tool call, or a summary or evidence "
+                    "in the submitted result"
+                ),
+                observed={
+                    "tool_calls": len(state.tool_history),
+                    "content_tool_successes": 0,
+                    "content_tools": sorted(self._CONTENT_TOOLS),
+                    "result_summary": bool(params.get("summary")),
+                    "result_evidence": (
+                        len(evidence_items) if isinstance(evidence_items, list) else 0
+                    ),
+                },
+            )
+        valid, _reason, report = self._validate_done_payload(state, params)
         if not valid:
-            return False, reason
+            check = report.get("check", "done_payload")
+            observed = {key: value for key, value in report.items() if key != "check"}
+            observed["content_tool_successes"] = content_successes
+            return False, GateEvidence(
+                check=check,
+                requirement=self._DONE_REQUIREMENTS.get(check, ""),
+                observed=observed,
+            )
         return True, ""
 
     def _validate_done_payload(self, state, params: Dict[str, Any]) -> Tuple[bool, str, Dict[str, Any]]:
@@ -632,13 +669,19 @@ CRITICAL EPISTEMIC CONTRACT: You CANNOT exit your turn by saying "I need to rese
         }
         if not strict:
             return True, "", report
+        # report["check"] names the failing contract so callers can identify it
+        # without reading the prose reason.
         if not summary:
+            report["check"] = "summary"
             return False, "DONE_VALIDATION_FAILED: summary is required", report
         if evidence_count == 0 and not has_finding_fallback:
+            report["check"] = "evidence"
             return False, "DONE_VALIDATION_FAILED: evidence is required", report
         if bad_evidence > 0:
+            report["check"] = "evidence_pointers"
             return False, "DONE_VALIDATION_FAILED: evidence entries must include pointer/url", report
         if bad_specs > 0:
+            report["check"] = "api_specs"
             return False, "DONE_VALIDATION_FAILED: api_specs entries need method + url/path", report
         if incomplete_specs:
             # Surface a clear warning — do not hard-fail since the Researcher may

--- a/jarviscore/kernel/gate.py
+++ b/jarviscore/kernel/gate.py
@@ -1,0 +1,170 @@
+"""Completion-gate evidence.
+
+A gate reports what it observed. It does not report what it concluded.
+
+The distinction is the whole point. A verdict — "evidence is required" — is a
+restatement of the rule in the checker's own vocabulary. An agent cannot map it
+onto anything it actually did, so its next attempt is a guess, and the guess is
+usually the previous attempt reworded. Evidence — "3 evidence items, 0 with a
+pointer" — is a fact about the artifact the agent produced. It can be acted on,
+and it cannot be satisfied by rewording, because the numbers only move when the
+work moves.
+
+There is a second reason to prefer evidence, and it matters more. Guidance
+teaches an agent to satisfy the checker; a critique is a description of what the
+gate wants to see, so an agent optimising against it optimises the gate. Facts
+about its own output give it nothing to optimise against but the work itself.
+
+So a gate states three things and stops: which named check did not hold, what it
+reads, and what it observed. It does not advise, rank causes, or suggest a fix —
+those are the agent's job, and doing them here would make the boundary into a
+decision-maker.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass, field
+from typing import Any, Dict, Mapping, Optional, Tuple, Union
+
+__all__ = [
+    "GateEvidence",
+    "GateAttempt",
+    "as_evidence",
+    "record_attempt",
+]
+
+
+def _canonical(value: Any) -> str:
+    """Stable text for a fact, so equal observations fingerprint equally."""
+    try:
+        return json.dumps(value, sort_keys=True, default=str, separators=(",", ":"))
+    except (TypeError, ValueError):
+        return str(value)
+
+
+def _render_fact(value: Any) -> str:
+    if isinstance(value, bool):
+        return "yes" if value else "no"
+    if isinstance(value, (list, tuple)):
+        if not value:
+            return "none"
+        return ", ".join(str(item) for item in value)
+    if value is None:
+        return "none"
+    return str(value)
+
+
+@dataclass(frozen=True)
+class GateEvidence:
+    """Why a completion attempt did not satisfy a gate, stated as facts.
+
+    Attributes:
+        check: Name of the check that did not hold. Machine-readable and stable,
+            so a repeat of the same failure is recognisable as a repeat.
+        requirement: What the check reads, stated once and plainly.
+        observed: What the agent actually produced, as named values.
+    """
+
+    check: str
+    requirement: str = ""
+    observed: Mapping[str, Any] = field(default_factory=dict)
+
+    def fingerprint(self) -> str:
+        """Identity of this failure: same check, same observations."""
+        facts = _canonical({str(k): v for k, v in sorted(self.observed.items())})
+        return hashlib.sha256(f"{self.check}:{facts}".encode("utf-8")).hexdigest()
+
+    def render(self) -> str:
+        """The agent-facing form: the check, what it reads, what is there."""
+        lines = [f"DONE_GATE_UNSATISFIED: {self.check}"]
+        if self.requirement:
+            lines.append(f"  requires  {self.requirement}")
+        if self.observed:
+            lines.append("  observed")
+            width = max(len(str(key)) for key in self.observed)
+            for key, value in self.observed.items():
+                lines.append(f"    {str(key).ljust(width)}  {_render_fact(value)}")
+        return "\n".join(lines)
+
+    def as_dict(self) -> Dict[str, Any]:
+        return {
+            "check": self.check,
+            "requirement": self.requirement,
+            "observed": dict(self.observed),
+        }
+
+
+def as_evidence(reason: Union[str, GateEvidence, None]) -> GateEvidence:
+    """Accept either form a gate may return.
+
+    ``_can_complete`` has always returned ``(bool, str)``. A gate that still
+    returns a bare string is reporting a verdict with no observations behind it,
+    so it is carried through as exactly that — named ``unspecified`` rather than
+    dressed up as evidence it did not provide.
+    """
+    if isinstance(reason, GateEvidence):
+        return reason
+    return GateEvidence(check="unspecified", requirement=str(reason or "").strip())
+
+
+@dataclass(frozen=True)
+class GateAttempt:
+    """One rejected completion attempt, as recorded by the harness."""
+
+    turn: int
+    fingerprint: str
+    payload_digest: str
+    tool_calls: int
+
+    def repeats(self, other: "GateAttempt") -> bool:
+        """True when this attempt carries no information the last one lacked.
+
+        Three things must all hold: the same check failed on the same observed
+        values, the agent submitted the same artifact, and it performed no work
+        in between. Any one of them changing means the attempt is new — an agent
+        that is still moving is not stalled, however many times it has been
+        rejected.
+        """
+        return (
+            self.fingerprint == other.fingerprint
+            and self.payload_digest == other.payload_digest
+            and self.tool_calls == other.tool_calls
+        )
+
+
+def _payload_digest(payload: Any) -> str:
+    return hashlib.sha256(_canonical(payload).encode("utf-8")).hexdigest()
+
+
+def record_attempt(
+    history: list,
+    *,
+    turn: int,
+    evidence: GateEvidence,
+    payload: Any,
+    tool_calls: int,
+) -> Tuple[GateAttempt, int, Optional[GateAttempt]]:
+    """Append this attempt to ``history`` and report how often it has repeated.
+
+    ``history`` is a plain list of dicts so it rides along in ``KernelState`` and
+    survives checkpointing. Returns the attempt, the length of the run of
+    identical attempts ending here (1 when it is new), and the previous attempt
+    if there was one.
+    """
+    attempt = GateAttempt(
+        turn=turn,
+        fingerprint=evidence.fingerprint(),
+        payload_digest=_payload_digest(payload),
+        tool_calls=tool_calls,
+    )
+    prior = [GateAttempt(**entry) for entry in history]
+    streak = 1
+    for earlier in reversed(prior):
+        if attempt.repeats(earlier):
+            streak += 1
+        else:
+            break
+    history.append(attempt.__dict__.copy())
+    return attempt, streak, prior[-1] if prior else None

--- a/jarviscore/kernel/subagent.py
+++ b/jarviscore/kernel/subagent.py
@@ -54,6 +54,7 @@ from typing import Any, Callable, Dict, List, Optional, cast
 from jarviscore.context.truth import AgentOutput
 from jarviscore.kernel.cognition import AgentCognitionManager, ConvergenceGovernor, FailureLedger
 from jarviscore.kernel.epistemic import EpistemicLedger
+from jarviscore.kernel.gate import GateEvidence, as_evidence, record_attempt
 from jarviscore.kernel.state import KernelState, ToolResult
 
 logger = logging.getLogger(__name__)
@@ -269,6 +270,12 @@ class BaseSubAgent(ABC):
     - Convergence detection and failure memory
     - AgentOutput construction
     """
+
+    #: How many times the same completion attempt may be rejected before the step
+    #: ends. An attempt only counts as the same when the gate observed identical
+    #: values, the agent submitted an identical result, and no tool ran in between
+    #: — so an agent that is still working is never cut off, however long it takes.
+    max_identical_done_attempts: int = 3
 
     def __init__(
         self,
@@ -752,16 +759,63 @@ class BaseSubAgent(ABC):
                 # ── Done-gate: subclasses can reject premature completion ──
                 can_exit, reject_reason = self._can_complete(state, parsed)
                 if not can_exit:
-                    self._log.info("Done rejected: %s", reject_reason)
-                    state.add_thought(
-                        f"[DONE_GATE] Cannot complete yet: {reject_reason}. "
-                        f"Continue working."
+                    evidence = as_evidence(reject_reason)
+                    attempts = state.internal_variables.setdefault("done_gate_attempts", [])
+                    _, streak, previous = record_attempt(
+                        attempts,
+                        turn=turn,
+                        evidence=evidence,
+                        payload=parsed.get("result"),
+                        tool_calls=len(state.tool_history),
                     )
+                    self._log.info(
+                        "Done rejected: check=%s attempt=%d", evidence.check, streak,
+                    )
+                    report = evidence.render()
+                    if previous is not None and streak > 1:
+                        report += (
+                            f"\n  unchanged  since turn {previous.turn}: same check, same values, "
+                            f"same result submitted, no tool call in between"
+                        )
+
+                    if streak >= self.max_identical_done_attempts:
+                        # A boundary, not a verdict on the work. The agent has the
+                        # facts and has stopped producing anything new, so another
+                        # turn cannot change the outcome — and an unsatisfied gate
+                        # is not a success to be granted on the way out.
+                        summary = (
+                            f"Completion gate '{evidence.check}' unsatisfied after "
+                            f"{streak} identical attempts"
+                        )
+                        state.status = "failed"
+                        state.add_thought(f"[DONE_GATE] {report}")
+                        trajectory.append({
+                            "turn": turn,
+                            "type": "done_gate_unsatisfied",
+                            "check": evidence.check,
+                            "attempts": streak,
+                        })
+                        _trace.log_step_complete(False, summary)
+                        return AgentOutput(
+                            status="failure",
+                            summary=summary,
+                            payload=state.get_final_output(),
+                            trajectory=trajectory,
+                            metadata={
+                                "tokens": total_tokens, "cost_usd": total_cost,
+                                "typed_outcome": "FAIL_DONE_GATE_UNSATISFIED",
+                                "gate_evidence": evidence.as_dict(),
+                                "gate_attempts": streak,
+                                "cognition": self._cognition.get_budget_summary(),
+                            },
+                        )
+
+                    state.add_thought(f"[DONE_GATE] {report}")
                     conversation_history.append({
                         "assistant": content,
                         "observation": (
-                            f"[Turn {turn}] DONE rejected: {reject_reason}\n"
-                            f"You must address this before calling DONE again."
+                            f"[Turn {turn}] {report}\n"
+                            f"DONE was not recorded. It may be attempted again."
                         ),
                     })
                     # Charge tokens WITHOUT the "done" label: track_usage("done")
@@ -1201,9 +1255,18 @@ class BaseSubAgent(ABC):
     ) -> tuple:
         """Called before accepting a DONE signal — subclass gate point.
 
-        Returns (True, "") to allow completion, or (False, reason) to
-        reject it. On rejection the loop continues — the LLM sees the
-        reason and must address it before calling DONE again.
+        Returns ``(True, "")`` to allow completion, or ``(False, reason)`` to
+        reject it. On rejection the loop continues and the agent sees the reason.
+
+        ``reason`` should be a :class:`~jarviscore.kernel.gate.GateEvidence`:
+        the check that did not hold, what it reads, and what was observed in the
+        agent's own output. A gate that reports a verdict instead ("evidence is
+        required") gives the agent nothing it can act on, so its next attempt is
+        a reworded version of the last one — which is how a rejection turns into
+        a loop. A bare string is still accepted and carried through unchanged.
+
+        Do not advise here. Naming the missing fact is this method's whole job;
+        deciding what to do about it is the agent's.
 
         Default: always allow.
         """

--- a/tests/test_done_gate_evidence.py
+++ b/tests/test_done_gate_evidence.py
@@ -1,0 +1,448 @@
+"""The done gate reports what the agent produced, not a verdict on it (#144).
+
+A rejection that only restates the rule gives an agent nothing to act on, so its
+next attempt is the previous one reworded and the gate becomes a loop. These
+tests hold the gate to evidence, hold the harness to noticing when an attempt
+carries no new information, and hold the boundary that ends a step which cannot
+move rather than letting it burn the lease.
+"""
+
+import asyncio
+from typing import Any, Dict, List, Optional
+
+import pytest
+
+from jarviscore.kernel.gate import (
+    GateAttempt,
+    GateEvidence,
+    as_evidence,
+    record_attempt,
+)
+from jarviscore.kernel.state import KernelState, ToolResult
+from jarviscore.kernel.subagent import BaseSubAgent
+
+
+# ──────────────────────────────────────────────────────────────────
+# Evidence shape
+# ──────────────────────────────────────────────────────────────────
+
+class TestGateEvidence:
+
+    def test_render_names_check_requirement_and_observations(self):
+        rendered = GateEvidence(
+            check="evidence_pointers",
+            requirement="every evidence entry carries a pointer or url",
+            observed={"evidence_count": 3, "bad_evidence": 3},
+        ).render()
+
+        assert "DONE_GATE_UNSATISFIED: evidence_pointers" in rendered
+        assert "every evidence entry carries a pointer or url" in rendered
+        assert "evidence_count" in rendered and "3" in rendered
+        assert "bad_evidence" in rendered
+
+    def test_render_states_facts_not_advice(self):
+        rendered = GateEvidence(
+            check="proof_of_work",
+            requirement="one execute_code call that succeeded",
+            observed={"execute_code_calls": 0},
+        ).render()
+
+        # The gate names what is missing. What to do about it is the agent's call.
+        for coaching in ("you must", "you should", "consider", "try ", "do not"):
+            assert coaching not in rendered.lower()
+
+    def test_empty_observations_render_without_a_table(self):
+        rendered = GateEvidence(check="unspecified", requirement="something").render()
+        assert "observed" not in rendered
+
+    def test_booleans_and_lists_render_readably(self):
+        rendered = GateEvidence(
+            check="c",
+            observed={"summary_present": False, "incomplete_specs": [], "tools": ["a", "b"]},
+        ).render()
+        assert "no" in rendered
+        assert "none" in rendered
+        assert "a, b" in rendered
+
+
+class TestFingerprint:
+
+    def test_same_check_and_observations_fingerprint_alike(self):
+        one = GateEvidence(check="evidence", observed={"evidence_count": 0, "bad": 2})
+        two = GateEvidence(check="evidence", observed={"bad": 2, "evidence_count": 0})
+        assert one.fingerprint() == two.fingerprint()
+
+    def test_progress_changes_the_fingerprint(self):
+        before = GateEvidence(check="evidence_pointers", observed={"bad_evidence": 3})
+        after = GateEvidence(check="evidence_pointers", observed={"bad_evidence": 2})
+        assert before.fingerprint() != after.fingerprint()
+
+    def test_a_different_check_is_a_different_failure(self):
+        one = GateEvidence(check="summary", observed={"n": 1})
+        two = GateEvidence(check="evidence", observed={"n": 1})
+        assert one.fingerprint() != two.fingerprint()
+
+    def test_unserialisable_observations_still_fingerprint(self):
+        evidence = GateEvidence(check="c", observed={"obj": object()})
+        assert len(evidence.fingerprint()) == 64
+
+
+class TestLegacyStringReason:
+    """A gate that returns a bare string is reporting a verdict. Say so."""
+
+    def test_string_is_carried_through_as_unspecified(self):
+        evidence = as_evidence("Research completion requires evidence")
+        assert evidence.check == "unspecified"
+        assert evidence.requirement == "Research completion requires evidence"
+        assert evidence.observed == {}
+
+    def test_evidence_passes_through_untouched(self):
+        original = GateEvidence(check="x", observed={"a": 1})
+        assert as_evidence(original) is original
+
+    def test_empty_reason_is_tolerated(self):
+        assert as_evidence(None).check == "unspecified"
+        assert as_evidence("").requirement == ""
+
+
+# ──────────────────────────────────────────────────────────────────
+# Repetition: what counts as a new attempt
+# ──────────────────────────────────────────────────────────────────
+
+class TestRecordAttempt:
+
+    def _record(self, history, evidence, payload, tool_calls, turn=0):
+        return record_attempt(
+            history, turn=turn, evidence=evidence, payload=payload, tool_calls=tool_calls,
+        )
+
+    def test_first_attempt_is_never_a_repeat(self):
+        history: List[Dict[str, Any]] = []
+        _, streak, previous = self._record(history, GateEvidence(check="c"), {"a": 1}, 2)
+        assert streak == 1
+        assert previous is None
+
+    def test_identical_attempt_counts_as_a_repeat(self):
+        history: List[Dict[str, Any]] = []
+        evidence = GateEvidence(check="c", observed={"n": 0})
+        self._record(history, evidence, {"a": 1}, 2, turn=3)
+        _, streak, previous = self._record(history, evidence, {"a": 1}, 2, turn=4)
+        assert streak == 2
+        assert previous.turn == 3
+
+    def test_a_changed_result_is_a_new_attempt(self):
+        history: List[Dict[str, Any]] = []
+        evidence = GateEvidence(check="c", observed={"n": 0})
+        self._record(history, evidence, {"a": 1}, 2)
+        _, streak, _ = self._record(history, evidence, {"a": 2}, 2)
+        assert streak == 1
+
+    def test_work_done_in_between_is_a_new_attempt(self):
+        """An agent that ran a tool has produced something the gate has not seen."""
+        history: List[Dict[str, Any]] = []
+        evidence = GateEvidence(check="c", observed={"n": 0})
+        self._record(history, evidence, {"a": 1}, 2)
+        _, streak, _ = self._record(history, evidence, {"a": 1}, 3)
+        assert streak == 1
+
+    def test_changed_observations_are_a_new_attempt(self):
+        history: List[Dict[str, Any]] = []
+        self._record(history, GateEvidence(check="c", observed={"n": 3}), {"a": 1}, 2)
+        _, streak, _ = self._record(history, GateEvidence(check="c", observed={"n": 2}), {"a": 1}, 2)
+        assert streak == 1
+
+    def test_streak_resumes_from_zero_after_progress(self):
+        history: List[Dict[str, Any]] = []
+        stuck = GateEvidence(check="c", observed={"n": 0})
+        self._record(history, stuck, {"a": 1}, 2)
+        self._record(history, stuck, {"a": 1}, 2)
+        self._record(history, stuck, {"a": 2}, 2)          # moved
+        _, streak, _ = self._record(history, stuck, {"a": 2}, 2)
+        assert streak == 2
+
+    def test_history_is_plain_data_so_it_survives_checkpointing(self):
+        history: List[Dict[str, Any]] = []
+        self._record(history, GateEvidence(check="c"), {"a": 1}, 2)
+        assert all(isinstance(entry, dict) for entry in history)
+        assert GateAttempt(**history[0]).tool_calls == 2
+
+
+# ──────────────────────────────────────────────────────────────────
+# Harness behaviour
+# ──────────────────────────────────────────────────────────────────
+
+class _ScriptedLLM:
+    """Replays canned assistant turns and records what it was shown."""
+
+    def __init__(self, replies: List[str]):
+        self._replies = list(replies)
+        self.seen: List[List[Dict[str, str]]] = []
+
+    async def generate(self, messages=None, **kwargs):
+        self.seen.append(list(messages or []))
+        reply = self._replies.pop(0) if self._replies else self._replies_last()
+        return {"content": reply, "tokens": {"input": 1, "output": 1, "total": 2}, "cost_usd": 0.0}
+
+    def _replies_last(self):
+        return "THOUGHT: again\nDONE: done\nRESULT: {\"a\": 1}"
+
+
+class _GatedAgent(BaseSubAgent):
+    """Rejects every completion with a fixed piece of evidence."""
+
+    def __init__(self, llm, evidence=None):
+        self.rejections = 0
+        self._evidence = evidence or GateEvidence(
+            check="evidence",
+            requirement="at least one evidence entry",
+            observed={"evidence_count": 0},
+        )
+        super().__init__(agent_id="gated", role="researcher", llm_client=llm)
+
+    def get_system_prompt(self, *args, **kwargs) -> str:
+        return "system"
+
+    def setup_tools(self) -> None:
+        return None
+
+    def _can_complete(self, state, parsed):
+        self.rejections += 1
+        return False, self._evidence
+
+
+def _done(result: str = '{"a": 1}') -> str:
+    return f"THOUGHT: finishing\nDONE: summary\nRESULT: {result}"
+
+
+def _observations(llm: _ScriptedLLM) -> List[str]:
+    return [
+        message["content"]
+        for exchange in llm.seen
+        for message in exchange
+        if message["role"] == "user"
+    ]
+
+
+class TestRejectionReachesTheAgent:
+
+    def test_the_agent_is_shown_the_evidence(self):
+        llm = _ScriptedLLM([_done(), _done('{"a": 2}')])
+        agent = _GatedAgent(llm)
+
+        asyncio.run(agent.run(task="t", max_turns=2))
+
+        shown = "\n".join(_observations(llm))
+        assert "DONE_GATE_UNSATISFIED: evidence" in shown
+        assert "evidence_count" in shown
+
+    def test_a_repeat_is_reported_as_unchanged(self):
+        llm = _ScriptedLLM([_done(), _done(), _done()])
+        agent = _GatedAgent(llm)
+
+        asyncio.run(agent.run(task="t", max_turns=3))
+
+        shown = "\n".join(_observations(llm))
+        assert "unchanged" in shown
+
+    def test_a_first_rejection_is_not_reported_as_unchanged(self):
+        llm = _ScriptedLLM([_done(), "THOUGHT: t\nTOOL: nope\nPARAMS: {}"])
+        agent = _GatedAgent(llm)
+
+        asyncio.run(agent.run(task="t", max_turns=2))
+
+        assert "unchanged" not in "\n".join(_observations(llm))
+
+
+class TestTerminalBoundary:
+
+    def test_identical_attempts_end_the_step_rather_than_the_lease(self):
+        llm = _ScriptedLLM([_done()] * 12)
+        agent = _GatedAgent(llm)
+
+        result = asyncio.run(agent.run(task="t", max_turns=12))
+
+        assert result.status == "failure"
+        assert result.metadata["typed_outcome"] == "FAIL_DONE_GATE_UNSATISFIED"
+        assert agent.rejections == BaseSubAgent.max_identical_done_attempts
+
+    def test_the_failure_carries_the_evidence(self):
+        llm = _ScriptedLLM([_done()] * 12)
+        agent = _GatedAgent(llm)
+
+        result = asyncio.run(agent.run(task="t", max_turns=12))
+
+        assert result.metadata["gate_evidence"]["check"] == "evidence"
+        assert result.metadata["gate_evidence"]["observed"] == {"evidence_count": 0}
+        assert "evidence" in result.summary
+
+    def test_an_agent_that_keeps_changing_its_answer_is_not_cut_off(self):
+        """Movement is not a stall, however many rejections it takes."""
+        llm = _ScriptedLLM([_done(f'{{"a": {n}}}') for n in range(8)])
+        agent = _GatedAgent(llm)
+
+        result = asyncio.run(agent.run(task="t", max_turns=8))
+
+        assert result.metadata.get("typed_outcome") != "FAIL_DONE_GATE_UNSATISFIED"
+        assert agent.rejections == 8
+
+    def test_the_boundary_is_configurable_per_agent(self):
+        class _Patient(_GatedAgent):
+            max_identical_done_attempts = 5
+
+        llm = _ScriptedLLM([_done()] * 12)
+        agent = _Patient(llm)
+
+        asyncio.run(agent.run(task="t", max_turns=12))
+
+        assert agent.rejections == 5
+
+    def test_a_legacy_string_gate_still_terminates(self):
+        class _Verdict(_GatedAgent):
+            def _can_complete(self, state, parsed):
+                self.rejections += 1
+                return False, "evidence is required"
+
+        llm = _ScriptedLLM([_done()] * 12)
+        agent = _Verdict(llm)
+        result = asyncio.run(agent.run(task="t", max_turns=12))
+
+        assert result.metadata["typed_outcome"] == "FAIL_DONE_GATE_UNSATISFIED"
+        assert result.metadata["gate_evidence"]["check"] == "unspecified"
+
+
+class TestAttemptLedger:
+
+    def test_attempts_are_recorded_on_state(self):
+        llm = _ScriptedLLM([_done()] * 12)
+        agent = _GatedAgent(llm)
+
+        asyncio.run(agent.run(task="t", max_turns=12))
+
+        recorded = agent._current_state.internal_variables["done_gate_attempts"]
+        assert len(recorded) == BaseSubAgent.max_identical_done_attempts
+        assert {entry["fingerprint"] for entry in recorded} == {
+            GateEvidence(
+                check="evidence",
+                requirement="at least one evidence entry",
+                observed={"evidence_count": 0},
+            ).fingerprint()
+        }
+
+
+# ──────────────────────────────────────────────────────────────────
+# The default agents report facts
+# ──────────────────────────────────────────────────────────────────
+
+def _state(**overrides) -> KernelState:
+    defaults = {"workflow_id": "w", "step_id": "s", "agent_id": "a", "task": "t"}
+    defaults.update(overrides)
+    return KernelState(**defaults)
+
+
+class TestResearcherGate:
+
+    def _researcher(self):
+        from jarviscore.kernel.defaults.researcher import ResearcherSubAgent
+        return ResearcherSubAgent.__new__(ResearcherSubAgent)
+
+    def test_no_research_reports_what_was_run(self):
+        ok, evidence = self._researcher()._can_complete(_state(), {"result": {}})
+
+        assert ok is False
+        assert evidence.check == "research_performed"
+        assert evidence.observed["tool_calls"] == 0
+        assert evidence.observed["content_tool_successes"] == 0
+
+    def test_no_evidence_at_all_is_counted(self, monkeypatch):
+        monkeypatch.setenv("RESEARCH_STRICT_DONE_VALIDATION", "true")
+        state = _state(tool_history=[
+            ToolResult(tool_name="read_web_content", status="success", tool_output="x"),
+        ])
+        parsed = {"result": {"summary": "s", "evidence": [{"text": "a"}, {"text": "b"}]}}
+
+        ok, evidence = self._researcher()._can_complete(state, parsed)
+
+        assert ok is False
+        assert evidence.check == "evidence"
+        assert evidence.observed["evidence_count"] == 0
+        assert evidence.observed["bad_evidence"] == 2
+
+    def test_missing_pointers_are_counted_not_described(self, monkeypatch):
+        monkeypatch.setenv("RESEARCH_STRICT_DONE_VALIDATION", "true")
+        state = _state(tool_history=[
+            ToolResult(tool_name="read_web_content", status="success", tool_output="x"),
+        ])
+        parsed = {"result": {
+            "summary": "s",
+            "evidence": [{"pointer": "http://x"}, {"text": "b"}],
+        }}
+
+        ok, evidence = self._researcher()._can_complete(state, parsed)
+
+        assert ok is False
+        assert evidence.check == "evidence_pointers"
+        assert evidence.observed["evidence_count"] == 1
+        assert evidence.observed["bad_evidence"] == 1
+        assert evidence.observed["content_tool_successes"] == 1
+
+    def test_a_satisfied_gate_says_nothing(self, monkeypatch):
+        monkeypatch.setenv("RESEARCH_STRICT_DONE_VALIDATION", "true")
+        state = _state(tool_history=[
+            ToolResult(tool_name="read_web_content", status="success", tool_output="x"),
+        ])
+        parsed = {"result": {"summary": "s", "evidence": [{"pointer": "http://x"}]}}
+
+        ok, reason = self._researcher()._can_complete(state, parsed)
+
+        assert ok is True
+        assert reason == ""
+
+    def test_progress_moves_the_fingerprint(self, monkeypatch):
+        monkeypatch.setenv("RESEARCH_STRICT_DONE_VALIDATION", "true")
+        state = _state(tool_history=[
+            ToolResult(tool_name="read_web_content", status="success", tool_output="x"),
+        ])
+        researcher = self._researcher()
+
+        _, before = researcher._can_complete(
+            state, {"result": {"summary": "s", "evidence": [{"t": "a"}, {"t": "b"}]}},
+        )
+        _, after = researcher._can_complete(
+            state, {"result": {"summary": "s", "evidence": [{"pointer": "u"}, {"t": "b"}]}},
+        )
+
+        assert before.fingerprint() != after.fingerprint()
+
+
+class TestCoderGate:
+
+    def _coder(self):
+        from jarviscore.kernel.defaults.coder import CoderSubAgent
+        return CoderSubAgent.__new__(CoderSubAgent)
+
+    def test_unproven_work_reports_the_calls_that_were_made(self):
+        state = _state(tool_history=[
+            ToolResult(tool_name="write_code", status="failure", error="boom"),
+            ToolResult(tool_name="check_registry", status="success", tool_output={}),
+        ])
+
+        ok, evidence = self._coder()._can_complete(state, {"result": "42"})
+
+        assert ok is False
+        assert evidence.check == "proof_of_work"
+        assert evidence.observed["write_code_calls"] == 1
+        assert evidence.observed["execute_code_calls"] == 0
+        assert evidence.observed["successful_executions"] == 0
+        assert evidence.observed["tool_calls"] == 2
+
+    def test_a_successful_execution_satisfies_the_gate(self):
+        state = _state(tool_history=[
+            ToolResult(tool_name="execute_code", status="success", tool_output={"output": 42}),
+        ])
+        parsed: Dict[str, Any] = {"result": None}
+
+        ok, reason = self._coder()._can_complete(state, parsed)
+
+        assert ok is True
+        assert reason == ""
+        assert parsed["result"] == 42

--- a/tests/test_kernel.py
+++ b/tests/test_kernel.py
@@ -287,11 +287,12 @@ class TestKernelExecuteFailure:
             max_dispatches=2,
             agent_default_role="coder",
         )
-        assert output.status == "yield"
-        # A rejected DONE no longer marks the agent done and kills it next turn
-        # (issue #139); an agent that can never satisfy proof-of-work now runs
-        # to the emergency turn fuse, which is the honest outcome.
-        assert output.metadata["typed_outcome"] == "YIELD_EMERGENCY_TURN_FUSE"
+        assert output.status == "failure"
+        # An agent that resubmits the same rejected result without doing any work
+        # in between cannot converge, so each dispatch ends on the gate that
+        # stopped it instead of burning the turn fuse first (#144). The kernel
+        # then reports the honest workflow-level outcome.
+        assert output.metadata["typed_outcome"] == "FAIL_ALL_DISPATCHES_EXHAUSTED"
 
     @pytest.mark.asyncio
     async def test_failure_then_success(self, kernel, mock_llm):

--- a/tests/test_ooda_hooks.py
+++ b/tests/test_ooda_hooks.py
@@ -36,6 +36,38 @@ def _make_state(**overrides):
     return KernelState(**defaults)
 
 
+def _done_reply(result: str = '{"a": 1}') -> str:
+    return f"THOUGHT: finishing\nDONE: summary\nRESULT: {result}"
+
+
+class _ReplayLLM:
+    def __init__(self, replies):
+        self._replies = list(replies)
+
+    async def generate(self, messages=None, **kwargs):
+        reply = self._replies.pop(0) if self._replies else _done_reply()
+        return {"content": reply, "tokens": {"input": 1, "output": 1, "total": 2}, "cost_usd": 0.0}
+
+
+class _RunnableAgent(BaseSubAgent):
+    """Minimal agent whose done-gate verdict is supplied per test."""
+
+    def __init__(self, replies, gate):
+        self._gate = gate
+        self.gate_calls = 0
+        super().__init__(agent_id="hooks", role="tester", llm_client=_ReplayLLM(replies))
+
+    def get_system_prompt(self, *args, **kwargs) -> str:
+        return "system"
+
+    def setup_tools(self) -> None:
+        return None
+
+    def _can_complete(self, state, parsed):
+        self.gate_calls += 1
+        return self._gate()
+
+
 # ──────────────────────────────────────────────────────────────────
 # 1. State-Driven Exit Tests
 # ──────────────────────────────────────────────────────────────────
@@ -168,32 +200,32 @@ class TestDoneGate:
         assert "parsed" in params
 
     def test_done_gate_called_before_exit(self):
-        """_can_complete must be called BEFORE setting state.status = 'completed'."""
-        source = inspect.getsource(BaseSubAgent.run)
-        # Find the DONE handler block
-        done_idx = source.index("Handle DONE")
-        done_block = source[done_idx:done_idx + 2000]
-        gate_pos = done_block.index("_can_complete")
-        completed_pos = done_block.index("state.status = \"completed\"")
-        assert gate_pos < completed_pos
+        """A rejected DONE must not complete the step."""
+        agent = _RunnableAgent([_done_reply()], gate=lambda: (False, "not yet"))
+
+        result = asyncio.run(agent.run(task="t", max_turns=1))
+
+        assert agent.gate_calls == 1
+        assert result.status != "success"
+        assert agent._current_state.status != "completed"
 
     def test_rejection_injects_thought(self):
-        """On rejection, a [DONE_GATE] thought should be injected."""
-        source = inspect.getsource(BaseSubAgent.run)
-        done_idx = source.index("Handle DONE")
-        done_block = source[done_idx:done_idx + 2000]
-        assert "DONE_GATE" in done_block
-        assert "Continue working" in done_block
+        """On rejection, a [DONE_GATE] thought is recorded on the state."""
+        agent = _RunnableAgent([_done_reply()], gate=lambda: (False, "not yet"))
+
+        asyncio.run(agent.run(task="t", max_turns=1))
+
+        assert any("[DONE_GATE]" in thought for thought in agent._current_state.thoughts)
 
     def test_rejection_continues_loop(self):
-        """On rejection, the loop should continue (not exit)."""
-        source = inspect.getsource(BaseSubAgent.run)
-        done_idx = source.index("Handle DONE")
-        # Find the not can_exit block
-        block = source[done_idx:done_idx + 2000]
-        gate_idx = block.index("_can_complete")
-        after_gate = block[gate_idx:gate_idx + 1200]
-        assert "continue" in after_gate
+        """A rejection continues the loop; a later DONE still completes."""
+        gates = iter([(False, "not yet"), (True, "")])
+        agent = _RunnableAgent([_done_reply(), _done_reply()], gate=lambda: next(gates))
+
+        result = asyncio.run(agent.run(task="t", max_turns=2))
+
+        assert agent.gate_calls == 2
+        assert result.status == "success"
 
 
 # ──────────────────────────────────────────────────────────────────
@@ -240,11 +272,15 @@ class TestResearcherHookIntegration:
         assert "PHASE_TOOL_CONTRACT_VIOLATION" in source
 
     def test_researcher_can_complete_checks_evidence(self):
-        """The researcher's _can_complete checks for meaningful research."""
+        """The researcher rejects a DONE with no research behind it."""
         from jarviscore.kernel.defaults.researcher import ResearcherSubAgent
-        source = inspect.getsource(ResearcherSubAgent._can_complete)
-        assert "meaningful_research" in source
-        assert "read_web_content" in source
+        researcher = ResearcherSubAgent.__new__(ResearcherSubAgent)
+
+        ok, evidence = researcher._can_complete(_make_state(), {"result": {}})
+
+        assert ok is False
+        assert evidence.check == "research_performed"
+        assert "read_web_content" in evidence.observed["content_tools"]
 
 
 # ──────────────────────────────────────────────────────────────────


### PR DESCRIPTION
A researcher agent called DONE, was rejected, tried again with substantially the same state, and repeated that eight times before the gate finally let it through. The step ended `success`, having spent most of its lease arguing with a checker.

## The rejection was a verdict

What reached the agent was:

```
DONE rejected: DONE_VALIDATION_FAILED: evidence is required
You must address this before calling DONE again.
```

That is the rule restated in the checker's own vocabulary. The agent cannot map it onto anything it actually produced, so its next attempt is a guess — usually the last attempt reworded. And the observation was **byte-identical every time**: no counts, no state, no history. There was no mechanism by which attempt 2 could differ from attempt 1. The loop wasn't the agent failing to learn; it was the only behaviour the contract permitted.

The one signal that did fire made it worse. At attempt 8 the convergence governor said:

> You have called 'continue_after_done_gate' 8 times consecutively… Consider: (1) trying a different tool, (2) adjusting your parameters, or (3) synthesizing the results you already have.

To an agent whose actual problem was three evidence dicts missing a `pointer` key.

## The facts already existed

`_validate_done_payload` computes a full report on every call — `summary_present`, `evidence_count`, `bad_evidence`, `bad_api_specs`, `incomplete_specs`, `finding_fallback`. Every fact the agent needed. Then:

```python
valid, reason, _ = self._validate_done_payload(state, params)
```

The report went into `_`. The coder gate was worse: three lines of instruction and zero facts about what the agent had done.

## What a gate reports now

Which named check did not hold, what it reads, and what it observed in the agent's own output:

```
DONE_GATE_UNSATISFIED: evidence_pointers
  requires  every evidence entry carries a pointer or url
  observed
    summary_present         yes
    evidence_count          1
    bad_evidence            1
    content_tool_successes  3
```

Counts move only when the work moves, so this is something the agent can act on and cannot satisfy by rewording. It also gives nothing to optimise against except the work itself — hand an agent a critique and you teach it to satisfy the checker; hand it facts about its own output and there is nothing else to aim at.

The gate does not advise. Naming the missing fact is its job; deciding what to do about it is the agent's. Anything more would make the boundary into a decision-maker, which is the thing the harness doctrine exists to prevent.

## Repetition is a fact too

The harness records each rejected attempt and recognises one that carries no new information — **the same check failing on the same values, the same result submitted, and no tool run in between**. All three must hold. It reports it:

```
  unchanged  since turn 4: same check, same values, same result submitted, no tool call in between
```

Which is itself a fact the agent did not previously have.

This dissolves question 2 in the issue. An escalation ladder is only needed because the message was static; once each rejection carries current values, attempt 2 differs from attempt 1 by construction.

## The boundary (question 3)

Evidence cannot manufacture a pointer that doesn't exist, so a task whose sources legitimately dry up could still loop until lease exhaustion.

After `max_identical_done_attempts` (default 3, a class attribute) the step ends on the gate that stopped it, carrying the evidence, as `FAIL_DONE_GATE_UNSATISFIED`. Not a success it did not earn, and not "out of turns" — which is what the emergency fuse used to report, hiding the actual reason.

The safety of this rests entirely on the definition of "identical". **An agent that is still changing its output is never cut off, however many rejections it takes** — movement is not a stall. The run in this issue succeeded on attempt 9, and a cruder "stop after N" rule would have converted that into a failure; the no-new-information condition is what makes the boundary safe.

## Deliberately not done

The convergence governor is untouched. Suppressing its generic coaching while a specific gate signal is live would mean calling `reset_streaks()`, which also clears unrelated tool-spinning detection and could mask a real stall. With rejections now carrying facts, the loop should not reach the intervention threshold in the first place.

## Compatibility

`_can_complete` keeps its `(bool, reason)` signature. A gate returning a bare string is reporting a verdict with no observations behind it, and is carried through as exactly that — named `unspecified` rather than dressed up as evidence it did not supply. Existing subclasses keep working, including the terminal boundary.

## Tests

Two DONE-gate tests asserted on the *text* of `run()`'s source (`assert "Continue working" in done_block`) rather than its behaviour, so they broke on contact with any rewrite. They now drive the loop and assert what it does.

`test_all_dispatches_fail` encoded the old outcome explicitly — *"an agent that can never satisfy proof-of-work now runs to the emergency turn fuse, which is the honest outcome"*. That is the behaviour this change exists to remove. Each dispatch now ends in 3 turns on the gate, and the kernel reaches its honest `FAIL_ALL_DISPATCHES_EXHAUSTED` instead of two full turn fuses.

## Verification

`tests/test_done_gate_evidence.py` — **34 new tests**: evidence rendering and fingerprint stability, the three-part identity of a repeated attempt, streak resumption after progress, legacy string gates, the terminal boundary and its per-agent override, and the researcher and coder gates reporting real counts.

Full suite: **1517 passed, 38 failed**, failure set diffed **identical** to `main` (1485 passed, 38 failed) — the pre-existing P2P / fanout / import-hygiene suites needing extras not installed here. Two additional skips versus `main` are `test_llm_fallback.py` Azure/provider checks, which skip in any worktree because only the primary checkout carries a `.env`.

Closes #144
