### PR TITLE
ci: run the test suite on pull requests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,45 @@
+name: Tests
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: tests-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  pytest:
+    name: pytest (Python ${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    # A hung test is the failure mode this job exists to catch: the recursion bug
+    # in #163 showed up as a suite that ran for minutes before it ever errored.
+    timeout-minutes: 20
+
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11", "3.12"]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+          cache-dependency-path: pyproject.toml
+
+      - name: Install package and test dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev]"
+
+      - name: Run test suite
+        run: pytest tests -q

--- a/jarviscore/cli/atom.py
+++ b/jarviscore/cli/atom.py
@@ -434,7 +434,8 @@ def cmd_test(args):
         if not bundles:
             print(_info("No atom bundles found in integrations/atoms/"))
             sys.exit(0)
-        print(f"{_info(f'Testing {len(bundles)} bundle(s): {', '.join(bundles)}')}")
+        names = ", ".join(bundles)
+        print(_info(f"Testing {len(bundles)} bundle(s): {names}"))
         all_passed = True
         for bundle in bundles:
             atoms = _get_atoms_for_bundle(bundle)
@@ -465,7 +466,7 @@ def cmd_test(args):
         print(_err(f"No atoms found in bundle '{bundle}'"))
         sys.exit(1)
 
-    print(f"{_info(f'Bundle: {bundle}  |  Atoms: {len(atoms)}')}")
+    print(_info(f"Bundle: {bundle}  |  Atoms: {len(atoms)}"))
     all_passed = True
 
     for atom in atoms:
@@ -516,7 +517,7 @@ def cmd_list(args):
             print(f"    {_dim('·')} {atom}")
         print()
 
-    print(f"{_dim(f'{len(bundles)} bundles  ·  {total_atoms} atoms total')}")
+    print(_dim(f"{len(bundles)} bundles  ·  {total_atoms} atoms total"))
 
 
 # ── Main ──────────────────────────────────────────────────────────────────────

--- a/jarviscore/profiles/agent_profile.py
+++ b/jarviscore/profiles/agent_profile.py
@@ -102,11 +102,14 @@ class AgentProfile:
             return None
 
         try:
-            import yaml  # PyYAML — already in most envs, graceful fallback otherwise
-        except ImportError:
-            logger.warning("[AgentProfile] PyYAML not installed — agent profiles disabled. "
-                           "Install with: pip install pyyaml")
-            return None
+            import yaml
+        except ImportError as exc:  # pragma: no cover - a declared dependency is missing
+            raise RuntimeError(
+                f"A profile exists at {yaml_path} but PyYAML is not importable, so it "
+                "cannot be read. PyYAML is a declared dependency of "
+                "jarviscore-framework; reinstall the package. Running without the "
+                "profile would drop the agent's role intelligence silently."
+            ) from exc
 
         try:
             with open(yaml_path, "r", encoding="utf-8") as f:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,9 @@ dependencies = [
     "aiohttp>=3.9.0",
     "certifi",
 
+    # Agent profiles ship as YAML and are read on every AutoAgent load.
+    "pyyaml>=6.0",
+
     # LLM Providers — the engine. Always available, zero-config.
     # Developer picks which provider to use via env vars, not pip extras.
     "openai>=1.0.0",
@@ -93,7 +96,7 @@ full = [
     "jarviscore-framework[p2p,web,redis,prometheus,azure,browser,rag,research,memory-athena]",
 ]
 dev = [
-    "jarviscore-framework[p2p,web,redis]",
+    "jarviscore-framework[p2p,web,redis,prometheus]",
     "pytest>=7.4.0",
     "pytest-asyncio>=0.21.0",
     "pytest-cov>=4.1.0",

--- a/tests/test_14_cloud_deployment.py
+++ b/tests/test_14_cloud_deployment.py
@@ -267,7 +267,7 @@ class TestAgentJoinLeaveMesh:
         os.environ.pop("JARVISCORE_SEED_NODES", None)
 
         with pytest.raises(ValueError) as exc_info:
-            asyncio.get_event_loop().run_until_complete(agent.join_mesh())
+            asyncio.run(agent.join_mesh())
 
         assert "JARVISCORE_MESH_ENDPOINT" in str(exc_info.value)
 

--- a/tests/test_fanout.py
+++ b/tests/test_fanout.py
@@ -245,7 +245,7 @@ class TestAggregation:
 
     def test_run_fanout_validates_inputs(self):
         with pytest.raises(ValueError, match="concurrency"):
-            asyncio.get_event_loop().run_until_complete(
+            asyncio.run(
                 run_fanout(
                     fanout_id="f", find_agent=lambda s: None, agent="a",
                     items=[], task="t", concurrency=0,

--- a/tests/test_mesh_phase9.py
+++ b/tests/test_mesh_phase9.py
@@ -15,6 +15,8 @@ What these tests prove:
 - Prometheus server IS started when prometheus_enabled=True in settings
 """
 
+import importlib
+
 import pytest
 from typing import Any, Dict
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -297,8 +299,12 @@ class TestPrometheus:
         mock_settings.storage_backend = "local"
         mock_settings.storage_base_path = "./blob_storage"
 
-        with patch(
-            "jarviscore.config.settings.Settings", return_value=mock_settings
+        # jarviscore.config exports both the `settings` submodule and a `settings`
+        # instance, so a dotted patch target resolves to whichever import ran
+        # last. Patch the module object so the target cannot drift.
+        settings_module = importlib.import_module("jarviscore.config.settings")
+        with patch.object(
+            settings_module, "Settings", return_value=mock_settings
         ), patch(
             "jarviscore.telemetry.metrics.start_prometheus_server"
         ) as mock_start:


### PR DESCRIPTION
The repository had workflows for docs, issue triage and publishing — and none for tests. **CodeQL was the only check a pull request waited on**, which made a green PR look verified when nothing had verified it.

## The concrete cost

#163 carried 87 passing tests of its own and shipped a `RecursionError` in `_metadata_value`, which walked provider objects with no depth or cycle bound. It surfaced as:

```
RuntimeError: All LLM providers failed. Last error: maximum recursion depth exceeded
```

A healthy provider reported as an outage, on the code path every LLM call in the framework takes. It was caught by running the full suite by hand and noticing that `test_llm_fallback.py` — a file the PR did not touch — had gone from 5.57s to minutes. **At that moment the PR was CLEAN and mergeable.**

## The 38 failures were never real

The issue said CI needed a recorded baseline because a stock developer machine fails 38 tests. That turned out to be wrong, and worth stating plainly: the number was carried in someone's head and diffed by hand between branches, and **every one of those failures was a missing dependency**.

- **PyYAML was never declared.** [jarviscore/profiles/agent_profile.py](jarviscore/profiles/agent_profile.py) reads agent profiles from YAML on every AutoAgent load — a shipped feature, on a dependency nobody installed on purpose. The comment read *"already in most envs, graceful fallback otherwise"*, and the fallback was to return `None`: a profile sitting on disk was silently ignored and the agent ran without its role intelligence. That is #91 again, in a different file. PyYAML is now a core dependency, and an unreadable profile raises and names the broken install rather than disappearing.
- **prometheus-client was missing from the `dev` extra** while `test_telemetry.py` tests it. The dev extra should install what the test suite needs.
- **Two tests called `asyncio.get_event_loop().run_until_complete()`** from synchronous test bodies. On 3.12 there is no current loop to find, so they failed with `RuntimeError: There is no current event loop`.

With those fixed:

```
1709 passed, 42 skipped, 1 xfailed in 187s
```

**Zero failures.** So the job can be required rather than advisory, which was the open question in the issue. No baseline to record, no expected-failure list to maintain.

## The workflow

Runs on `pull_request`, on push to `main`, and on manual dispatch.

- **Matrix: 3.10, 3.11, 3.12** — the range `requires-python = ">=3.10"` already claims. Note `publish.yml` builds on 3.11 and local development is on 3.12; nothing was testing 3.10 before this.
- **`timeout-minutes: 20`** — a hung test is precisely the failure mode this job exists to catch. The recursion bug's first symptom was slowness, not an error.
- **`fail-fast: false`** — a 3.10-only failure should not be hidden by a 3.12 failure.
- Concurrency group cancels superseded runs on the same ref.

## For a maintainer

I could not verify 3.10 or 3.11 locally — only 3.12 is installed on this machine. This PR runs its own workflow, so the matrix result on this page is the first real evidence for those two. If 3.10 fails, that is a genuine finding: we currently claim support for it.

Making the check **required for merge** is a branch-protection setting and not something a PR can carry. Worth doing once this is green, otherwise it stays advisory and gets ignored.

Closes #167
