### PR TITLE
fix(planning): the planner and evaluator stop cutting inside a record

### DIFF
--- a/jarviscore/context/fidelity.py
+++ b/jarviscore/context/fidelity.py
@@ -1,0 +1,96 @@
+"""Fitting whole records into a bounded prompt.
+
+Nothing here shortens a value. A character limit applied inside a record decides
+what a reader may know by counting bytes, and the part it removes is simply gone
+— a half payload is not a smaller payload, it is a different one. Planning and
+evaluation are where that costs most: a planner reasons about work that has not
+happened yet, and an evaluator issues a verdict on work that has. Both are
+judging the record they were handed, so handing them a fragment does not make
+them slightly less accurate, it makes them accurate about the wrong thing.
+
+So a budget is spent on whole records, in priority order, and whatever does not
+fit is named rather than halved. Naming matters: a reader told "6 of 41 facts
+are not shown here" knows its picture is partial and can ask for the rest. A
+reader handed a value cut at 200 characters has no idea anything is missing.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Iterable, List, Sequence
+
+__all__ = ["Record", "Selection", "select_whole"]
+
+
+@dataclass(frozen=True)
+class Record:
+    """One indivisible item competing for room in a prompt.
+
+    Attributes:
+        key: How the record is named if it does not fit.
+        text: The rendered record, always used whole or not at all.
+        priority: Lower is kept first. 0 is never shed.
+    """
+
+    key: str
+    text: str
+    priority: int = 1
+
+    @property
+    def cost(self) -> int:
+        return len(self.text)
+
+
+@dataclass
+class Selection:
+    kept: List[Record] = field(default_factory=list)
+    withheld: List[Record] = field(default_factory=list)
+    budget: int = 0
+    required: int = 0
+
+    @property
+    def complete(self) -> bool:
+        return not self.withheld
+
+    def render(self, separator: str = "\n") -> str:
+        return separator.join(record.text for record in self.kept)
+
+    def notice(self, where: str) -> str:
+        """What is missing and where it still lives, in the reader's own prompt."""
+        if self.complete:
+            return ""
+        names = ", ".join(f"`{record.key}`" for record in self.withheld)
+        return (
+            f"{len(self.withheld)} of {len(self.kept) + len(self.withheld)} records are "
+            f"not shown here because the prompt budget could not hold them whole "
+            f"({self.required} of {self.budget} characters at full fidelity): {names}. "
+            f"Nothing shown has been shortened. The full records are unchanged in {where}."
+        )
+
+
+def select_whole(records: Iterable[Record], budget: int) -> Selection:
+    """Spend ``budget`` on whole records, cheapest first within each priority.
+
+    Priority 0 is always kept, even past the budget: a record the caller has
+    declared essential is not something to trade away for room, and silently
+    dropping it would be the same failure as cutting it.
+
+    Cheapest-first within a priority keeps the greatest number of complete
+    records rather than letting one large one crowd out many small ones. What
+    survives is then restored to the caller's order — the reader's prompt should
+    read in the order it was written, not in the order the budget was spent.
+    """
+    ordered = sorted(enumerate(records), key=lambda pair: (pair[1].priority, pair[1].cost))
+    selection = Selection(budget=budget, required=sum(record.cost for _, record in ordered))
+    spent = 0
+    kept: List[tuple] = []
+    withheld: List[tuple] = []
+    for index, record in ordered:
+        if record.priority == 0 or spent + record.cost <= budget:
+            kept.append((index, record))
+            spent += record.cost
+        else:
+            withheld.append((index, record))
+    selection.kept = [record for _, record in sorted(kept)]
+    selection.withheld = [record for _, record in sorted(withheld)]
+    return selection

--- a/jarviscore/planning/evaluator.py
+++ b/jarviscore/planning/evaluator.py
@@ -23,6 +23,7 @@ import json
 import os
 from typing import Any, Optional
 
