### PR TITLE
fix(p2p): a probe this process never watched cannot accuse a peer

### DIFF
--- a/jarviscore/p2p/scheduling.py
+++ b/jarviscore/p2p/scheduling.py
@@ -1,0 +1,99 @@
+"""Knowing when this process was not scheduled to observe anything.
+
+SWIM decides a peer is failing when a PONG does not arrive inside the probe
+budget. That inference holds only if we were actually running while the budget
+elapsed. When the SWIM thread is descheduled — a long GIL hold from tokenizer or
+inference work in the same process, a blocking call on another thread — the PONG
+may arrive perfectly on time and simply not be read until later. The timeout is
+then a fact about this process, and turning it into a claim about a peer is the
+same mistake as reporting a conclusion in place of an observation.
+
+So measure it. A ticker that sleeps a fixed interval and compares the elapsed
+time against the interval it asked for reports exactly how long this thread was
+not running. Nothing else in the process needs to cooperate, and there is no
+guess involved: the number is the difference between what we asked the loop for
+and what the loop gave us.
+
+Raising probe timeouts does not address this. A timeout large enough for the
+worst pause is also large enough to miss a genuinely dead peer for that long,
+and the pause has no fixed size — it scales with model, batch and hardware. The
+question worth answering is not "how long might we stall" but "did we stall
+during the window we are about to draw a conclusion from".
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from collections import deque
+from typing import Deque, Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+
+class SchedulingMonitor:
+    """Records how long this event loop was unable to run.
+
+    Args:
+        tick: How often to sample. Shorter samples resolve short pauses;
+            the cost is one wakeup per tick on an otherwise idle loop.
+        window: How far back samples are kept. Only needs to cover the
+            longest probe budget a caller will ask about.
+    """
+
+    def __init__(self, tick: float = 0.1, window: float = 60.0) -> None:
+        self._tick = tick
+        self._window = window
+        self._stalls: Deque[Tuple[float, float]] = deque()
+        self._task: Optional[asyncio.Task] = None
+        self._running = False
+        self.max_stall = 0.0
+
+    async def run(self) -> None:
+        """Sample until stopped. Intended to be scheduled on the loop it watches."""
+        self._running = True
+        while self._running:
+            asked_at = time.monotonic()
+            await asyncio.sleep(self._tick)
+            elapsed = time.monotonic() - asked_at
+            stall = elapsed - self._tick
+            if stall > 0:
+                self._record(stall)
+
+    def start(self) -> None:
+        if self._task is None or self._task.done():
+            self._task = asyncio.get_event_loop().create_task(
+                self.run(), name="swim-scheduling-monitor",
+            )
+
+    def stop(self) -> None:
+        self._running = False
+        if self._task is not None:
+            self._task.cancel()
+            self._task = None
+
+    def _record(self, stall: float) -> None:
+        now = time.monotonic()
+        self._stalls.append((now, stall))
+        self.max_stall = max(self.max_stall, stall)
+        horizon = now - self._window
+        while self._stalls and self._stalls[0][0] < horizon:
+            self._stalls.popleft()
+
+    def stall_within(self, seconds: float) -> float:
+        """Total time this loop was not running over the last ``seconds``."""
+        if seconds <= 0:
+            return 0.0
+        horizon = time.monotonic() - seconds
+        return sum(stall for at, stall in self._stalls if at >= horizon)
+
+    def observed_fraction(self, seconds: float) -> float:
+        """How much of the last ``seconds`` this loop was actually running.
+
+        1.0 means it never missed a beat; 0.0 means it was descheduled for the
+        whole window and saw none of it.
+        """
+        if seconds <= 0:
+            return 1.0
+        return max(0.0, 1.0 - self.stall_within(seconds) / seconds)

--- a/jarviscore/p2p/suspicion.py
+++ b/jarviscore/p2p/suspicion.py
@@ -1,0 +1,118 @@
+"""Refusing to call a peer suspect for a probe this process never watched.
+
+`FailureDetector.ping` retries, times out, and calls `members.mark_suspect(target)`
+with the default reason `ping_timeout`. That call is the moment an observation
+about our own socket becomes a claim about someone else's liveness, and it is
+made without asking whether we were running while the budget elapsed.
+
+This guard sits on that one call. When the reason is a timeout we observed
+ourselves, and the scheduling monitor says this loop was descheduled for a
+meaningful part of that window, the suspicion is declined: the peer stays ALIVE
+and gets probed again on the next cycle, by a probe we can actually watch. The
+judgement is deferred, not overruled — nothing here decides a peer is healthy,
+it only declines to claim the opposite from evidence we did not collect.
+
+Suspicion arriving from other nodes is untouched. That travels through
+`merge_digest`, is another node's observation rather than ours, and our own
+scheduling has no bearing on whether it is true.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any, Optional, Tuple
+
+from .scheduling import SchedulingMonitor
+
+logger = logging.getLogger(__name__)
+
+#: Reasons that mean "we timed out waiting", as opposed to "a peer told us".
+LOCAL_OBSERVATION_REASONS = frozenset({
+    "ping_timeout",
+    "indirect_ping_timeout",
+    "probe_timeout",
+    "timeout",
+})
+
+
+@dataclass
+class SuspicionGuardStats:
+    raised: int = 0
+    declined: int = 0
+    max_stall_seconds: float = 0.0
+    last_declined_peer: Optional[str] = None
+
+    def to_dict(self) -> dict:
+        return {
+            "raised": self.raised,
+            "declined": self.declined,
+            "max_stall_seconds": round(self.max_stall_seconds, 3),
+            "last_declined_peer": self.last_declined_peer,
+        }
+
+
+class SuspicionGuard:
+    """Wraps ``MemberList.mark_suspect`` so a starved probe cannot accuse a peer.
+
+    Args:
+        monitor: Scheduling monitor for the loop the probe ran on.
+        probe_budget: Probe window to assume when the caller does not say.
+        min_observed_fraction: How much of the window this loop must have been
+            running before a timeout is allowed to mean anything. At 0.5, a
+            probe that spent half its budget with the loop descheduled is
+            treated as unwatched rather than failed.
+    """
+
+    def __init__(
+        self,
+        monitor: SchedulingMonitor,
+        *,
+        probe_budget: float = 2.0,
+        min_observed_fraction: float = 0.5,
+    ) -> None:
+        self._monitor = monitor
+        self._probe_budget = probe_budget
+        self._min_observed = min_observed_fraction
+        self.stats = SuspicionGuardStats()
+
+    def attach(self, member_list: Any) -> None:
+        """Install the guard on a live MemberList."""
+        original = member_list.mark_suspect
+
+        async def mark_suspect(
+            addr: Tuple[str, int],
+            incarnation: Optional[int] = None,
+            suspicion_reason: str = "ping_timeout",
+            timeout_duration: Optional[float] = None,
+            *args: Any,
+            **kwargs: Any,
+        ) -> bool:
+            if self._should_decline(suspicion_reason, timeout_duration):
+                window = timeout_duration or self._probe_budget
+                stalled = self._monitor.stall_within(window)
+                self.stats.declined += 1
+                self.stats.max_stall_seconds = max(self.stats.max_stall_seconds, stalled)
+                self.stats.last_declined_peer = f"{addr[0]}:{addr[1]}"
+                logger.info(
+                    "SWIM suspicion declined for %s:%s — this process was descheduled "
+                    "for %.2fs of a %.2fs probe window, so the timeout describes us, "
+                    "not the peer. Re-probing next cycle.",
+                    addr[0], addr[1], stalled, window,
+                )
+                return False
+
+            self.stats.raised += 1
+            return await original(
+                addr, incarnation, suspicion_reason, timeout_duration, *args, **kwargs
+            )
+
+        member_list.mark_suspect = mark_suspect
+
+    def _should_decline(
+        self, suspicion_reason: str, timeout_duration: Optional[float]
+    ) -> bool:
+        if suspicion_reason not in LOCAL_OBSERVATION_REASONS:
+            return False
+        window = timeout_duration or self._probe_budget
+        return self._monitor.observed_fraction(window) < self._min_observed

