### PR TITLE
fix(memory): the Athena tier ships what it is given, or says what it lost

### DIFF
--- a/jarviscore/config/settings.py
+++ b/jarviscore/config/settings.py
@@ -220,6 +220,13 @@ class Settings(BaseSettings):
     athena_session_ttl_days: int = 30           # How long session_id is cached in Redis
     athena_api_key: Optional[str] = None         # Optional Athena X-API-Key credential
     athena_jwt_token: Optional[str] = None       # Optional Athena X-JWT-Token credential
+    athena_outbox_max_events: int = 1000         # Queued writes before the oldest is dropped
+    athena_write_max_attempts: int = 4           # Tries per write, only used when deduplicating
+    athena_breaker_threshold: int = 3            # Consecutive failures before the breaker opens
+    athena_breaker_cooldown_seconds: float = 30.0  # Wait before one probe call is let through
+    # Only enable when the Athena deployment deduplicates on the idempotency key
+    # JarvisCore attaches: without it, a retry stores the same event twice.
+    athena_deduplicates_writes: bool = False
 
 
     # === Browser ===

--- a/jarviscore/memory/athena_client.py
+++ b/jarviscore/memory/athena_client.py
@@ -45,6 +45,10 @@ from typing import Any, Dict, List, Optional
 
 logger = logging.getLogger(__name__)
 
+
+class AthenaWriteRejected(RuntimeError):
+    """Athena accepted the request and declined to store the event."""
+
 # Event types mirroring Athena's STMEventType
 ROLE_AGENT  = "agent"
 ROLE_USER   = "user"
@@ -78,12 +82,14 @@ class AthenaClient:
         timeout: float = 10.0,
         api_key: Optional[str] = None,
         jwt_token: Optional[str] = None,
+        session_ttl_days: int = 30,
     ) -> None:
         self._base_url = base_url.rstrip("/")
         self._tenant_id = tenant_id
         self._timeout = timeout
         self._api_key = api_key
         self._jwt_token = jwt_token
+        self._session_ttl_seconds = max(1, int(session_ttl_days)) * 86400
         self._client = None  # lazy-init httpx.AsyncClient
 
     @classmethod
@@ -114,6 +120,7 @@ class AthenaClient:
             timeout=timeout,
             api_key=os.getenv("ATHENA_API_KEY") or None,
             jwt_token=os.getenv("ATHENA_JWT_TOKEN") or None,
+            session_ttl_days=int(os.getenv("ATHENA_SESSION_TTL_DAYS", "30")),
         )
 
     async def _http(self):
@@ -235,6 +242,7 @@ class AthenaClient:
         resolved_user_id = user_id or agent_id
         redis_key = f"athena_session:{self._tenant_id}:{resolved_user_id}:{agent_id}"
         legacy_redis_key = f"athena_session:{agent_id}"
+        session_ttl = self._session_ttl_seconds
 
         # 1. Try Redis cache
         if redis_store:
@@ -243,10 +251,18 @@ class AthenaClient:
                 if not cached:
                     cached = redis_store._redis.get(legacy_redis_key)
                     if cached:
-                        redis_store._redis.set(redis_key, cached, ex=30 * 86400)
-                if cached:
+                        redis_store._redis.set(redis_key, cached, ex=session_ttl)
+                if cached and await self.session_exists(cached):
                     logger.debug(f"[Athena] Reusing session for '{agent_id}': {cached}")
                     return cached
+                if cached:
+                    # Athena no longer has it — reusing the id writes into a void
+                    # that nothing reports, so mint a new one and replace the
+                    # mapping rather than keep a pointer to nothing (#128).
+                    logger.info(
+                        "[Athena] Cached session %s for '%s' no longer exists; recreating",
+                        cached, agent_id,
+                    )
             except Exception:
                 pass
 
@@ -257,14 +273,29 @@ class AthenaClient:
         if not session_id:
             return None
 
-        # 3. Cache in Redis (TTL = 30 days so sessions are very long-lived)
+        # 3. Cache in Redis (TTL from athena_session_ttl_days)
         if redis_store:
             try:
-                redis_store._redis.set(redis_key, session_id, ex=30 * 86400)
+                redis_store._redis.set(redis_key, session_id, ex=session_ttl)
             except Exception:
                 pass
 
         return session_id
+
+    async def session_exists(self, session_id: str) -> bool:
+        """Whether Athena still holds this session.
+
+        Unreachable is not the same as deleted, so a transport failure answers
+        True: discarding a good session id because the network blinked would
+        scatter one agent's memory across new sessions.
+        """
+        try:
+            http = await self._http()
+            resp = await http.get(f"/api/v1/sessions/{session_id}")
+        except Exception as exc:
+            logger.debug(f"[Athena] session_exists unreachable for {session_id}: {exc}")
+            return True
+        return resp.status_code != 404
 
     # ── Memory Writes ─────────────────────────────────────────────────────────
 
@@ -382,36 +413,72 @@ class AthenaClient:
         payload: Optional[bytes],
         mime_type: Optional[str],
     ) -> Optional[Dict[str, Any]]:
-        if payload is not None and not mime_type:
-            raise ValueError("mime_type is required when payload is provided")
         try:
-            http = await self._http()
-            request: Dict[str, Any] = {
-                "session_id": session_id,
-                "role": role,
-                "type": event_type,
-                "content": content,
-                "metadata": {
-                    "tenant_id": self._tenant_id,
-                    "origin_service": "jarviscore",
-                    **(metadata or {}),
-                },
-            }
-            serialized_timestamp = _rfc3339(timestamp)
-            if serialized_timestamp:
-                request["timestamp"] = serialized_timestamp
-            if payload is not None:
-                request["payload"] = base64.b64encode(payload).decode("ascii")
-                request["mime_type"] = mime_type
-            resp = await http.post(
-                f"/api/v1/sessions/{session_id}/events", json=request
+            return await self.write_event(
+                session_id,
+                role,
+                event_type,
+                content,
+                metadata,
+                timestamp=timestamp,
+                payload=payload,
+                mime_type=mime_type,
             )
-            resp.raise_for_status()
-            data = resp.json()
-            return data if data.get("success", True) else None
+        except ValueError:
+            raise
         except Exception as exc:
             logger.warning(f"[Athena] store_event failed: {exc}")
             return None
+
+    async def write_event(
+        self,
+        session_id: str,
+        role: str,
+        event_type: str,
+        content: str,
+        metadata: Optional[Dict[str, str]] = None,
+        *,
+        timestamp: Optional[datetime | str] = None,
+        payload: Optional[bytes] = None,
+        mime_type: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Store an event, raising on failure.
+
+        ``store_event`` reports a failed write as ``False`` and moves on, which
+        is why an unreachable Athena looked identical to a working one. A caller
+        that intends to retry, count or alert needs the failure itself, so this
+        is the path the durable outbox uses (#128).
+        """
+        if payload is not None and not mime_type:
+            raise ValueError("mime_type is required when payload is provided")
+        http = await self._http()
+        request: Dict[str, Any] = {
+            "session_id": session_id,
+            "role": role,
+            "type": event_type,
+            "content": content,
+            "metadata": {
+                "tenant_id": self._tenant_id,
+                "origin_service": "jarviscore",
+                **(metadata or {}),
+            },
+        }
+        serialized_timestamp = _rfc3339(timestamp)
+        if serialized_timestamp:
+            request["timestamp"] = serialized_timestamp
+        if payload is not None:
+            request["payload"] = base64.b64encode(payload).decode("ascii")
+            request["mime_type"] = mime_type
+        resp = await http.post(
+            f"/api/v1/sessions/{session_id}/events", json=request
+        )
+        resp.raise_for_status()
+        data = resp.json()
+        if not data.get("success", True):
+            raise AthenaWriteRejected(
+                f"Athena rejected the event for session {session_id}: {data}"
+            )
+        return data
 
     # ── Memory Reads ──────────────────────────────────────────────────────────
 

--- a/jarviscore/memory/athena_memory.py
+++ b/jarviscore/memory/athena_memory.py
@@ -38,8 +38,31 @@ from .athena_client import (
     TYPE_OBSERVATION,
     TYPE_THOUGHT,
 )
+from .delivery import CircuitBreaker, Outbox
 
 logger = logging.getLogger(__name__)
+
+
+def _outbox_from_settings() -> Outbox:
+    """Build the write outbox from the Athena settings block.
+
+    Retries default off. Athena has no client-supplied deduplication key today,
+    so replaying a write that actually landed would store it twice — and a
+    memory tier with invented corroboration is worse than one with a counted
+    gap. Turning ``athena_deduplicates_writes`` on is a claim about the
+    deployment, which only an operator can make.
+    """
+    from jarviscore.config import settings
+
+    return Outbox(
+        max_queue=settings.athena_outbox_max_events,
+        max_attempts=settings.athena_write_max_attempts,
+        deduplicates=settings.athena_deduplicates_writes,
+        breaker=CircuitBreaker(
+            threshold=settings.athena_breaker_threshold,
+            cooldown=settings.athena_breaker_cooldown_seconds,
+        ),
+    )
 
 
 class AthenaMemory:
@@ -65,10 +88,14 @@ class AthenaMemory:
         agent_id: str,
         session_id: str,
         client: AthenaClient,
+        outbox: Optional[Outbox] = None,
     ) -> None:
         self._agent_id = agent_id
         self._session_id = session_id
         self._client = client
+        # Writes are this tier's problem, not the caller's: a turn should not
+        # wait on Athena, and a write it loses should be countable (#128).
+        self._outbox = outbox if outbox is not None else Outbox()
 
     @classmethod
     async def create(
@@ -79,6 +106,7 @@ class AthenaMemory:
         metadata: Optional[Dict[str, str]] = None,
         *,
         user_id: Optional[str] = None,
+        outbox: Optional[Outbox] = None,
     ) -> "AthenaMemory":
         """
         Factory: creates or reuses an Athena session for this agent.
@@ -110,36 +138,66 @@ class AthenaMemory:
                 f"Is Athena running at {client._base_url}?"
             )
         logger.info(f"[Athena] AthenaMemory ready: agent={agent_id} session={session_id}")
-        return cls(agent_id=agent_id, session_id=session_id, client=client)
+        return cls(
+            agent_id=agent_id,
+            session_id=session_id,
+            client=client,
+            outbox=outbox if outbox is not None else _outbox_from_settings(),
+        )
 
     # ── Write helpers ─────────────────────────────────────────────────────────
+    #
+    # These return once the event is queued. They use the client's raising write
+    # path, because the outbox has to see a failure in order to count or retry it.
+
+    def _submit(
+        self, event_type: str, content: str, metadata: Optional[Dict[str, str]]
+    ) -> None:
+        self._outbox.submit(
+            self._client.write_event,
+            session_id=self._session_id,
+            role=ROLE_AGENT,
+            event_type=event_type,
+            content=content,
+            metadata={"agent_id": self._agent_id, **(metadata or {})},
+        )
 
     async def record_thought(
         self, content: str, metadata: Optional[Dict[str, str]] = None
     ) -> None:
         """Record an internal agent reasoning step (maps to Athena TYPE_THOUGHT)."""
-        await self._client.store_event(
-            self._session_id, ROLE_AGENT, TYPE_THOUGHT, content,
-            metadata={"agent_id": self._agent_id, **(metadata or {})},
-        )
+        self._submit(TYPE_THOUGHT, content, metadata)
 
     async def record_action(
         self, content: str, metadata: Optional[Dict[str, str]] = None
     ) -> None:
         """Record a concrete agent action (task assignment, tool call)."""
-        await self._client.store_event(
-            self._session_id, ROLE_AGENT, TYPE_ACTION, content,
-            metadata={"agent_id": self._agent_id, **(metadata or {})},
-        )
+        self._submit(TYPE_ACTION, content, metadata)
 
     async def record_observation(
         self, content: str, metadata: Optional[Dict[str, str]] = None
     ) -> None:
         """Record the outcome of an action (task completed, meeting noted, HITL resolved)."""
-        await self._client.store_event(
-            self._session_id, ROLE_AGENT, TYPE_OBSERVATION, content,
-            metadata={"agent_id": self._agent_id, **(metadata or {})},
-        )
+        self._submit(TYPE_OBSERVATION, content, metadata)
+
+    # ── Delivery ──────────────────────────────────────────────────────────────
+
+    @property
+    def delivery_stats(self) -> Dict[str, Any]:
+        """Shipped, retried, dropped, queue depth, breaker state, last success.
+
+        A tier that is configured and silently storing nothing reads exactly
+        like a healthy one from the outside. These are how you tell.
+        """
+        return self._outbox.stats.to_dict()
+
+    async def flush(self, timeout: float = 5.0) -> bool:
+        """Wait for queued writes to reach Athena. False if any are still queued."""
+        return await self._outbox.flush(timeout=timeout)
+
+    async def close(self, timeout: float = 5.0) -> bool:
+        """Ship what is queued and stop the shipper."""
+        return await self._outbox.close(timeout=timeout)
 
     # ── Domain event helpers (called by the kernel at lifecycle points) ────────
 

--- a/jarviscore/memory/delivery.py
+++ b/jarviscore/memory/delivery.py
@@ -1,0 +1,296 @@
+"""A bounded outbox, so a memory write is not a step in the agent's turn.
+
+`log_turn` used to await an HTTP round trip in the middle of reasoning, and a
+failed write was logged at debug and forgotten. Both are the same mistake: the
+turn was made to care about the state of a downstream service. Memory is a
+consequence of thinking, not a part of it.
+
+A submitted write is queued and returns immediately. One worker drains the queue
+in order, so events reach Athena in the order the agent produced them. The queue
+is bounded, because an unbounded one turns a memory outage into a memory leak.
+
+Retries need care, and this is the part worth reading. Replaying a write that
+actually landed stores it twice, and a memory tier with duplicates is its own
+kind of wrong — worse than a gap, because a gap is visible and a duplicate reads
+as corroboration. So a retry only happens when the caller can promise the
+receiver deduplicates on the key we attach. Without that promise a failed write
+is dropped and counted, which is a smaller lie than an invented one.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import random
+import time
+import uuid
+from collections import deque
+from dataclasses import dataclass, field
+from typing import Any, Awaitable, Callable, Dict, Optional
+
+logger = logging.getLogger(__name__)
+
+#: Metadata field carrying the client-generated key a receiver deduplicates on.
+IDEMPOTENCY_KEY = "idempotency_key"
+
+Send = Callable[..., Awaitable[Any]]
+
+
+class BreakerOpen(RuntimeError):
+    """Raised instead of calling a service that is known to be down."""
+
+
+@dataclass
+class CircuitBreaker:
+    """Stops calling a service that is failing, and notices when it returns.
+
+    Owned by the boundary it protects. The previous behaviour disabled the whole
+    memory tier after one failed initialisation, which turned a thirty-second
+    Athena restart into a dead tier for the life of the process. A breaker is
+    that protection without the permanence: it opens after repeated failure, and
+    after a cooldown lets exactly one call through to find out what is true now.
+    """
+
+    threshold: int = 3
+    cooldown: float = 30.0
+    _failures: int = field(default=0, init=False)
+    _opened_at: Optional[float] = field(default=None, init=False)
+    _probing: bool = field(default=False, init=False)
+
+    @property
+    def state(self) -> str:
+        if self._opened_at is None:
+            return "closed"
+        return "probing" if self._probing else "open"
+
+    def allows(self) -> bool:
+        if self._opened_at is None:
+            return True
+        if time.monotonic() - self._opened_at >= self.cooldown:
+            self._probing = True
+            return True
+        return False
+
+    def record_success(self) -> None:
+        self._failures = 0
+        self._opened_at = None
+        self._probing = False
+
+    def record_failure(self) -> None:
+        self._failures += 1
+        self._probing = False
+        if self._failures >= self.threshold:
+            self._opened_at = time.monotonic()
+
+
+@dataclass
+class Write:
+    """One queued call: the bound method to make it with, and its arguments."""
+
+    send: Send
+    kwargs: Dict[str, Any]
+    key: str = field(default_factory=lambda: uuid.uuid4().hex)
+    attempts: int = 0
+
+
+@dataclass
+class OutboxStats:
+    """What the outbox has done. A quiet tier and a working tier look alike."""
+
+    submitted: int = 0
+    shipped: int = 0
+    retried: int = 0
+    dropped_overflow: int = 0
+    dropped_exhausted: int = 0
+    depth: int = 0
+    breaker: str = "closed"
+    last_success_at: Optional[float] = None
+    last_error: Optional[str] = None
+
+    @property
+    def dropped(self) -> int:
+        return self.dropped_overflow + self.dropped_exhausted
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "submitted": self.submitted,
+            "shipped": self.shipped,
+            "retried": self.retried,
+            "dropped": self.dropped,
+            "dropped_overflow": self.dropped_overflow,
+            "dropped_exhausted": self.dropped_exhausted,
+            "depth": self.depth,
+            "breaker": self.breaker,
+            "last_success_at": self.last_success_at,
+            "last_error": self.last_error,
+        }
+
+
+class Outbox:
+    """Queues writes and ships them in order behind a circuit breaker.
+
+    Args:
+        max_queue: Events held before the oldest is dropped. A gap in old
+            history costs less than losing what the agent just did.
+        max_attempts: Tries per write. Forced to 1 unless ``deduplicates``,
+            because a retry without deduplication invents history.
+        deduplicates: The receiver honours ``IDEMPOTENCY_KEY``. This is a
+            statement about the deployment, so it is the operator's to make.
+        breaker: Shared with the boundary being called, when there is one.
+    """
+
+    def __init__(
+        self,
+        *,
+        max_queue: int = 1000,
+        max_attempts: int = 4,
+        base_delay: float = 0.5,
+        max_delay: float = 15.0,
+        deduplicates: bool = False,
+        breaker: Optional[CircuitBreaker] = None,
+    ) -> None:
+        if max_attempts > 1 and not deduplicates:
+            logger.debug(
+                "Outbox: retries disabled — the receiver does not promise to "
+                "deduplicate, and a replayed write would duplicate history."
+            )
+        self._max_queue = max_queue
+        self._max_attempts = max_attempts if deduplicates else 1
+        self._base_delay = base_delay
+        self._max_delay = max_delay
+        self._deduplicates = deduplicates
+        self._breaker = breaker or CircuitBreaker()
+        self._queue: "deque[Write]" = deque()
+        self._wake = asyncio.Event()
+        self._drained = asyncio.Event()
+        self._drained.set()
+        self._worker: Optional[asyncio.Task] = None
+        self._stopping = False
+        self.stats = OutboxStats()
+
+    # ── submitting ───────────────────────────────────────────────────────────
+
+    def submit(self, send: Send, **kwargs: Any) -> None:
+        """Queue a call. Returns as soon as it is queued; never raises."""
+        write = Write(send=send, kwargs=dict(kwargs))
+        if self._deduplicates:
+            metadata = dict(write.kwargs.get("metadata") or {})
+            metadata[IDEMPOTENCY_KEY] = write.key
+            write.kwargs["metadata"] = metadata
+
+        if len(self._queue) >= self._max_queue:
+            self._queue.popleft()
+            self.stats.dropped_overflow += 1
+            logger.warning(
+                "Outbox full at %d events; oldest dropped (%d lost so far)",
+                self._max_queue, self.stats.dropped_overflow,
+            )
+
+        self._queue.append(write)
+        self.stats.submitted += 1
+        self.stats.depth = len(self._queue)
+        self._drained.clear()
+        self._wake.set()
+        self._ensure_worker()
+
+    # ── lifecycle ────────────────────────────────────────────────────────────
+
+    def _ensure_worker(self) -> None:
+        if self._worker is not None and not self._worker.done():
+            return
+        try:
+            self._worker = asyncio.get_running_loop().create_task(
+                self._run(), name="athena-outbox",
+            )
+        except RuntimeError:
+            # No loop yet: the first submit inside a running loop starts it.
+            self._worker = None
+
+    async def flush(self, timeout: float = 5.0) -> bool:
+        """Wait for the queue to drain. False when it did not finish in time."""
+        if not self._queue:
+            return True
+        self._ensure_worker()
+        self._wake.set()
+        try:
+            await asyncio.wait_for(self._drained.wait(), timeout=timeout)
+        except asyncio.TimeoutError:
+            return False
+        return True
+
+    async def close(self, timeout: float = 5.0) -> bool:
+        """Ship what is queued, then stop. Reports whether anything was left."""
+        drained = await self.flush(timeout=timeout)
+        self._stopping = True
+        self._wake.set()
+        worker, self._worker = self._worker, None
+        if worker is not None:
+            try:
+                await asyncio.wait_for(worker, timeout=timeout)
+            except (asyncio.TimeoutError, asyncio.CancelledError):
+                worker.cancel()
+        if not drained:
+            logger.warning(
+                "Outbox closed with %d event(s) still queued", len(self._queue),
+            )
+        return drained
+
+    # ── shipping ─────────────────────────────────────────────────────────────
+
+    async def _run(self) -> None:
+        while True:
+            if not self._queue:
+                self._drained.set()
+                if self._stopping:
+                    return
+                self._wake.clear()
+                await self._wake.wait()
+                continue
+
+            if not self._breaker.allows():
+                self.stats.breaker = self._breaker.state
+                if self._stopping:
+                    return
+                await asyncio.sleep(min(self._base_delay, 1.0))
+                continue
+
+            write = self._queue[0]
+            delivered = await self._attempt(write)
+            self.stats.breaker = self._breaker.state
+
+            if delivered:
+                self._queue.popleft()
+                self.stats.shipped += 1
+                self.stats.depth = len(self._queue)
+                continue
+
+            write.attempts += 1
+            if write.attempts >= self._max_attempts:
+                self._queue.popleft()
+                self.stats.dropped_exhausted += 1
+                self.stats.depth = len(self._queue)
+                logger.warning(
+                    "Outbox gave up after %d attempt(s): %s",
+                    write.attempts, self.stats.last_error,
+                )
+                continue
+
+            self.stats.retried += 1
+            await asyncio.sleep(self._backoff(write.attempts))
+
+    async def _attempt(self, write: Write) -> bool:
+        try:
+            await write.send(**write.kwargs)
+        except Exception as exc:  # noqa: BLE001 - the outcome matters, not the type
+            self.stats.last_error = f"{type(exc).__name__}: {exc}"
+            self._breaker.record_failure()
+            return False
+        self.stats.last_success_at = time.time()
+        self.stats.last_error = None
+        self._breaker.record_success()
+        return True
+
+    def _backoff(self, attempt: int) -> float:
+        """Exponential with jitter, so a fleet does not retry in lockstep."""
+        delay = min(self._base_delay * (2 ** (attempt - 1)), self._max_delay)
+        return delay * (0.5 + random.random() / 2)

--- a/jarviscore/memory/unified.py
+++ b/jarviscore/memory/unified.py
@@ -102,9 +102,24 @@ class UnifiedMemory:
                 redis_store=self._redis,
             )
         except Exception as exc:
+            # Athena restarting is a condition to recover from, not a reason to
+            # disable the tier for the life of the process. The client's breaker
+            # keeps the retry cheap while it is down (#128).
             logger.warning("[UnifiedMemory] Athena init failed (non-fatal): %s", exc)
-            self._athena_client = None   # disable so we don't retry on every turn
         return self._athena_memory
+
+    @property
+    def athena_delivery_stats(self) -> Optional[Dict[str, Any]]:
+        """Delivery counters for the Athena tier, or None when it is not active."""
+        if self._athena_memory is None:
+            return None
+        return self._athena_memory.delivery_stats
+
+    async def close(self, timeout: float = 5.0) -> bool:
+        """Flush queued memory writes. False if anything was still unsent."""
+        if self._athena_memory is None:
+            return True
+        return await self._athena_memory.close(timeout=timeout)
 
 
     async def log_turn(

--- a/tests/test_athena_delivery.py
+++ b/tests/test_athena_delivery.py
@@ -1,0 +1,442 @@
+"""The Athena tier ships what it is given, or says what it lost (#128).
+
+The tier was fail-soft to the point of being unfalsifiable: writes were awaited
+on the reasoning path, failures were swallowed and logged at debug, and an
+initialisation error disabled memory for the life of the process. A configured
+tier storing nothing looked exactly like a working one.
+
+The first test here is the one that matters most. Every event write without an
+explicit timestamp was silently dropped before it reached the network, from
+v1.4.0 through v1.7.0, and nothing in the suite noticed.
+"""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from jarviscore.memory.athena_client import (
+    AthenaClient,
+    AthenaWriteRejected,
+    ROLE_AGENT,
+    TYPE_THOUGHT,
+)
+from jarviscore.memory.athena_memory import AthenaMemory
+from jarviscore.memory.delivery import IDEMPOTENCY_KEY, CircuitBreaker, Outbox
+from jarviscore.memory.unified import UnifiedMemory
+
+
+def _response(payload=None, status_code=200):
+    response = MagicMock()
+    response.status_code = status_code
+    response.raise_for_status = MagicMock()
+    response.json.return_value = payload if payload is not None else {"success": True}
+    return response
+
+
+def _client(http=None):
+    client = AthenaClient(base_url="http://athena.test")
+    client._client = http or AsyncMock()
+    return client
+
+
+# ──────────────────────────────────────────────────────────────────
+# The write actually leaves the process
+# ──────────────────────────────────────────────────────────────────
+
+class TestEventIsPosted:
+
+    @pytest.mark.asyncio
+    async def test_event_without_a_timestamp_is_posted(self):
+        """Regression: the POST sat inside `if serialized_timestamp:`.
+
+        AthenaMemory never passes a timestamp, so from v1.4.0 to v1.7.0 every
+        thought, action and observation was assembled and then never sent. The
+        call returned False, nobody checks the return, and the tier was empty.
+        """
+        http = AsyncMock()
+        http.post.return_value = _response()
+        client = _client(http)
+
+        await client.write_event("s1", ROLE_AGENT, TYPE_THOUGHT, "a thought")
+
+        http.post.assert_awaited_once()
+        assert http.post.await_args.args[0] == "/api/v1/sessions/s1/events"
+        assert http.post.await_args.kwargs["json"]["content"] == "a thought"
+        assert "timestamp" not in http.post.await_args.kwargs["json"]
+
+    @pytest.mark.asyncio
+    async def test_event_with_a_timestamp_is_still_posted(self):
+        http = AsyncMock()
+        http.post.return_value = _response()
+
+        await _client(http).write_event(
+            "s1", ROLE_AGENT, TYPE_THOUGHT, "c", timestamp="2026-09-06T00:00:00Z",
+        )
+
+        assert http.post.await_args.kwargs["json"]["timestamp"] == "2026-09-06T00:00:00Z"
+
+    @pytest.mark.asyncio
+    async def test_payload_is_attached_without_a_timestamp(self):
+        http = AsyncMock()
+        http.post.return_value = _response()
+
+        await _client(http).write_event(
+            "s1", ROLE_AGENT, TYPE_THOUGHT, "c", payload=b"\x00\x01", mime_type="application/octet-stream",
+        )
+
+        assert http.post.await_args.kwargs["json"]["mime_type"] == "application/octet-stream"
+
+
+class TestWriteEventRaises:
+    """The outbox cannot count or retry a failure it is never told about."""
+
+    @pytest.mark.asyncio
+    async def test_transport_failure_raises(self):
+        http = AsyncMock()
+        http.post.side_effect = RuntimeError("connection refused")
+
+        with pytest.raises(RuntimeError, match="connection refused"):
+            await _client(http).write_event("s1", ROLE_AGENT, TYPE_THOUGHT, "c")
+
+    @pytest.mark.asyncio
+    async def test_declined_write_raises(self):
+        http = AsyncMock()
+        http.post.return_value = _response({"success": False, "error": "full"})
+
+        with pytest.raises(AthenaWriteRejected):
+            await _client(http).write_event("s1", ROLE_AGENT, TYPE_THOUGHT, "c")
+
+    @pytest.mark.asyncio
+    async def test_store_event_keeps_its_boolean_contract(self):
+        http = AsyncMock()
+        http.post.side_effect = RuntimeError("down")
+
+        assert await _client(http).store_event("s1", ROLE_AGENT, TYPE_THOUGHT, "c") is False
+
+    @pytest.mark.asyncio
+    async def test_missing_mime_type_is_a_caller_error_not_a_delivery_failure(self):
+        with pytest.raises(ValueError):
+            await _client().store_event(
+                "s1", ROLE_AGENT, TYPE_THOUGHT, "c", payload=b"x",
+            )
+
+
+# ──────────────────────────────────────────────────────────────────
+# Outbox
+# ──────────────────────────────────────────────────────────────────
+
+class TestOutbox:
+
+    @pytest.mark.asyncio
+    async def test_submit_returns_before_the_write_lands(self):
+        started = asyncio.Event()
+        release = asyncio.Event()
+
+        async def slow(**kwargs):
+            started.set()
+            await release.wait()
+
+        outbox = Outbox()
+        outbox.submit(slow, content="c")          # returns immediately
+        await asyncio.wait_for(started.wait(), timeout=1)
+        assert outbox.stats.shipped == 0
+        release.set()
+        assert await outbox.flush(timeout=1)
+        assert outbox.stats.shipped == 1
+
+    @pytest.mark.asyncio
+    async def test_writes_ship_in_order(self):
+        seen = []
+
+        async def record(**kwargs):
+            seen.append(kwargs["content"])
+
+        outbox = Outbox()
+        for i in range(20):
+            outbox.submit(record, content=i)
+        await outbox.flush(timeout=2)
+
+        assert seen == list(range(20))
+
+    @pytest.mark.asyncio
+    async def test_a_failed_write_is_counted_not_swallowed(self):
+        async def broken(**kwargs):
+            raise RuntimeError("athena down")
+
+        outbox = Outbox()
+        outbox.submit(broken, content="c")
+        await outbox.flush(timeout=2)
+
+        assert outbox.stats.dropped == 1
+        assert outbox.stats.shipped == 0
+        assert "athena down" in outbox.stats.last_error
+
+    @pytest.mark.asyncio
+    async def test_no_retry_without_deduplication(self):
+        """A replayed write invents history. That is worse than a counted gap."""
+        attempts = []
+
+        async def broken(**kwargs):
+            attempts.append(1)
+            raise RuntimeError("boom")
+
+        outbox = Outbox(max_attempts=4, deduplicates=False)
+        outbox.submit(broken, content="c")
+        await outbox.flush(timeout=2)
+
+        assert len(attempts) == 1
+        assert outbox.stats.retried == 0
+
+    @pytest.mark.asyncio
+    async def test_retries_when_the_receiver_deduplicates(self):
+        attempts = []
+
+        async def flaky(**kwargs):
+            attempts.append(kwargs["metadata"][IDEMPOTENCY_KEY])
+            if len(attempts) < 3:
+                raise RuntimeError("boom")
+
+        outbox = Outbox(max_attempts=4, deduplicates=True, base_delay=0.001)
+        outbox.submit(flaky, content="c", metadata={"agent_id": "a"})
+        await outbox.flush(timeout=2)
+
+        assert len(attempts) == 3
+        assert len(set(attempts)) == 1          # same key every attempt
+        assert outbox.stats.shipped == 1
+
+    @pytest.mark.asyncio
+    async def test_idempotency_key_is_absent_when_not_deduplicating(self):
+        seen = {}
+
+        async def record(**kwargs):
+            seen.update(kwargs.get("metadata") or {})
+
+        outbox = Outbox(deduplicates=False)
+        outbox.submit(record, content="c", metadata={"agent_id": "a"})
+        await outbox.flush(timeout=2)
+
+        assert IDEMPOTENCY_KEY not in seen
+
+    @pytest.mark.asyncio
+    async def test_overflow_drops_the_oldest_and_counts_it(self):
+        release = asyncio.Event()
+        shipped = []
+
+        async def blocked(**kwargs):
+            await release.wait()
+            shipped.append(kwargs["content"])
+
+        outbox = Outbox(max_queue=3)
+        for i in range(6):
+            outbox.submit(blocked, content=i)
+
+        assert outbox.stats.dropped_overflow == 3
+        release.set()
+        await outbox.flush(timeout=2)
+        assert shipped[-1] == 5              # the newest survived
+
+    @pytest.mark.asyncio
+    async def test_stats_report_the_queue_depth(self):
+        release = asyncio.Event()
+
+        async def blocked(**kwargs):
+            await release.wait()
+
+        outbox = Outbox()
+        for i in range(4):
+            outbox.submit(blocked, content=i)
+        assert outbox.stats.depth == 4
+        release.set()
+        await outbox.flush(timeout=2)
+        assert outbox.stats.depth == 0
+
+    @pytest.mark.asyncio
+    async def test_close_flushes_what_is_queued(self):
+        shipped = []
+
+        async def record(**kwargs):
+            shipped.append(kwargs["content"])
+
+        outbox = Outbox()
+        for i in range(5):
+            outbox.submit(record, content=i)
+        assert await outbox.close(timeout=2)
+
+        assert shipped == list(range(5))
+
+
+class TestCircuitBreaker:
+
+    def test_opens_after_the_threshold(self):
+        breaker = CircuitBreaker(threshold=2, cooldown=60)
+        assert breaker.allows()
+        breaker.record_failure()
+        assert breaker.state == "closed"
+        breaker.record_failure()
+        assert breaker.state == "open"
+        assert not breaker.allows()
+
+    def test_probes_once_after_the_cooldown(self):
+        breaker = CircuitBreaker(threshold=1, cooldown=0)
+        breaker.record_failure()
+        assert breaker.allows()
+        assert breaker.state == "probing"
+
+    def test_a_success_closes_it_again(self):
+        breaker = CircuitBreaker(threshold=1, cooldown=0)
+        breaker.record_failure()
+        breaker.allows()
+        breaker.record_success()
+        assert breaker.state == "closed"
+
+    def test_success_resets_the_failure_run(self):
+        breaker = CircuitBreaker(threshold=3, cooldown=60)
+        breaker.record_failure()
+        breaker.record_failure()
+        breaker.record_success()
+        breaker.record_failure()
+        breaker.record_failure()
+        assert breaker.state == "closed"
+
+
+# ──────────────────────────────────────────────────────────────────
+# The tier
+# ──────────────────────────────────────────────────────────────────
+
+class TestAthenaMemoryDelivery:
+
+    def _memory(self, http, **outbox_kwargs):
+        return AthenaMemory(
+            agent_id="a", session_id="s1", client=_client(http),
+            outbox=Outbox(**outbox_kwargs),
+        )
+
+    @pytest.mark.asyncio
+    async def test_recorded_events_reach_athena(self):
+        http = AsyncMock()
+        http.post.return_value = _response()
+        memory = self._memory(http)
+
+        await memory.record_thought("thinking")
+        await memory.record_action("acting")
+        await memory.flush(timeout=2)
+
+        assert http.post.await_count == 2
+        assert memory.delivery_stats["shipped"] == 2
+
+    @pytest.mark.asyncio
+    async def test_a_slow_athena_does_not_hold_up_the_turn(self):
+        release = asyncio.Event()
+        http = AsyncMock()
+
+        async def slow(*args, **kwargs):
+            await release.wait()
+            return _response()
+
+        http.post.side_effect = slow
+        memory = self._memory(http)
+
+        await asyncio.wait_for(memory.record_thought("thinking"), timeout=0.5)
+
+        release.set()
+        await memory.flush(timeout=2)
+
+    @pytest.mark.asyncio
+    async def test_an_outage_is_visible_in_the_counters(self):
+        http = AsyncMock()
+        http.post.side_effect = RuntimeError("athena down")
+        memory = self._memory(http)
+
+        await memory.record_thought("thinking")
+        await memory.flush(timeout=2)
+
+        stats = memory.delivery_stats
+        assert stats["shipped"] == 0
+        assert stats["dropped"] == 1
+        assert "athena down" in stats["last_error"]
+
+    @pytest.mark.asyncio
+    async def test_domain_events_go_through_the_outbox_too(self):
+        http = AsyncMock()
+        http.post.return_value = _response()
+        memory = self._memory(http)
+
+        await memory.on_task_completed("t1", "Ship the thing", "done")
+        await memory.flush(timeout=2)
+
+        assert memory.delivery_stats["shipped"] == 1
+        assert "Ship the thing" in http.post.await_args.kwargs["json"]["content"]
+
+
+# ──────────────────────────────────────────────────────────────────
+# Sessions and recovery
+# ──────────────────────────────────────────────────────────────────
+
+class TestStaleSession:
+
+    @pytest.mark.asyncio
+    async def test_a_deleted_session_is_recreated(self):
+        http = AsyncMock()
+        http.get.return_value = _response(status_code=404)
+        http.post.return_value = _response({"session_id": "fresh"})
+        client = _client(http)
+        redis_store = MagicMock()
+        redis_store._redis.get.return_value = "stale"
+
+        session_id = await client.get_or_create_session("a", redis_store=redis_store)
+
+        assert session_id == "fresh"
+        redis_store._redis.set.assert_called()
+
+    @pytest.mark.asyncio
+    async def test_a_live_session_is_reused(self):
+        http = AsyncMock()
+        http.get.return_value = _response({"id": "live"}, status_code=200)
+        client = _client(http)
+        redis_store = MagicMock()
+        redis_store._redis.get.return_value = "live"
+
+        assert await client.get_or_create_session("a", redis_store=redis_store) == "live"
+        http.post.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_unreachable_athena_does_not_discard_the_session(self):
+        """A network blink is not evidence the session was deleted."""
+        http = AsyncMock()
+        http.get.side_effect = RuntimeError("connection refused")
+        client = _client(http)
+        redis_store = MagicMock()
+        redis_store._redis.get.return_value = "keep-me"
+
+        assert await client.get_or_create_session("a", redis_store=redis_store) == "keep-me"
+
+
+class TestTierRecovery:
+
+    @pytest.mark.asyncio
+    async def test_a_failed_start_does_not_disable_memory_for_the_process(self):
+        """Athena restarting used to cost the whole run's memory."""
+        attempts = {"n": 0}
+
+        class Flaky:
+            async def get_or_create_session(self, *args, **kwargs):
+                attempts["n"] += 1
+                if attempts["n"] == 1:
+                    raise RuntimeError("athena starting up")
+                return "s1"
+
+        memory = UnifiedMemory(
+            workflow_id="w", step_id="s", agent_id="a", athena_client=Flaky(),
+        )
+
+        assert await memory._get_athena_memory() is None
+        assert memory._athena_client is not None      # not nulled out
+        assert await memory._get_athena_memory() is not None
+        assert attempts["n"] == 2
+
+    @pytest.mark.asyncio
+    async def test_stats_are_none_when_the_tier_is_not_active(self):
+        memory = UnifiedMemory(workflow_id="w", step_id="s", agent_id="a")
+        assert memory.athena_delivery_stats is None
+        assert await memory.close() is True


### PR DESCRIPTION
The Athena tier was fail-soft to the point of being unfalsifiable: writes awaited on the reasoning path, every failure swallowed and logged at debug, and one initialisation error disabling memory for the life of the process. A configured tier storing nothing read exactly like a working one.

## First, #170

Building this surfaced a bug that predates the issue. `_store_event` posted **inside the timestamp branch**:

```python
serialized_timestamp = _rfc3339(timestamp)
if serialized_timestamp:
    request["timestamp"] = serialized_timestamp
    ...
    resp = await http.post(f"/api/v1/sessions/{session_id}/events", json=request)
```

`_rfc3339(None)` returns `None`, and **nothing passes a timestamp** — `record_thought`, `record_action`, `record_observation` and every `on_*` helper call `store_event` without one. The request was built and dropped on the floor.

**Athena has stored no agent event since v1.4.0.** Shipped in 1.4.0, 1.4.1, 1.5.0, 1.5.1 on PyPI, and in the tagged 1.6.0 and 1.7.0. Filed separately as #170.

It survived five releases because the only test on this path uses `RecordingAthena` — a fake **AthenaMemory** — so it verifies the layer above the one that was broken.

## Why the swallow had to go first

`store_event` catches everything and returns `False`. An outbox built on top of it would have counted every lost write as shipped: breaker closed, `dropped: 0`, cheerful counters, empty database. I'd have built an observability layer that reports success by construction — the same disease as #148 and #150, inside the fix for it.

So `write_event` raises, and `store_event` keeps its `bool` contract on top for existing callers. A boundary that swallows its own failures cannot be monitored by anything above it.

## Durability belongs to the tier

`AthenaMemory` owns an `Outbox`. `record_*` and `on_*` return once the event is queued. **`UnifiedMemory` calls them exactly as before** — its only change is to stop setting `_athena_client = None` on a failed start.

That last one was the difference between an outage and an amputation: a thirty-second Athena restart cost the whole run's memory. The client's breaker now makes the retry cheap while it's down and lets one probe through after a cooldown.

## Delivery

One worker drains the queue, so events keep the order the agent produced them. The queue is bounded — an unbounded one turns a memory outage into a memory leak — and at the limit the oldest event is dropped and counted, since a gap in old history costs less than losing what the agent just did.

Readable from `AthenaMemory.delivery_stats` / `UnifiedMemory.athena_delivery_stats`:

```
submitted, shipped, retried, dropped, dropped_overflow,
dropped_exhausted, depth, breaker, last_success_at, last_error
```

## The acceptance criterion I cannot meet, stated plainly

> *Write retries occur only with an idempotency guarantee.*

Athena has **no client-supplied deduplication key today** — `store_event_with_id` reads a *server*-generated `eventId`. The issue lists that API work as a prerequisite, and it isn't done.

So **retries default to off.** JarvisCore attaches an `idempotency_key` to each write and will retry only when `athena_deduplicates_writes` is set, which is a claim about a deployment and therefore the operator's to make. Without it, a failed write is dropped and counted.

That is the deliberate choice: replaying a write that actually landed stores it twice, and a memory tier with invented corroboration is worse than one with a counted gap — the gap is visible, the duplicate reads as confirmation.

## Sessions

A cached session id is checked before reuse. A 404 mints a new session and replaces the Redis mapping. An **unreachable** Athena keeps the id — a network blink is not evidence a session was deleted, and discarding a good id would scatter one agent's memory across new sessions.

## Against the acceptance criteria

| Criterion | |
|---|---|
| Outage at start, recover later, no restart | ✅ breaker + cooldown probe |
| Stale session recreated, mapping updated | ✅ |
| Read retries bounded and observable | ⚠️ reads bounded by the HTTP timeout and the breaker; no read-retry counter |
| Write retries only with idempotency | ✅ off by default, opt-in on operator assertion |
| Slow Athena adds no turn latency | ✅ submit returns immediately |
| Operators can inspect tier health | ✅ `delivery_stats` |
| Tests for outage/stale/recovery/overflow/flush | ✅ 29 tests |

## Tests

`tests/test_athena_delivery.py` — **29 passed**. The first one is the one that matters: it asserts a POST is actually awaited when no timestamp is supplied, which is the assertion nobody had written.

Also covers ordering, overflow dropping the oldest, retry suppressed without deduplication, the idempotency key held constant across attempts, breaker open/probe/close, slow-Athena non-blocking, stale and unreachable sessions, and recovery after a failed start.

Closes #128
Closes #170
