### PR TITLE
fix(kernel): the router is told whether a declared system can be authenticated

### DIFF
--- a/jarviscore/kernel/kernel.py
+++ b/jarviscore/kernel/kernel.py
@@ -29,6 +29,7 @@ from jarviscore.context.context_manager import ContextManager, BudgetConfig
 from jarviscore.execution.llm import LLMProvider
 from jarviscore.kernel.lease import ExecutionLease, ROLE_LEASE_PROFILES
 from jarviscore.kernel.cognition import AgentCognitionManager
+from jarviscore.context.fidelity import Record, select_whole
 from jarviscore.kernel.state import KernelState
 from jarviscore.kernel.hitl import AdaptiveHITLPolicy
 from jarviscore.promo import PROMO_MODEL
@@ -42,6 +43,16 @@ _BUILTIN_KERNEL_ROLES = frozenset(ROLE_LEASE_PROFILES.keys())
 
 class RoutingError(RuntimeError):
     """Raised when Kernel cannot obtain a valid, typed routing decision."""
+
+
+#: Roles that can use a resolved Nexus credential. The coder sandbox holds the
+#: only call proxy, so every other role reaches a declared system unauthenticated.
+CREDENTIALED_ROLES = frozenset({"coder"})
+
+_ROUTING_ESSENTIAL_KEYS = frozenset({
+    "workflow_id", "step_id", "system", "system_credentials_available",
+})
+_ROUTER_CONTEXT_BUDGET_CHARS = 8000
 
 
 @dataclass(frozen=True)
@@ -71,6 +82,15 @@ Built-in role contract:
 - researcher: gather unknown facts from web/docs/files, investigate, compare evidence.
 - communicator: draft/review/summarize/structure decisions, reports, messages, requests, JSON contracts.
 - browser: operate an interactive browser/UI: navigation, clicks, screenshots, forms, login flows.
+
+Credentials:
+context_summary may carry system_credentials_available. When it is true, the task
+names a system this deployment can already authenticate to, and only coder can use
+that credential — every other role would have to reach the system unauthenticated
+and ask a human to log in to something access was already granted for. Treat such a
+task as API work and route it to coder, unless it genuinely requires interactive UI
+that no API exposes. When it is false, the credential is missing rather than unused,
+and the choice of role does not change that.
 
 Use the task, context summary, agent default role, and available registry/handoff context.
 For custom roles, use role_catalog from the payload as the authoritative contract.
@@ -162,17 +182,28 @@ processing is actually required.
             "step_id",
             "complexity",
             "system",
+            "system_credentials_available",
             "previous_step_results",
             "registry_candidate",
             "meeting_step_id",
             "task_id",
         ]
-        summary: Dict[str, Any] = {}
-        for key in keys:
-            if key in context:
-                value = context[key]
-                rendered = json.dumps(value, ensure_ascii=False, default=str)
-                summary[key] = rendered[:1200]
+        records = [
+            Record(
+                key=key,
+                text=json.dumps(context[key], ensure_ascii=False, default=str),
+                # Identity and credential availability decide the route; the rest
+                # is supporting detail that can be left out whole if it will not fit.
+                priority=0 if key in _ROUTING_ESSENTIAL_KEYS else 1,
+            )
+            for key in keys
+            if key in context
+        ]
+        selection = select_whole(records, _ROUTER_CONTEXT_BUDGET_CHARS)
+        summary: Dict[str, Any] = {record.key: record.text for record in selection.kept}
+        if not selection.complete:
+            # A router reading half a JSON value is reading a different value.
+            summary["withheld"] = selection.notice("the step context")
         return summary
 
     @staticmethod
@@ -333,6 +364,36 @@ class Kernel:
         return None
 
 
+    async def _resolve_connection(self, system_name: str) -> Optional[str]:
+        """Opaque connection handle for a declared system, or None if we hold none.
+
+        Asked twice per dispatch and answered the same way both times: once before
+        routing, so the router knows whether a credentialed path exists, and again
+        at dispatch to tag the coder's context. Never returns credential material.
+        """
+        if not system_name:
+            return None
+        if self.auth_manager:
+            try:
+                conn_id = await self.auth_manager.get_connection_id(system_name)
+                if conn_id is not None:
+                    return conn_id
+            except Exception as auth_exc:
+                logger.debug(
+                    "[Kernel] Nexus gateway unavailable for system=%s — "
+                    "trying local vault: %s",
+                    system_name, auth_exc,
+                )
+        # Local-vault mode: connection_id IS the provider name — NexusCallProxy
+        # resolves it from NexusLocalStore at call time.
+        try:
+            from jarviscore.nexus.store import get_store
+            if get_store().get(system_name):
+                return system_name
+        except Exception as store_exc:
+            logger.debug("[Kernel] Nexus local vault unavailable: %s", store_exc)
+        return None
+
     async def _route_task(
         self,
         task: str,
@@ -344,6 +405,11 @@ class Kernel:
         """
         Route a task into a subagent role using explicit contracts first, then
         a structured LLM router. Keyword routing is intentionally not used.
+
+        A declared system is resolved before routing so the router is told whether
+        credentials exist for it. Without that, it chose rationally from what it
+        had and sent tasks holding a working token to roles that cannot use one,
+        which then asked a human to log in (#152).
         """
         explicit_role = None
         if context:
@@ -361,11 +427,30 @@ class Kernel:
                 reason="Explicit planner/profile role.",
             )
 