--- a/jarviscore/p2p/swim_manager.py
+++ b/jarviscore/p2p/swim_manager.py
@@ -13,6 +13,9 @@ import logging
 import threading
 from typing import Optional
 
+from .scheduling import SchedulingMonitor
+from .suspicion import SuspicionGuard
+
 # swim-p2p announces itself on stdout at import; a library must stay quiet
 with contextlib.redirect_stdout(io.StringIO()) as _swim_import_noise:
     from swim.transport.hybrid import HybridTransport
@@ -45,6 +48,8 @@ class SWIMThreadManager:
         self.swim_zmq_bridge = None
         self.event_dispatcher = None
         self.bind_addr = None  # Store bind address for node_id access
+        self.scheduling_monitor: Optional[SchedulingMonitor] = None
+        self.suspicion_guard: Optional[SuspicionGuard] = None
         self._started = False
         self._initialized = threading.Event()
         self._shutdown_event = threading.Event()
@@ -145,11 +150,11 @@ class SWIMThreadManager:
                 "STABILITY_TIMEOUT_SECONDS": 3.0
             })
 
-            # Transport must tolerate co-resident inference (issue #138).
-            # Adaptive timing tunes PING_TIMEOUT toward idle sub-ms RTTs; a GIL
-            # pause from LLM/tokenizer work then blows the probe and flaps live
-            # peers to SUSPECT/DEAD. Until transport runs in its own process,
-            # probe budgets must assume inference pauses, not idle latency.
+            # A probe budget is a guess about how long inference might hold the
+            # GIL; the scheduling monitor measures it instead, and the suspicion
+            # guard refuses to call a peer suspect over a window this process was
+            # not running for (#138). The floors below remain only so ordinary
+            # jitter does not churn state between probes.
             # Env SWIM_* vars still win when explicitly set.
             import os as _os
             if "SWIM_PING_TIMEOUT" not in _os.environ:
@@ -161,6 +166,8 @@ class SWIMThreadManager:
                     float(swim_config.get("SUSPECT_TIMEOUT", 5.0)), 15.0
                 )
             if "SWIM_ADAPTIVE_TIMING" not in _os.environ:
+                # Tunes toward idle sub-millisecond RTTs, which is the opposite
+                # of what a co-resident inference workload needs.
                 swim_config["ADAPTIVE_TIMING_ENABLED"] = False
 
             # Validate config
@@ -198,6 +205,22 @@ class SWIMThreadManager:
                 return
 
             logger.info(f"SWIM node created at {self.bind_addr}")
+
+            # Watch this loop's own scheduling before the protocol starts, so the
+            # first probe already has a window to check against.
+            self.scheduling_monitor = SchedulingMonitor(
+                tick=float(self.config.get("scheduling_tick", 0.1)),
+                window=max(30.0, float(swim_config["SUSPECT_TIMEOUT"]) * 2),
+            )
+            self.scheduling_monitor.start()
+            self.suspicion_guard = SuspicionGuard(
+                self.scheduling_monitor,
+                probe_budget=float(swim_config["PING_TIMEOUT"]),
+                min_observed_fraction=float(
+                    self.config.get("min_observed_probe_fraction", 0.5)
+                ),
+            )
+            self.suspicion_guard.attach(self.swim_node.members)
 
             # Setup ZMQ integration
             zmq_port = self.bind_addr[1] + swim_config.get("ZMQ_PORT_OFFSET", zmq_port_offset)
@@ -307,6 +330,8 @@ class SWIMThreadManager:
             return
 
         logger.info("Shutting down SWIM thread...")
+        if self.scheduling_monitor and self.swim_loop:
+            self.swim_loop.call_soon_threadsafe(self.scheduling_monitor.stop)
         self._shutdown_event.set()
 
         if self.swim_thread:

--- a/tests/test_swim_starvation.py
+++ b/tests/test_swim_starvation.py
@@ -1,0 +1,218 @@
+"""A starved probe says nothing about a peer (#138).
+
+SWIM decided peers were failing while this process held the GIL doing inference.
+LIFEGUARD flagged the results as likely false positives, which is the detector
+noticing it had been misled without being able to say why. The reason is that
+`FailureDetector.ping` converts "no PONG inside the budget" into "that peer is
+suspect" without asking whether this process was running while the budget
+elapsed. These tests hold the boundary: a timeout observed by a loop that was
+descheduled describes the loop, not the peer.
+"""
+
+import asyncio
+import time
+
+import pytest
+
+from jarviscore.p2p.scheduling import SchedulingMonitor
+from jarviscore.p2p.suspicion import LOCAL_OBSERVATION_REASONS, SuspicionGuard
+
+
+class FakeMonitor(SchedulingMonitor):
+    """A monitor whose stalls are stated rather than measured."""
+
+    def __init__(self, stall: float = 0.0):
+        super().__init__()
+        self._fixed = stall
+
+    def stall_within(self, seconds: float) -> float:
+        return min(self._fixed, seconds)
+
+
+class RecordingMemberList:
+    def __init__(self):
+        self.suspected = []
+
+    async def mark_suspect(
+        self, addr, incarnation=None, suspicion_reason="ping_timeout",
+        timeout_duration=None, attempt_number=None, indirect_ping_attempted=False,
+    ):
+        self.suspected.append((addr, suspicion_reason))
+        return True
+
+
+# ──────────────────────────────────────────────────────────────────
+# Measuring the stall
+# ──────────────────────────────────────────────────────────────────
+
+class TestSchedulingMonitor:
+
+    @pytest.mark.asyncio
+    async def test_an_unblocked_loop_reports_almost_no_stall(self):
+        monitor = SchedulingMonitor(tick=0.01)
+        monitor.start()
+        await asyncio.sleep(0.15)
+        monitor.stop()
+
+        assert monitor.stall_within(1.0) < 0.05
+        assert monitor.observed_fraction(1.0) > 0.9
+
+    @pytest.mark.asyncio
+    async def test_a_blocked_loop_reports_the_stall(self):
+        """A synchronous sleep is what a GIL-holding tokenizer looks like."""
+        monitor = SchedulingMonitor(tick=0.01)
+        monitor.start()
+        await asyncio.sleep(0.02)
+        time.sleep(0.3)                     # blocks the loop, as inference does
+        await asyncio.sleep(0.02)
+        monitor.stop()
+
+        assert monitor.stall_within(2.0) >= 0.25
+        assert monitor.max_stall >= 0.25
+
+    def test_stalls_age_out_of_the_window(self):
+        monitor = SchedulingMonitor(tick=0.01, window=0.05)
+        monitor._record(0.5)
+        assert monitor.stall_within(10.0) >= 0.5
+
+        time.sleep(0.06)
+        monitor._record(0.001)          # any sample prunes what is now too old
+
+        assert monitor.stall_within(10.0) < 0.5
+        assert monitor.max_stall >= 0.5   # the worst seen is not forgotten
+
+    def test_observed_fraction_is_bounded(self):
+        monitor = FakeMonitor(stall=99.0)
+        assert monitor.observed_fraction(2.0) == 0.0
+        assert FakeMonitor(stall=0.0).observed_fraction(2.0) == 1.0
+
+    def test_a_zero_window_is_fully_observed(self):
+        assert SchedulingMonitor().observed_fraction(0) == 1.0
+        assert SchedulingMonitor().stall_within(0) == 0.0
+
+
+# ──────────────────────────────────────────────────────────────────
+# Declining the accusation
+# ──────────────────────────────────────────────────────────────────
+
+class TestSuspicionGuard:
+
+    def _guard(self, stall, **kwargs):
+        members = RecordingMemberList()
+        guard = SuspicionGuard(FakeMonitor(stall), probe_budget=2.0, **kwargs)
+        guard.attach(members)
+        return members, guard
+
+    @pytest.mark.asyncio
+    async def test_a_watched_timeout_still_accuses(self):
+        members, guard = self._guard(stall=0.0)
+
+        assert await members.mark_suspect(("10.0.0.1", 7946)) is True
+        assert members.suspected == [(("10.0.0.1", 7946), "ping_timeout")]
+        assert guard.stats.raised == 1
+
+    @pytest.mark.asyncio
+    async def test_a_starved_timeout_does_not(self):
+        members, guard = self._guard(stall=1.8)
+
+        assert await members.mark_suspect(("10.0.0.1", 7946)) is False
+        assert members.suspected == []
+        assert guard.stats.declined == 1
+        assert guard.stats.last_declined_peer == "10.0.0.1:7946"
+
+    @pytest.mark.asyncio
+    async def test_the_peer_is_left_alive_for_the_next_probe(self):
+        """Declining defers the judgement; it does not assert the peer is well."""
+        members, guard = self._guard(stall=1.8)
+        await members.mark_suspect(("10.0.0.1", 7946))
+
+        guard._monitor = FakeMonitor(0.0)     # the pause is over
+        assert await members.mark_suspect(("10.0.0.1", 7946)) is True
+        assert members.suspected == [(("10.0.0.1", 7946), "ping_timeout")]
+
+    @pytest.mark.asyncio
+    async def test_suspicion_from_another_node_is_never_declined(self):
+        """Their observation is not affected by our scheduling."""
+        members, guard = self._guard(stall=99.0)
+
+        assert await members.mark_suspect(
+            ("10.0.0.1", 7946), None, "gossip", None,
+        ) is True
+        assert guard.stats.declined == 0
+
+    @pytest.mark.asyncio
+    async def test_the_declared_probe_window_is_used_when_given(self):
+        members, guard = self._guard(stall=1.0)
+
+        # 1.0s stall against a 10s probe: most of the window was watched.
+        assert await members.mark_suspect(
+            ("10.0.0.1", 7946), None, "ping_timeout", 10.0,
+        ) is True
+        # The same stall against a 1.5s probe: most of it was not.
+        assert await members.mark_suspect(
+            ("10.0.0.2", 7946), None, "ping_timeout", 1.5,
+        ) is False
+
+    @pytest.mark.asyncio
+    async def test_the_threshold_is_configurable(self):
+        members, _ = self._guard(stall=1.0, min_observed_fraction=0.9)
+        assert await members.mark_suspect(("10.0.0.1", 7946)) is False
+
+        members, _ = self._guard(stall=1.0, min_observed_fraction=0.1)
+        assert await members.mark_suspect(("10.0.0.1", 7946)) is True
+
+    @pytest.mark.asyncio
+    async def test_every_local_timeout_reason_is_covered(self):
+        for reason in LOCAL_OBSERVATION_REASONS:
+            members, guard = self._guard(stall=99.0)
+            assert await members.mark_suspect(
+                ("10.0.0.1", 7946), None, reason, None,
+            ) is False, reason
+
+    @pytest.mark.asyncio
+    async def test_declines_are_counted_not_silent(self):
+        members, guard = self._guard(stall=1.8)
+        await members.mark_suspect(("10.0.0.1", 7946))
+
+        stats = guard.stats.to_dict()
+        assert stats["declined"] == 1
+        assert stats["max_stall_seconds"] >= 1.7
+        assert stats["last_declined_peer"] == "10.0.0.1:7946"
+
+
+class TestEndToEnd:
+
+    @pytest.mark.asyncio
+    async def test_inference_in_process_does_not_flap_a_live_peer(self):
+        """The reported failure: four nodes, LLM work, peers marked DEAD."""
+        monitor = SchedulingMonitor(tick=0.01)
+        monitor.start()
+        await asyncio.sleep(0.03)             # the monitor is ticking
+        members = RecordingMemberList()
+        guard = SuspicionGuard(monitor, probe_budget=0.5)
+        guard.attach(members)
+
+        time.sleep(0.4)                       # a model holds the GIL
+        await asyncio.sleep(0.02)
+        declined = await members.mark_suspect(("10.0.0.1", 7946))
+
+        monitor.stop()
+        assert declined is False
+        assert members.suspected == []
+        assert guard.stats.declined == 1
+
+    @pytest.mark.asyncio
+    async def test_a_pause_small_against_the_budget_still_accuses(self):
+        """The guard is proportional: a brief pause is not an excuse."""
+        monitor = SchedulingMonitor(tick=0.01)
+        monitor.start()
+        await asyncio.sleep(0.03)
+        members = RecordingMemberList()
+        SuspicionGuard(monitor, probe_budget=10.0).attach(members)
+
+        time.sleep(0.3)
+        await asyncio.sleep(0.02)
+        raised = await members.mark_suspect(("10.0.0.1", 7946))
+
+        monitor.stop()
+        assert raised is True