+from jarviscore.context.fidelity import Record, select_whole
 from .goal_context import GoalExecution, PlannedStep, StepEvaluation
 
 _EVAL_SCHEMA = """\
@@ -57,13 +58,10 @@ additional_findings:
   Return an empty object {} if there is nothing new to add.
   Do NOT duplicate facts already listed in accumulated_goal_facts.
 
-Truncated evidence:
-  Step output may end with a marker like "[truncated: showing N of M chars]".
-  That means the work exists but only part of it is visible to you. If the
-  visible portion satisfies the criterion and ONLY the truncation prevents
-  full verification, return "partial" and note what you could not see.
-  Never return "fail" solely because evidence was clipped — a hidden tail
-  is not a failed step, and "fail" burns a replan cycle on blindness.
+Withheld facts:
+  The accumulated goal facts may end with a note saying some records are not
+  shown. That note concerns the fact list only — the step output above is
+  always complete. Judge the criterion against the output as given.
 """
 
 
@@ -79,8 +77,9 @@ class EvaluatorError(Exception):
 def _honest_clip(text: str, limit: int) -> str:
     """Clip with an explicit marker — never silently (#55/#85).
 
-    Prompt views may be bounded, but a bound the model cannot see poisons
-    the judgment: markers are the floor.
+    Only used on an LLM response that failed to parse, where the text is being
+    quoted back as a diagnostic rather than judged. Evidence is never clipped:
+    see ``_format_output`` (#166).
     """
     if len(text) <= limit:
         return text
@@ -237,11 +236,15 @@ class StepEvaluator:
         goal_execution: GoalExecution,
     ) -> str:
         output_repr = self._format_output(output)
-        facts_limit = int(os.environ.get("EVALUATOR_FACTS_EVIDENCE_LIMIT", "2000"))
-        known = _honest_clip(
-            json.dumps(goal_execution.truth.to_flat_dict(), default=str),
-            facts_limit,
-        )
+        facts = goal_execution.truth.to_flat_dict()
+        records = [
+            Record(key=str(key), text=f"  - {key}: {value}", priority=1)
+            for key, value in facts.items()
+        ]
+        selection = select_whole(records, self._facts_budget())
+        known = selection.render() or "None yet."
+        if not selection.complete:
+            known += f"\n  {selection.notice('the goal truth store')}"
 
         return (
             f"Evaluate whether this agent step met its success criterion.\n\n"
@@ -250,7 +253,7 @@ class StepEvaluator:
             f"Success criterion: {step.success_criterion}\n"
             f"Expected findings: {step.expected_findings}\n\n"
             f"Step output:\n{output_repr}\n\n"
-            f"Accumulated goal facts (do not re-extract these): {known}\n\n"
+            f"Accumulated goal facts (do not re-extract these):\n{known}\n\n"
             f"{_EVAL_SCHEMA}"
         )
 
@@ -295,19 +298,25 @@ class StepEvaluator:
 
         return response.get("content", "") if isinstance(response, dict) else str(response)
 