-        return await self._task_router.route(
+        system_name = (context or {}).get("system")
+        routing_context = dict(context or {})
+        credentialed = False
+        if system_name:
+            credentialed = await self._resolve_connection(str(system_name)) is not None
+            routing_context["system_credentials_available"] = credentialed
+
+        decision = await self._task_router.route(
             task=task,
-            context=context,
+            context=routing_context,
             agent_default_role=agent_default_role,
         )
+
+        if credentialed and decision.role not in CREDENTIALED_ROLES:
+            # Not overridden: the router may have a reason this task needs a UI.
+            # But a credential we hold and did not use is worth saying out loud,
+            # because the symptom is an agent asking for access it already has.
+            logger.warning(
+                "[Kernel] system=%s has resolvable credentials, but routed to %s, "
+                "which has no credential path — the token will not be used and the "
+                "run may ask a human to log in. Router reason: %s",
+                system_name, decision.role, decision.reason,
+            )
+        return decision
 
     def _lease_for_role(self, role: str) -> ExecutionLease:
         """Create a lease from built-in or application-registered role profile."""
@@ -765,27 +850,7 @@ class Kernel:
                     or (context.get("system") if context else None)
                 )
                 if system_name:
-                    conn_id = None
-                    if self.auth_manager:
-                        try:
-                            conn_id = await self.auth_manager.get_connection_id(system_name)
-                        except Exception as auth_exc:
-                            logger.debug(
-                                "[Kernel] Nexus gateway unavailable for system=%s — "
-                                "trying local vault: %s",
-                                system_name, auth_exc,
-                            )
-                    if conn_id is None:
-                        # Local-vault mode: connection_id IS the provider name —
-                        # NexusCallProxy resolves it from NexusLocalStore at call time.
-                        try:
-                            from jarviscore.nexus.store import get_store
-                            if get_store().get(system_name):
-                                conn_id = system_name
-                        except Exception as store_exc:
-                            logger.debug(
-                                "[Kernel] Nexus local vault unavailable: %s", store_exc
-                            )
+                    conn_id = await self._resolve_connection(str(system_name))
                     if conn_id is not None:
                         # Only the opaque handle goes into context — NEVER tokens or keys
                         enriched_context["_nexus_connection_id"] = conn_id