### PR DESCRIPTION
SWIM marked live peers SUSPECT then DEAD while nodes ran LLM work in the same process, and LIFEGUARD flagged the results as likely false positives — the detector noticing it had been misled without being able to say why.

## Where the wrong inference is made

`FailureDetector.ping` retries, times out, and calls:

```python
await self.members.mark_suspect(target)     # suspicion_reason="ping_timeout"
```

That single line is where an observation about **our own socket** becomes a claim about **someone else's liveness** — made without asking whether this process was running while the budget elapsed.

When the SWIM thread is descheduled — a long GIL hold from tokenizer or inference work, a blocking call on another thread — the PONG can arrive perfectly on time and simply not be read until later. The timeout is then a fact about us, and we report it as a fact about the peer.

## Why the existing mitigation isn't the fix

`main` raises `PING_TIMEOUT` to 2s, `SUSPECT_TIMEOUT` to 15s, and disables adaptive timing. Its own comment concedes the point:

> *"Until transport runs in its own process, probe budgets must assume inference pauses, not idle latency."*

Those are guesses about how long inference might hold the GIL. A pause has no fixed size — it scales with model, batch and hardware. And a budget large enough for the worst pause is also large enough to **miss a genuinely dead peer for that long**. Tuning the number trades one wrong answer for another.