+    @staticmethod
+    def _facts_budget() -> int:
+        return int(os.environ.get("EVALUATOR_FACTS_BUDGET_CHARS", "40000"))
+
     def _format_output(self, output: Any) -> str:
         """
         Render AgentOutput fields for the evaluation prompt.
         Keeps it focused: status, summary, and payload.
 
-        Evidence windows are generous and tunable, and clipping is announced
-        with an honest marker (issue #85). A blind verdict drives the whole
-        Plan-Execute-Evaluate loop, so a few KB of evidence is cheap next to
-        the replan cycle a false "fail" costs.
-        """
-        summary_limit = int(os.environ.get("EVALUATOR_SUMMARY_EVIDENCE_LIMIT", "2000"))
-        payload_limit = int(os.environ.get("EVALUATOR_PAYLOAD_EVIDENCE_LIMIT", "6000"))
+        The evidence is never cut (#166). A verdict is a judgment about this
+        output, so judging half of it is not a slightly worse judgment, it is a
+        judgment about something else — and a step whose proof of success fell
+        past a character limit gets marked failed, which costs a replan cycle
+        and buries the real result. Whatever the step produced goes in whole.
 
+        EVALUATOR_SUMMARY_EVIDENCE_LIMIT and EVALUATOR_PAYLOAD_EVIDENCE_LIMIT
+        are still read so existing configuration keeps working, but they no
+        longer shorten anything.
+        """
         parts = []
         status = getattr(output, "status", "unknown")
         summary = getattr(output, "summary", None)
@@ -315,13 +324,13 @@ class StepEvaluator:
 
         parts.append(f"status: {status}")
         if summary:
-            parts.append(f"summary: {_honest_clip(summary, summary_limit)}")
+            parts.append(f"summary: {summary}")
         if payload is not None:
             if isinstance(payload, dict):
                 payload_str = json.dumps(payload, default=str)
             else:
                 payload_str = str(payload)
-            parts.append(f"payload: {_honest_clip(payload_str, payload_limit)}")
+            parts.append(f"payload: {payload_str}")
 
         return "\n".join(parts)
 

--- a/jarviscore/planning/planner.py
+++ b/jarviscore/planning/planner.py
@@ -26,9 +26,11 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 import uuid
 from typing import Any, Dict, List, Optional
 
+from jarviscore.context.fidelity import Record, select_whole
 from .goal_context import GoalExecution, PlannedStep
 
 logger = logging.getLogger(__name__)
@@ -121,12 +123,13 @@ class Planner:
 
     Args:
         llm_client:            The LLM client (same instance the Kernel uses).
-        system_prompt_excerpt: First ~400 chars of the agent's system_prompt,
-                               used to give the planner the agent's identity
-                               and domain context.
+        system_prompt:         The agent's full system_prompt, giving the planner
+                               its identity, domain and operating rules.
+                               ``system_prompt_excerpt`` is the former name and
+                               is still accepted.
 
     Usage:
-        planner = Planner(llm_client, system_prompt_excerpt=agent.system_prompt[:400])
+        planner = Planner(llm_client, system_prompt=agent.system_prompt)
 
         # Initial plan
         steps = await planner.plan(goal="Run the weekly market analysis", goal_execution=exec)
@@ -135,32 +138,37 @@ class Planner:
         steps = await planner.replan(goal_execution=exec, failed_step=cs, reason="API timeout")
     """
 
-    def __init__(self, llm_client, system_prompt_excerpt: str = ""):
+    def __init__(self, llm_client, system_prompt: str = "", system_prompt_excerpt: str = ""):
         self.llm = llm_client
-        self._identity = system_prompt_excerpt[:400] if system_prompt_excerpt else ""
+        # Identity is the smallest and most load-bearing thing in the prompt; an
+        # excerpt is the persona without the rules that constrain it (#91).
+        self._identity = str(system_prompt or system_prompt_excerpt or "")
 
     @staticmethod
-    def _clip(value: Any, limit: int) -> str:
-        """Honest cut — a planner working from amputated facts plans wrong."""
-        text = str(value)
-        if len(text) <= limit:
-            return text
-        return f"{text[:limit]}…[truncated: showing {limit} of {len(text)} chars]"
+    def _facts_budget() -> int:
+        return int(os.environ.get("PLANNER_FACTS_BUDGET_CHARS", "40000"))
 
-    def _render_facts(self, facts: Dict[str, Any], limit: int = 20) -> str:
-        """Render known facts one per line with an honest count (#74).
+    @staticmethod
+    def _context_budget() -> int:
+        return int(os.environ.get("PLANNER_CONTEXT_BUDGET_CHARS", "20000"))
 
-        Replaces the old clipped-JSON-blob rendering, which silently cut
-        facts mid-key at 800 chars — lost facts produce wrong plans.
+    def _render_facts(self, facts: Dict[str, Any]) -> str:
+        """Render known facts one per line, whole (#74, #166).
+
+        A fact the planner cannot read is a fact it will plan to go and find
+        again, so a clipped value costs a step. Facts that do not fit are named
+        rather than halved.
         """
         if not facts:
             return "None yet."
-        items = list(facts.items())
-        lines = [f"{len(items)} fact(s) known:"]
-        for key, value in items[:limit]:
-            lines.append(f"  - {key}: {self._clip(value, 200)}")
-        if len(items) > limit:
-            lines.append(f"  …and {len(items) - limit} more facts not shown")
+        records = [
+            Record(key=str(key), text=f"  - {key}: {value}", priority=1)
+            for key, value in facts.items()
+        ]
+        selection = select_whole(records, self._facts_budget())
+        lines = [f"{len(records)} fact(s) known:", selection.render()]
+        if not selection.complete:
+            lines.append(f"  {selection.notice('the goal truth store')}")
         return "\n".join(lines)
 
     async def plan(
@@ -192,7 +200,14 @@ class Planner:
         if context:
             public = {k: v for k, v in context.items() if not str(k).startswith("_")}
             if public:
-                ctx_note = f"\nAvailable context:\n{self._clip(json.dumps(public, default=str), 600)}\n"
+                records = [
+                    Record(key=str(key), text=f"  {key}: {json.dumps(value, default=str)}", priority=1)
+                    for key, value in public.items()
+                ]
+                selection = select_whole(records, self._context_budget())
+                ctx_note = f"\nAvailable context:\n{selection.render()}\n"
+                if not selection.complete:
+                    ctx_note += f"{selection.notice('the workflow context')}\n"
 
         prompt = self._build_initial_prompt(goal, known_str, ctx_note)
         return await self._call_and_parse(prompt, goal)
@@ -230,7 +245,7 @@ class Planner:
             PlannerError: if the LLM call fails or response is unparseable.
         """
         completed_summary = "\n".join(
-            f"  - [{cs.evaluation.verdict.upper()}] {cs.step.step_id}: {self._clip(cs.step.task, 120)}"
+            f"  - [{cs.evaluation.verdict.upper()}] {cs.step.step_id}: {cs.step.task}"
             for cs in goal_execution.completed
         )
 
@@ -240,7 +255,7 @@ class Planner:
         pending_summary = ""
         if pending_steps:
             pending_summary = "\n".join(
-                f"  - {s.step_id}: {self._clip(s.task, 120)}"
+                f"  - {s.step_id}: {s.task}"
                 for s in pending_steps
             )
 

--- a/jarviscore/profiles/autoagent.py
+++ b/jarviscore/profiles/autoagent.py
@@ -869,7 +869,7 @@ class AutoAgent(Profile):
         )
 
         # Shared planner and evaluator — stateless, reused across steps
-        planner = Planner(self.llm, system_prompt_excerpt=str(self.system_prompt or "")[:400])
+        planner = Planner(self.llm, system_prompt=str(self.system_prompt or ""))
         evaluator = StepEvaluator(self.llm)
 
         # ── Resume path (issue #73) ──────────────────────────────────────────────

--- a/tests/test_fidelity.py
+++ b/tests/test_fidelity.py
@@ -1,0 +1,85 @@
+"""Whole records or none — the budget never cuts inside one (#166).
+
+A character limit applied inside a record decides what a reader may know by
+counting bytes. These tests hold the selector to shedding whole records, naming
+what it shed, and keeping what the caller declared essential.
+"""
+
+import pytest
+
+from jarviscore.context.fidelity import Record, select_whole
+
+
+def _records(count: int, size: int, priority: int = 1):
+    return [Record(key=f"r{i}", text="x" * size, priority=priority) for i in range(count)]
+
+
+class TestSelection:
+
+    def test_everything_fits_when_the_budget_is_enough(self):
+        selection = select_whole(_records(5, 10), budget=1000)
+        assert selection.complete
+        assert len(selection.kept) == 5
+        assert selection.notice("the store") == ""
+
+    def test_records_are_shed_whole(self):
+        selection = select_whole(_records(10, 100), budget=350)
+        assert len(selection.kept) == 3
+        assert len(selection.withheld) == 7
+        # Nothing kept is a fragment of anything.
+        assert all(record.text == "x" * 100 for record in selection.kept)
+
+    def test_nothing_is_shortened(self):
+        selection = select_whole([Record(key="big", text="y" * 5000)], budget=100)
+        assert selection.kept == []
+        assert selection.withheld[0].text == "y" * 5000
+
+    def test_priority_zero_survives_a_budget_it_exceeds(self):
+        essential = Record(key="evidence", text="z" * 5000, priority=0)
+        selection = select_whole([essential, *_records(3, 100)], budget=200)
+        assert essential in selection.kept
+        assert "evidence" not in [record.key for record in selection.withheld]
+
+    def test_cheapest_first_keeps_the_most_complete_records(self):
+        records = [
+            Record(key="huge", text="h" * 900),
+            *[Record(key=f"small{i}", text="s" * 100) for i in range(5)],
+        ]
+        selection = select_whole(records, budget=500)
+        assert [record.key for record in selection.kept] == [f"small{i}" for i in range(5)]
+        assert [record.key for record in selection.withheld] == ["huge"]
+
+    def test_kept_records_keep_the_caller_order(self):
+        """A prompt should read in the order it was written."""
+        records = [
+            Record(key="first", text="f" * 300),
+            Record(key="second", text="s" * 10),
+            Record(key="third", text="t" * 10),
+        ]
+        selection = select_whole(records, budget=100)
+        assert [record.key for record in selection.kept] == ["second", "third"]
+
+    def test_empty_input_is_complete(self):
+        selection = select_whole([], budget=100)
+        assert selection.complete
+        assert selection.render() == ""
+
+
+class TestNotice:
+
+    def test_notice_names_what_is_missing_and_where_it_lives(self):
+        selection = select_whole(_records(4, 100), budget=150)
+        notice = selection.notice("the goal truth store")
+
+        assert "3 of 4 records are not shown" in notice
+        assert "`r1`" in notice
+        assert "the goal truth store" in notice
+
+    def test_notice_states_that_nothing_shown_was_shortened(self):
+        notice = select_whole(_records(4, 100), budget=150).notice("the store")
+        assert "Nothing shown has been shortened" in notice
+
+    def test_notice_reports_the_real_cost(self):
+        selection = select_whole(_records(4, 100), budget=150)
+        assert selection.required == 400
+        assert "400 of 150 characters" in selection.notice("the store")

--- a/tests/test_planning.py
+++ b/tests/test_planning.py
@@ -327,34 +327,33 @@ class TestStepEvaluator:
         assert "END-OF-ARTIFACT" in rendered          # the whole artifact is evidence
         assert "[truncated" not in rendered           # nothing silently hidden
 
-    def test_clipped_evidence_is_announced(self):
-        """When evidence must be clipped, the marker is explicit (#55/#85)."""
+    def test_large_evidence_is_never_clipped(self):
+        """#166 — a verdict is about this output, so half of it is a different one."""
         ev = self._evaluator()
         huge = "y" * 10_000
         out = _make_output(summary="s" * 5_000, payload=huge)
         rendered = ev._format_output(out)
-        assert "[truncated: showing 2000 of 5000 chars]" in rendered
-        assert "[truncated: showing 6000 of 10000 chars]" in rendered
+        assert huge in rendered
+        assert "s" * 5_000 in rendered
+        assert "truncated" not in rendered
 
-    def test_evidence_limits_are_tunable(self, monkeypatch):
+    def test_legacy_evidence_limits_no_longer_clip(self, monkeypatch):
+        """The old knobs still import; they no longer shorten the evidence."""
         monkeypatch.setenv("EVALUATOR_PAYLOAD_EVIDENCE_LIMIT", "50")
         ev = self._evaluator()
         out = _make_output(payload="z" * 100)
         rendered = ev._format_output(out)
-        assert "[truncated: showing 50 of 100 chars]" in rendered
+        assert "z" * 100 in rendered
+        assert "truncated" not in rendered
 
-    def test_schema_teaches_truncation_semantics(self):
-        """The verdict contract says clipped evidence is partial, never fail."""
+    def test_schema_no_longer_teaches_around_truncated_evidence(self):
+        """The prompt patch retires with the truncation it was covering for."""
         from jarviscore.planning.evaluator import _EVAL_SCHEMA
-        assert "Truncated evidence" in _EVAL_SCHEMA
-        assert "Never return \"fail\" solely because evidence was clipped" in _EVAL_SCHEMA
+        assert "Truncated evidence" not in _EVAL_SCHEMA
+        assert "the step output above is" in _EVAL_SCHEMA
 
-    def test_accumulated_facts_never_clipped_silently(self):
-        """The facts block in the prompt clips with a marker, not silently (#55/#85).
-
-        Regression: the prompt told the model 'do not re-extract these' while
-        silently hiding everything past 500 chars.
-        """
+    def test_accumulated_facts_are_whole_or_named(self):
+        """#166 — the prompt says 'do not re-extract these', so they must be readable."""
         from jarviscore.context.truth import TruthFact
         ev = self._evaluator()
         ge = GoalExecution(goal="G", agent_id="a")
@@ -364,9 +363,22 @@ class TestStepEvaluator:
             )
         prompt = ev._build_prompt(_make_step(), _make_output(), ge)
         facts_block = prompt.split("Accumulated goal facts", 1)[1]