--- a/tests/test_router_credentials.py
+++ b/tests/test_router_credentials.py
@@ -1,0 +1,218 @@
+"""The router is told whether a declared system can be authenticated (#152).
+
+A CRM agent with a registered HubSpot token was asked to read its contacts. The
+router saw `system: "hubspot"` and a role contract advertising `browser: ...
+forms, login flows`, chose browser, and the run ended by asking a human to sign
+in to a system it already held a working token for.
+
+The router was choosing rationally from what it was told. It was not told the
+thing that mattered, because credentials are resolved after routing and only for
+the coder. So resolve first, and put the answer in the payload.
+"""
+
+import json
+
+import pytest
+
+from jarviscore.kernel.kernel import (
+    CREDENTIALED_ROLES,
+    Kernel,
+    RoutingDecision,
+    TaskRouter,
+)
+
+
+class RecordingRouter:
+    def __init__(self, role="browser"):
+        self.role = role
+        self.contexts = []
+
+    async def route(self, *, task, context=None, agent_default_role=None):
+        self.contexts.append(dict(context or {}))
+        return RoutingDecision(role=self.role, confidence=0.9, reason="test")
+
+
+def _kernel(router, *, vault=None):
+    kernel = Kernel.__new__(Kernel)
+    kernel._task_router = router
+    kernel.auth_manager = None
+    kernel._role_lease_profiles = {
+        "coder": object(), "browser": object(),
+        "researcher": object(), "communicator": object(),
+    }
+    kernel._vault = vault or {}
+    return kernel
+
+
+@pytest.fixture
+def local_vault(monkeypatch):
+    """Stand in for the Nexus local store."""
+    registered = set()
+
+    class Store:
+        def get(self, name):
+            return {"token": "..."} if name in registered else None
+
+    monkeypatch.setattr(
+        "jarviscore.nexus.store.get_store", lambda: Store(), raising=False,
+    )
+    return registered
+
+
+# ──────────────────────────────────────────────────────────────────
+# The router is told
+# ──────────────────────────────────────────────────────────────────
+
+class TestRouterSeesCredentials:
+
+    @pytest.mark.asyncio
+    async def test_a_resolvable_system_is_reported_as_available(self, local_vault):
+        local_vault.add("hubspot")
+        router = RecordingRouter(role="coder")
+        kernel = _kernel(router)
+
+        await kernel._route_task("Read our CRM", {"system": "hubspot"})
+
+        assert router.contexts[0]["system_credentials_available"] is True
+
+    @pytest.mark.asyncio
+    async def test_an_unregistered_system_is_reported_as_unavailable(self, local_vault):
+        router = RecordingRouter(role="coder")
+        kernel = _kernel(router)
+
+        await kernel._route_task("Read our CRM", {"system": "hubspot"})
+
+        assert router.contexts[0]["system_credentials_available"] is False
+
+    @pytest.mark.asyncio
+    async def test_no_declared_system_says_nothing_either_way(self, local_vault):
+        router = RecordingRouter(role="researcher")
+        kernel = _kernel(router)
+
+        await kernel._route_task("Find the top three competitors", {})
+
+        assert "system_credentials_available" not in router.contexts[0]
+
+    @pytest.mark.asyncio
+    async def test_the_caller_context_is_not_mutated(self, local_vault):
+        local_vault.add("hubspot")
+        router = RecordingRouter(role="coder")
+        context = {"system": "hubspot"}
+
+        await _kernel(router)._route_task("Read our CRM", context)
+
+        assert context == {"system": "hubspot"}
+
+
+class TestDiscardedCredentialIsVisible:
+
+    @pytest.mark.asyncio
+    async def test_routing_away_from_a_held_credential_warns(self, local_vault, caplog):
+        local_vault.add("hubspot")
+        router = RecordingRouter(role="browser")
+
+        with caplog.at_level("WARNING"):
+            await _kernel(router)._route_task("Read our CRM", {"system": "hubspot"})
+
+        assert "has resolvable credentials" in caplog.text
+        assert "browser" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_the_router_is_not_overridden(self, local_vault):
+        """A task may genuinely need a UI. The decision stays the router's."""
+        local_vault.add("hubspot")
+        router = RecordingRouter(role="browser")
+
+        decision = await _kernel(router)._route_task("Read our CRM", {"system": "hubspot"})
+
+        assert decision.role == "browser"
+
+    @pytest.mark.asyncio
+    async def test_the_credentialed_route_does_not_warn(self, local_vault, caplog):
+        local_vault.add("hubspot")
+        router = RecordingRouter(role="coder")
+
+        with caplog.at_level("WARNING"):
+            await _kernel(router)._route_task("Read our CRM", {"system": "hubspot"})
+
+        assert "resolvable credentials" not in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_no_warning_when_there_is_no_credential_to_discard(self, local_vault, caplog):
+        router = RecordingRouter(role="browser")
+
+        with caplog.at_level("WARNING"):
+            await _kernel(router)._route_task("Read our CRM", {"system": "hubspot"})
+
+        assert "resolvable credentials" not in caplog.text
+
+    def test_coder_is_the_only_credentialed_role(self):
+        """The coder sandbox holds the sole call proxy; this encodes that."""
+        assert CREDENTIALED_ROLES == frozenset({"coder"})
+
+
+class TestExplicitRoleStillWins:
+
+    @pytest.mark.asyncio
+    async def test_an_explicit_role_skips_the_router_entirely(self, local_vault):
+        local_vault.add("hubspot")
+        router = RecordingRouter(role="coder")
+        kernel = _kernel(router)
+
+        decision = await kernel._route_task(
+            "Read our CRM", {"system": "hubspot"},
+            agent_default_role="communicator",
+            use_default_role_as_fallback=False,
+        )
+
+        assert decision.role == "communicator"
+        assert router.contexts == []
+
+
+# ──────────────────────────────────────────────────────────────────
+# The payload the router reads
+# ──────────────────────────────────────────────────────────────────
+
+class TestContextSummary:
+
+    def test_credential_availability_is_forwarded(self):
+        summary = TaskRouter._summarize_context({
+            "system": "hubspot", "system_credentials_available": True,
+        })
+        assert json.loads(summary["system_credentials_available"]) is True
+
+    def test_values_are_never_cut_mid_json(self):
+        """A router reading half a JSON value is reading a different value."""
+        summary = TaskRouter._summarize_context({
+            "previous_step_results": {"rows": ["x" * 4000]},
+        })
+        json.loads(summary["previous_step_results"])      # parses, so it is whole
+
+    def test_an_oversized_value_is_withheld_whole_and_named(self):
+        summary = TaskRouter._summarize_context({
+            "workflow_id": "wf-1",
+            "system": "hubspot",
+            "previous_step_results": {"rows": ["x" * 20000]},
+        })
+
+        assert "previous_step_results" not in summary
+        assert "previous_step_results" in summary["withheld"]
+        assert json.loads(summary["system"]) == "hubspot"
+
+    def test_routing_essentials_survive_a_crowded_context(self):
+        summary = TaskRouter._summarize_context({
+            "system": "hubspot",
+            "system_credentials_available": True,
+            "registry_candidate": {"code": "y" * 30000},
+        })
+
+        assert json.loads(summary["system"]) == "hubspot"
+        assert json.loads(summary["system_credentials_available"]) is True
+
+    def test_unlisted_keys_are_not_forwarded(self):
+        summary = TaskRouter._summarize_context({"_nexus_connection_id": "secret-handle"})
+        assert summary == {}
+
+    def test_a_small_context_is_complete(self):
+        summary = TaskRouter._summarize_context({"workflow_id": "wf-1", "step_id": "s1"})
+        assert "withheld" not in summary


