### PR TITLE
chore(release): 1.7.0

### DIFF
--- a/jarviscore/docs/changelog.md
+++ b/jarviscore/docs/changelog.md
@@ -24,6 +24,72 @@ All notable changes to JarvisCore Framework are documented here. This project fo
 
 <div class="changelog-release" markdown>
 
+## 1.7.0 <span class="changelog-date">2026-09-06</span>
+
+**Fixed**
+
+- A rejected `DONE` now tells the agent what it produced instead of what rule it
+  broke (#144). The gate returned a verdict in its own vocabulary —
+  `DONE_VALIDATION_FAILED: evidence is required` — and the observation was
+  identical on every attempt, so nothing in the agent's input changed between the
+  first rejection and the eighth. The facts already existed:
+  `_validate_done_payload` computes `evidence_count`, `bad_evidence`,
+  `bad_api_specs` and `incomplete_specs` on every call, and the report was
+  discarded to return a sentence. A gate now names the check that did not hold,
+  what it reads, and what it observed. The harness recognises an attempt that
+  carries no new information — same check failing on the same values, same result
+  submitted, no tool run in between — reports that too, and ends the step after
+  `max_identical_done_attempts` (default 3) of them rather than spending the
+  remaining lease re-submitting a rejected artifact. An agent that is still
+  changing its output is never cut off.
+- `single_response` can no longer report an unfinished completion as success
+  (#148). A truncated answer, a refusal, a content-filter block and a completed
+  answer were indistinguishable to the caller, because the provider's finish
+  reason was discarded by every adapter before the profile could read it. Native
+  reasons and completion metadata now travel with the response, and success
+  requires a terminal reason. A missing reason stays `None` — a generation that
+  stops short of the cap is not evidence that it finished, and inferring one
+  would manufacture the confidence this removes. Gemini output tokens now include
+  `thoughts_token_count`, thought parts are excluded from content, and
+  `execution_contract.max_output_tokens` is honoured instead of ignored.
+- Search no longer cancels healthy grounded requests (#147). Every provider ran
+  under one hard six-second deadline, so Gemini grounded search — a generative
+  call — was routinely cut off and the run lost its highest-weight provider
+  without saying so. Deadlines are now per provider (45s grounded, 15s otherwise)
+  and configurable; a failing provider is named in the log with its error type
+  and the deadline it exceeded, instead of an anonymous "Search provider failed".
+- Docs and the packaged skill report the installed atom catalog rather than a
+  count that was true when the page was written (#149).
+
+**Added**
+
+- `jarviscore.kernel.gate`: `GateEvidence` for reporting a completion failure as
+  the check that did not hold plus what was observed, and the attempt ledger the
+  harness uses to recognise a repeat.
+- Per-provider search deadlines via `RESEARCH_GROUNDED_TIMEOUT_SECONDS` and
+  `RESEARCH_SEARCH_TIMEOUT_SECONDS`, or constructor arguments on either public
+  `InternetSearch` client.
+- `finish_reason` and `provider_metadata` on every LLM response.
+
+**Behaviour changes to know about (compatible, but read this)**
+
+- **A step can now end on an unsatisfied completion gate.** `_can_complete` keeps
+  its `(bool, reason)` signature and a bare string is still accepted — carried
+  through as a verdict with no observations behind it — but a gate that rejects
+  the same unchanged attempt three times ends the step as
+  `FAIL_DONE_GATE_UNSATISFIED` instead of running to the emergency turn fuse. The
+  outcome names the gate rather than reporting "out of turns".
+- **A single-response turn that used to succeed may now fail.** Truncated,
+  refused and filtered completions are reported as failures that name their cause.
+  They were already failures; they were being reported as successes.
+- **Grounded search takes longer before giving up.** The default grounded
+  deadline is 45s. A run that previously lost that provider at six seconds will
+  now wait for it, and return better evidence for the wait.
+
+</div>
+
+<div class="changelog-release" markdown>
+
 ## 1.6.0 <span class="changelog-date">2026-09-06</span>
 
 **Added**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "jarviscore-framework"
-version = "1.6.0"
+version = "1.7.0"
 description = "Orchestrate multi-agent systems with peer-to-peer coordination, unified memory, and built-in auth."
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
Release **1.7.0**, shipping #144, #147, #148 and #149 (all merged to `main`).

## Why MINOR

New public API surface plus backward-compatible behavioural changes:

- `jarviscore.kernel.gate` — `GateEvidence` and the attempt ledger
- Per-provider search deadline configuration on both public `InternetSearch` clients
- `finish_reason` and `provider_metadata` on every LLM response

Nothing public was removed. `_can_complete` keeps its `(bool, reason)` signature and still accepts a bare string, carried through as a verdict with no observations behind it.

Not MAJOR: no public API breaks. Not PATCH: behaviour changes beyond bug fixes, and three of the four add surface.

## The theme, since it's worth naming

Three of these four are the same failure wearing different clothes — **a result that was not earned, reported as though it were.**

A `single_response` turn truncated mid-sentence returned `success`. A `DONE` the gate refused was answered with the rule restated rather than the facts behind it, so the agent could not see what it had actually produced and re-submitted it eight times. A grounded search cancelled at six seconds returned whatever the fallbacks found and said nothing about the provider it dropped.

Same species as 1.6.0's #150 and #153. We keep finding it because it is the failure mode of a system that reports conclusions instead of evidence.

## Behaviour worth reading before upgrading

- **A step can end on an unsatisfied completion gate.** Three identical rejected attempts now end the step as `FAIL_DONE_GATE_UNSATISFIED` rather than running to the emergency turn fuse. An agent still changing its output is never cut off.
- **A single-response turn that used to succeed may now fail.** Truncated, refused and filtered completions are reported as failures that name their cause. They were always failures — they were being reported as successes.
- **Grounded search takes longer before giving up.** Default grounded deadline is 45s, up from a shared 6s.

## Verification

Full suite on `main` after all four merges: **1672 passed, 38 failed**. Failure set diffed line-for-line against `main` at v1.6.0 (1485 passed, 38 failed) — **identical**. The 38 are the pre-existing P2P / fanout / import-hygiene suites needing extras that are not installed on this machine.

CI on this repository runs CodeQL only, so the test evidence above is local. Worth fixing separately — #163 touched every provider path in the framework and nothing on GitHub would have caught the recursion bug that surfaced there.

## After merge

Tag `v1.7.0` and cut the GitHub release; the PyPI publish workflow is `workflow_dispatch` only and waits on its reviewer.