-        assert "[truncated: showing" in facts_block   # clipped, but honestly
-        # and the window is real: far more than the old 500 silent chars
-        assert "fact_20" in facts_block
+        assert "truncated" not in facts_block
+        assert "fact_20: " + "v" * 60 in facts_block
+
+    def test_facts_past_the_budget_are_named_not_halved(self, monkeypatch):
+        from jarviscore.context.truth import TruthFact
+        monkeypatch.setenv("EVALUATOR_FACTS_BUDGET_CHARS", "400")
+        ev = self._evaluator()
+        ge = GoalExecution(goal="G", agent_id="a")
+        for i in range(20):
+            ge.truth.facts[f"fact_{i:02d}"] = TruthFact(
+                value="v" * 100, source="t", confidence=0.9,
+            )
+        prompt = ev._build_prompt(_make_step(), _make_output(), ge)
+        facts_block = prompt.split("Accumulated goal facts", 1)[1]
+        assert "records are not shown here" in facts_block
+        assert "truncated" not in facts_block
 
     @pytest.mark.asyncio
     async def test_short_circuits_failure_status(self):
@@ -810,10 +822,13 @@ class TestHonestPlannerPrompts:
         prompt = llm.prompts[0]
         assert "25 fact(s) known:" in prompt
         assert "- fact_00: v0" in prompt