Note the library's own adaptive timing makes it worse, not better: it tunes toward idle sub-millisecond RTTs, so the budget shrinks precisely when the process is quiet and then a pause blows straight through it.

## Measure the stall instead of guessing it

`SchedulingMonitor` sleeps a fixed tick and compares elapsed time against the interval it asked for. The difference is exactly how long the loop was not running. No other component has to cooperate and nothing is inferred — it's the gap between what we asked the loop for and what the loop gave us.

`SuspicionGuard` wraps `mark_suspect`. When the reason is a timeout **we** observed and the loop was descheduled for more than half the probe window, the suspicion is declined:

```
SWIM suspicion declined for 127.0.0.1:7949 — this process was descheduled for
1.31s of a 2.00s probe window, so the timeout describes us, not the peer.
Re-probing next cycle.
```

**The judgement is deferred, not overruled.** Nothing here decides a peer is healthy; it declines to claim the opposite from evidence we did not collect. The peer stays ALIVE and is probed again next cycle by a probe we can actually watch.

**Suspicion from other nodes is untouched.** That arrives through `merge_digest`, is their observation rather than ours, and our scheduling has no bearing on whether it's true. Only the reasons in `LOCAL_OBSERVATION_REASONS` are gated.

The guard is proportional, which matters: a 0.3s pause against a 10s budget still accuses, because 97% of that window *was* watched. There's a test for exactly that, so this can't quietly become "never suspect anything".

## Not silent

`SuspicionGuard.stats` carries `raised`, `declined`, `max_stall_seconds` and `last_declined_peer`, and every decline logs at info with the stall that caused it. A node suppressing suspicion constantly is visible rather than quietly tolerant — which is the failure mode this class of fix invites.

## Honest scope

This does not eliminate the stall. Transport in its own process is still the way to stop LLM work descheduling the failure detector, and this doesn't do that. What it does is stop the stall being **misattributed to a peer**, which is the correctness problem the issue names: *"false-positive failure detection under load is a correctness problem for any workload that reacts to peer death."*

The `PING_TIMEOUT` / `SUSPECT_TIMEOUT` floors stay as protection against ordinary jitter. They're no longer the mechanism.

## Tests

`tests/test_swim_starvation.py` — **15 passed**. A blocked loop is simulated with `time.sleep`, which is what a GIL-holding tokenizer looks like from asyncio's side.

Covers: an unblocked loop reporting no stall; a blocked one reporting it; window pruning while `max_stall` is retained; a watched timeout still accusing; a starved one declining; the peer accused normally on the next probe once the pause ends; gossip suspicion never declined; the declared probe window respected; the threshold configurable; every local-timeout reason gated; declines counted; and the end-to-end case from the issue.

Closes #138