### PR DESCRIPTION
A CRM agent holding a registered HubSpot token was asked to read its contacts. The router saw `system: "hubspot"`, read a role contract advertising `browser: ... forms, login flows`, chose browser, and the run ended like this:

```
tool_result   {"url": "https://app.hubspot.com/login", "title": "HubSpot Login and Sign in"}
step_complete {"success": true, "summary": "Authentication is required to access the HubSpot CRM..."}
```

It asked a human to sign in to a system it already had a working token for. The same agent on the coder path reaches `api.hubapi.com` through `nexus_call` with nobody involved.

## The router was choosing rationally

It just wasn't told the thing that mattered. Credentials are resolved **after** routing and **only for the coder** — correct, since the coder sandbox is the sole credential boundary — but it means the one fact deciding whether a role can do the job at all was never in the payload. Meanwhile `browser: ... login flows` reads as a perfect match for "log into a CRM and read a number".

## Resolve first, then decide

`_resolve_connection` now answers that question in one place and is asked twice per dispatch: once **before** routing so the decision is made with it, and again at dispatch to tag the coder's context. Same question, same answer, one implementation — the dispatch path previously carried its own copy of the gateway-then-vault logic.

It returns an opaque handle or `None`. **No credential material enters the routing payload** — only whether one exists.

The contract gains a paragraph explaining what the flag means: only coder can use a resolved credential, so a task naming an authenticated system is API work unless it genuinely needs interactive UI no API exposes.

## The decision stays the router's

I did not make this a rule that forces `coder`. A task may really need a browser — an admin page with no API, a report only rendered in a UI — and a boolean is not a licence to overrule a model that can read the task. What was missing was the **fact**, not the authority.

What does change: when a credential resolves and the task is routed somewhere that cannot use it, that is now a warning naming the system, the role and the router's reason.

```
[Kernel] system=hubspot has resolvable credentials, but routed to browser, which has
no credential path — the token will not be used and the run may ask a human to log in.
Router reason: ...
```

Nothing distinguished "no credential" from "credential ignored" before, so the discard reached the operator only as an agent asking for access it already had.

## `_summarize_context` was clipping mid-JSON

Not in the issue, but the same bug class, in the payload this fix depends on:

```python
rendered = json.dumps(value, ensure_ascii=False, default=str)
summary[key] = rendered[:1200]
```

Render to JSON, then slice the string. Any context over 1200 characters reached the router as a fragment that **no longer parses** — the same failure #154 removed from the kernel and #166 from the planner. Fixing credential visibility while leaving the payload carrying half-values would have been fixing one field in a message that was already damaged.

Values are now included whole or withheld whole and named, using `jarviscore.context.fidelity` from #166. `workflow_id`, `step_id`, `system` and `system_credentials_available` are priority 0, so a large `previous_step_results` cannot push out the fields the route depends on.

## Tests

`tests/test_router_credentials.py` — **16 passed**. Availability reported both ways and absent when no system is declared; the caller's context not mutated; the discard warning firing only when there is something to discard; the router **not** overridden; explicit roles still bypassing the router entirely; and the payload never cut mid-value, withholding whole values by name, and keeping routing essentials under pressure.

Existing kernel suites: 87 passed.

Closes #152