-        assert "…and 5 more facts not shown" in prompt
+        # An item cap is not a budget. 25 small facts fit, so all 25 are shown.
+        assert "- fact_24: v24" in prompt
+        assert "not shown" not in prompt
 
     @pytest.mark.asyncio
-    async def test_long_fact_values_carry_markers(self):
+    async def test_long_fact_values_are_never_cut(self):
+        """#166 — a fact the planner cannot read is one it plans to re-fetch."""
         import json
         from jarviscore.planning.planner import Planner
         from jarviscore.context.truth import TruthFact
@@ -821,7 +836,50 @@ class TestHonestPlannerPrompts:
         ge = GoalExecution(goal="G", agent_id="a")
         ge.truth.facts["huge"] = TruthFact(value="H" * 700, source="s", confidence=0.9)
         await Planner(llm).plan(goal="G", goal_execution=ge)
-        assert "…[truncated: showing 200 of 700 chars]" in llm.prompts[0]
+        assert "H" * 700 in llm.prompts[0]
+        assert "truncated" not in llm.prompts[0]
+
+    @pytest.mark.asyncio
+    async def test_facts_past_the_budget_are_named_not_halved(self, monkeypatch):
+        import json
+        from jarviscore.planning.planner import Planner
+        from jarviscore.context.truth import TruthFact
+        monkeypatch.setenv("PLANNER_FACTS_BUDGET_CHARS", "300")
+        llm = _PlanLLM(json.dumps({"steps": [_step_json("s1")]}))
+        ge = GoalExecution(goal="G", agent_id="a")
+        for i in range(10):
+            ge.truth.facts[f"fact_{i:02d}"] = TruthFact(
+                value="v" * 100, source="s", confidence=0.9
+            )
+        await Planner(llm).plan(goal="G", goal_execution=ge)
+        prompt = llm.prompts[0]
+        assert "records are not shown here" in prompt
+        assert "the goal truth store" in prompt
+        assert "truncated" not in prompt
+        # Whatever is shown is shown whole.
+        assert "v" * 100 in prompt
+
+    @pytest.mark.asyncio
+    async def test_identity_reaches_the_planner_whole(self):
+        """#166 — 400 chars is the persona without the rules that constrain it."""
+        import json
+        from jarviscore.planning.planner import Planner
+        llm = _PlanLLM(json.dumps({"steps": [_step_json("s1")]}))
+        ge = GoalExecution(goal="G", agent_id="a")
+        identity = "You are Acme's analyst. " + ("RULE. " * 100) + "NEVER invoice a customer."
+        await Planner(llm, system_prompt=identity).plan(goal="G", goal_execution=ge)
+        assert "NEVER invoice a customer." in llm.prompts[0]
+
+    @pytest.mark.asyncio
+    async def test_legacy_excerpt_argument_still_accepted(self):
+        import json
+        from jarviscore.planning.planner import Planner
+        llm = _PlanLLM(json.dumps({"steps": [_step_json("s1")]}))
+        ge = GoalExecution(goal="G", agent_id="a")
+        await Planner(llm, system_prompt_excerpt="legacy identity").plan(
+            goal="G", goal_execution=ge,
+        )
+        assert "legacy identity" in llm.prompts[0]
 
 
 class TestReplanTailAndBudget:


### PR DESCRIPTION
Planning was the last place in the framework still cutting values mid-string, and it is where a fragment costs most. A planner reasons about work that has not happened yet; an evaluator issues a verdict on work that has. Both are judging the record they were handed — so a fragment does not make them slightly less accurate, it makes them **accurate about something else**.

## Identity was cut at 400 characters, twice

```python
# profiles/autoagent.py:872
planner = Planner(self.llm, system_prompt_excerpt=str(self.system_prompt or "")[:400])

# planning/planner.py:140
self._identity = system_prompt_excerpt[:400] if system_prompt_excerpt else ""
```

The caller cut to 400, then the constructor cut to 400 again. #91 fixed identity reaching the sub-agent turn — it still reached the **planner** as a preamble with none of the operating rules that constrain it. For most authored personas, 400 characters is the job title and none of the guardrails.

The planner now takes the whole `system_prompt`. `system_prompt_excerpt` is still accepted as an argument name.

## The evaluator was instructed to work around its own truncation

Summary clipped at 2000, payload at 6000. And in `_EVAL_SCHEMA`:

> *"Never return `"fail"` solely because evidence was clipped — a hidden tail is not a failed step, and `"fail"` burns a replan cycle on blindness."*

That instruction is the tell. Rather than stop clipping the evidence, we told the model to reason around the damage. A step whose proof of success fell past the cut still got a wrong verdict, and a wrong `fail` costs a replan cycle and buries the real result.

**Evidence now goes in whole.** The instruction retires with the problem it was managing.

## Shedding whole records, and naming them

New `jarviscore/context/fidelity.py`. Where a budget must bind it spends on complete records in priority order — cheapest first within a priority so one large record cannot crowd out many small ones — restores the caller's order for reading, and never sheds priority 0.

What does not fit is reported by key:

```
3 of 41 records are not shown here because the prompt budget could not hold them
whole (52,180 of 40,000 characters at full fidelity): `nvda_10k`, `peer_table`,
`fy24_transcript`. Nothing shown has been shortened. The full records are
unchanged in the goal truth store.
```

A reader told three of forty-one records are missing knows its picture is partial and can go and get them. A reader handed a value cut at 200 characters has no idea anything is gone.

## Also fixed on the way

The planner's fact list had an **item cap of 20** on top of per-value clipping. Twenty-five small facts were silently capped at twenty even when there was ample room. The cap is replaced by a real budget, so they all render.

## Compatibility

`EVALUATOR_SUMMARY_EVIDENCE_LIMIT` and `EVALUATOR_PAYLOAD_EVIDENCE_LIMIT` are still read so existing configuration keeps importing, and no longer shorten anything — same treatment `BudgetConfig` got in #154.

New budgets: `PLANNER_FACTS_BUDGET_CHARS` (40k), `PLANNER_CONTEXT_BUDGET_CHARS` (20k), `EVALUATOR_FACTS_BUDGET_CHARS` (40k). The old limits were 200–6000 characters against models with 128k-token windows.

`_honest_clip` survives in one place only: quoting back an LLM response that failed to parse, where the text is a diagnostic rather than something being judged. The issue explicitly scoped that out.

## Tests

Six tests asserted the clipping contract — including `test_schema_teaches_truncation_semantics`, which required the schema to keep teaching the model about truncation markers. They now assert the contract that replaced it.

New `tests/test_fidelity.py` — 10 tests: whole-record shedding, nothing shortened, priority 0 surviving a budget it exceeds, cheapest-first packing, caller order preserved, and the notice naming what is missing and where it lives.

Full suite in a complete dependency environment: **1721 passed, 2 failed**. Both failures are `asyncio.get_event_loop()` calls in test bodies, unrelated to this change and fixed by #168.

Closes #166
