### PR TITLE
feat(mesh): durable obligation reconciliation for 1.11.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,7 +291,7 @@ class MyAgent(CustomAgent):
 
 ### P2P Mesh and Distributed Workflows
 
-Agents discover each other over a SWIM protocol gossip mesh using ZMQ transport. Workflows execute across machines with Redis-backed crash recovery and step claiming.
+Agents discover each other over a SWIM protocol gossip mesh using ZMQ transport. Workflows execute across machines with Redis-backed crash recovery and step claiming. For goals whose steps are not known in advance, `Mesh.execute_goal()` publishes capability-addressed work without creating a master agent router.
 
 ```python
 mesh = Mesh(config={
@@ -299,7 +299,18 @@ mesh = Mesh(config={
     "bind_port": 7950,
     "redis_url": "redis://localhost:6379/0",
 })
+
+await mesh.start()
+result = await mesh.execute_goal(
+  "Inspect the active opportunity and prepare a decision brief.",
+  workflow_id="opportunity-2026-09-11",
+)
+print(result["status"], result["obligation_status"], result["response_status"])
 ```
+
+Attempts remain immutable across revisions. Reconciliation appends work only for
+unresolved obligation IDs, while satisfied obligations retain their evidence.
+See [Durable Goal Execution](https://jarviscore.developers.prescottdata.io/guides/goal-execution/).
 
 ### Observability
 

--- a/jarviscore/context/context_manager.py
+++ b/jarviscore/context/context_manager.py
@@ -344,6 +344,9 @@ class ContextManager:
             mission += f"**CRITICAL ERROR TO FIX:** {state.last_error}\n"
         add("mission", mission)
         add("goal_state", self._build_goal_state_block(state.context or {}))
+        mailbox_context = (state.context or {}).get("_mailbox_context")
+        if mailbox_context:
+            add("mailbox", str(mailbox_context))
 
         if state.failure_ledger:
             lines = ["## FAILURE MEMORY (Do Not Repeat)"]
@@ -439,8 +442,16 @@ class ContextManager:
                 output = (step_result.get("output", step_result)
                           if isinstance(step_result, dict) else step_result)
                 input_block += f"**[Prior Step: {step_id}]**\n{output}\n\n"
+        interpretations = state.context.get("previous_step_interpretations", {})
+        if interpretations:
+            for step_id, interpretation in interpretations.items():
+                input_block += (
+                    f"**[Prior Step Interpretation: {step_id}]**\n"
+                    f"{self._scrub_value('interpretation', interpretation)}\n\n"
+                )
 
         skip_keys = {"previous_step_results", "workflow_id", "step_id",
+                     "previous_step_interpretations",
                      "system_prompt", "_jarvis_context", "_auth_credentials",
                      "_agent_default_kernel_role",
                      "_goal", "_goal_id", "_goal_facts",
@@ -448,7 +459,8 @@ class ContextManager:
                      "_plan_revision",
                      # Memory is rendered as what it is, in its own block. Under
                      # INPUT CONTEXT it read as part of the task.
-                     "_recalled", "_athena_memory", "_ltm_summary"}
+                     "_recalled", "_athena_memory", "_ltm_summary",
+                     "_mailbox_context"}
         other = {key: value for key, value in state.context.items() if key not in skip_keys}
         allowed = set(filter_input_context_keys(other.keys(), tier))
         cleaned = self._scrub_dict({k: v for k, v in other.items() if k in allowed})

--- a/jarviscore/context/pressure.py
+++ b/jarviscore/context/pressure.py
@@ -58,6 +58,7 @@ BLOCK_PRIORITY: Dict[str, int] = {
     "budget": 0,
     "failure_memory": 1,
     "knowledge": 1,
+    "mailbox": 1,
     "belief_state": 1,
     "working_memory": 1,
     "input_context": 2,

--- a/jarviscore/context/truth.py
+++ b/jarviscore/context/truth.py
@@ -141,7 +141,7 @@ class AgentOutput(BaseModel):
         trajectory: Tool execution path taken (for audit)
         metadata: Additional context (evidence, facts, cost, etc.)
     """
-    status: Literal["success", "failure", "yield"]
+    status: Literal["success", "failure", "yield", "epoch_exhausted"]
     payload: Optional[Any] = None
     summary: str = ""
     trajectory: List[Dict[str, Any]] = Field(default_factory=list)

--- a/jarviscore/core/agent.py
+++ b/jarviscore/core/agent.py
@@ -12,8 +12,11 @@ from abc import ABC, abstractmethod
 from typing import List, Dict, Any, Optional, TYPE_CHECKING
 from uuid import uuid4
 import asyncio
+import json
 import logging
 import os
+
+from jarviscore.orchestration.envelopes import neutral_context
 
 if TYPE_CHECKING:
     from jarviscore.p2p import PeerClient
@@ -42,6 +45,7 @@ class Agent(ABC):
     # Class attributes - user must define these
     role: str = None
     capabilities: List[str] = []
+    capability_descriptions: Dict[str, str] = {}
 
     # Optional capability flags
     p2p_responder: bool = False  # Set to True for agents that run a continuous listener loop (e.g. CustomAgent)
@@ -124,6 +128,96 @@ class Agent(ABC):
         raise NotImplementedError(
             f"{self.__class__.__name__} must implement execute_task()"
         )
+
+    async def execute_capability_request(
+        self,
+        capability: str,
+        question: str,
+        context: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        """Execute a peer need using this agent's own declared authority."""
+        if capability not in self.capabilities:
+            return {
+                "status": "failure",
+                "error": f"{self.role} does not own capability {capability!r}.",
+            }
+        request_context = neutral_context(context)
+        if isinstance((context or {}).get("execution_budget"), dict):
+            request_context["execution_budget"] = dict(
+                (context or {})["execution_budget"]
+            )
+        request_context["capability"] = capability
+        contract = (
+            getattr(self, "capability_contracts", {}) or {}
+        ).get(capability) or {}
+        systems = [str(value) for value in contract.get("systems") or []]
+        effects = [str(value) for value in contract.get("effects") or []]
+        if systems:
+            request_context["systems"] = systems
+            if len(systems) == 1:
+                request_context["system"] = systems[0]
+        for effect in ("read", "propose", "write", "notify", "destructive"):
+            if effect in effects:
+                request_context["effect"] = effect
+                break
+        lock = getattr(self, "_peer_execution_lock", None)
+        if lock is None:
+            return await self.execute_task({"task": question, "context": request_context})
+        async with lock:
+            return await self.execute_task({"task": question, "context": request_context})
+
+    async def authorize_dependencies(
+        self,
+        task: str,
+        artifacts: Dict[str, Any],
+        interpretations: Dict[str, Any],
+    ):
+        """Decide whether upstream uncertainty materially prevents this task."""
+        from jarviscore.orchestration.envelopes import DependencyAuthorization
+
+        unresolved = {
+            step_id: interpretation
+            for step_id, interpretation in interpretations.items()
+            if isinstance(interpretation, dict)
+            and interpretation.get("verdict") != "satisfied"
+        }
+        if not unresolved:
+            return DependencyAuthorization("allow", "Dependencies are satisfied.")
+        llm = getattr(self, "llm", None)
+        if llm is None:
+            return DependencyAuthorization(
+                "block",
+                "Upstream uncertainty requires an explicit recipient decision.",
+            )
+        prompt = (
+            "You own the downstream task. Decide whether upstream uncertainty "
+            "materially prevents this task. Allow when the unresolved concern is "
+            "unrelated and the artifact contains every fact this task needs. Block "
+            "when a required fact or safety precondition is missing. Do not decide "
+            "the business outcome itself. Return only JSON: "
+            '{"decision":"allow|block","reason":"..."}.\n\n'
+            f"Downstream task: {task}\n"
+            f"Upstream artifacts: {json.dumps(artifacts, default=str)}\n"
+            f"Upstream interpretations: {json.dumps(unresolved, default=str)}"
+        )
+        try:
+            kwargs = {
+                "messages": [{"role": "user", "content": prompt}],
+                "response_format": {"type": "json_object"},
+            }
+            if getattr(llm, "nano_model", None):
+                kwargs["model"] = llm.nano_model
+            try:
+                response = await llm.generate(**kwargs)
+            except TypeError:
+                kwargs.pop("response_format", None)
+                response = await llm.generate(**kwargs)
+            content = response.get("content", "") if isinstance(response, dict) else str(response)
+            return DependencyAuthorization.from_response(content)
+        except Exception as exc:
+            return DependencyAuthorization(
+                "block", f"Dependency authorization failed closed: {exc}"
+            )
 
     async def setup(self):
         """

--- a/jarviscore/core/mesh.py
+++ b/jarviscore/core/mesh.py
@@ -748,9 +748,21 @@ class Mesh:
             records = [self._redis_store.get_step_definition(workflow_id, step_id) or {}
                        for step_id in step_ids]
             statuses = [record.get("status") for record in records]
-            if statuses and all(
-                status in {"completed", "failed", "waiting", "blocked", "cancelled"}
-                for status in statuses
+            revision = int(definition.get("revision", 1))
+            current_records = [
+                record for record in records
+                if int(record.get("plan_revision", 1)) == revision
+            ] or records
+            current_step_ids = {
+                str(record.get("id")) for record in current_records if record.get("id")
+            }
+            current_statuses = [record.get("status") for record in current_records]
+            if current_statuses and all(
+                status in {
+                    "completed", "failed", "waiting", "blocked", "cancelled",
+                    "superseded",
+                }
+                for status in current_statuses
             ):
                 steps = []
                 dependency_ids = {
@@ -764,24 +776,159 @@ class Mesh:
                     envelope = saved.get("output") if saved else None
                     steps.append({**record, "output": envelope})
                     if (
-                        step_id not in dependency_ids
+                        step_id in current_step_ids
+                        and step_id not in dependency_ids
                         and record.get("status") == "completed"
                         and isinstance(envelope, dict)
                         and isinstance(envelope.get("result_summary"), str)
                         and envelope["result_summary"].strip()
                     ):
                         terminal_summaries.append(envelope["result_summary"].strip())
+                obligation_projection = self._redis_store.get_obligation_projection(
+                    workflow_id
+                )
+                semantic_gaps = [
+                    obligation for obligation in obligation_projection.values()
+                    if obligation.get("state") == "unresolved"
+                    and obligation.get("attempt_interpretations")
+                ]
+                settlement = self._redis_store.get_workflow_reconciliation_settlement(
+                    workflow_id, revision
+                )
+                if not semantic_gaps and revision > 1 and settlement is None:
+                    settlement = {
+                        "event": "semantic_reconciliation_settled",
+                        "revision": revision,
+                        "obligation_status": "satisfied",
+                        "reason": "The amended workflow satisfied the outstanding obligations.",
+                    }
+                    self._redis_store.save_workflow_reconciliation_settlement(
+                        workflow_id, revision, settlement
+                    )
+                if semantic_gaps and settlement is None and self._has_planning_llm():
+                    max_revisions = max(
+                        1, int(self.config.get("mesh_max_reconciliation_revisions", 3))
+                    )
+                    if revision < max_revisions:
+                        from jarviscore.planning.mesh_planner import MeshPlanner
+
+                        lease_seconds = int(self.config.get(
+                            "mesh_planning_lease_seconds", 300
+                        ))
+                        if not self._redis_store.claim_workflow_reconciliation(
+                            workflow_id, revision, self._node_id, lease_seconds
+                        ):
+                            await asyncio.sleep(interval)
+                            continue
+                        try:
+                            settlement = (
+                                self._redis_store.get_workflow_reconciliation_settlement(
+                                    workflow_id, revision
+                                )
+                            )
+                            if settlement is not None:
+                                continue
+                            planner = MeshPlanner(
+                                self._planning_llm(),
+                                capabilities=self._mesh_capability_catalog(),
+                                response_capability=self.config.get(
+                                    "mesh_response_capability"
+                                ),
+                            )
+                            with workflow_budget_scope(
+                                self._redis_store,
+                                workflow_id,
+                                epoch_id=f"reconciliation:{revision}:{self._node_id}",
+                            ):
+                                decision = await planner.reconciliation_decision(
+                                    str(definition.get("goal") or ""),
+                                    obligations=semantic_gaps,
+                                    current_steps=steps,
+                                    revision=revision,
+                                )
+                            self._redis_store.append_ledger_entry(workflow_id, {
+                                "event": "semantic_reconciliation_requested",
+                                "revision": revision,
+                                "decision": decision["decision"],
+                                "reason": decision["reason"],
+                            })
+                            if decision["decision"] == "amend":
+                                remaining = (
+                                    None if deadline is None else max(
+                                        0.0, deadline - asyncio.get_running_loop().time()
+                                    )
+                                )
+                                return await self.replan_goal(
+                                    workflow_id,
+                                    reason=decision["reason"],
+                                    context={
+                                        "semantic_reconciliation": {
+                                            "revision": revision,
+                                            "obligations": semantic_gaps,
+                                        },
+                                    },
+                                    timeout=remaining,
+                                )
+                            settlement = {
+                                "event": "semantic_reconciliation_settled",
+                                "revision": revision,
+                                "obligation_status": "blocked",
+                                "reason": decision["reason"],
+                            }
+                            self._redis_store.save_workflow_reconciliation_settlement(
+                                workflow_id, revision, settlement
+                            )
+                        finally:
+                            self._redis_store.release_workflow_reconciliation(
+                                workflow_id, revision, self._node_id
+                            )
+                    else:
+                        settlement = {
+                            "event": "semantic_reconciliation_settled",
+                            "revision": revision,
+                            "obligation_status": "blocked",
+                            "reason": "The bounded reconciliation revision limit was reached.",
+                        }
+                        self._redis_store.save_workflow_reconciliation_settlement(
+                            workflow_id, revision, settlement
+                        )
                 overall = (
-                    "cancelled" if "cancelled" in statuses
-                    else "waiting" if "waiting" in statuses
-                    else "failed" if "failed" in statuses
+                    "cancelled" if "cancelled" in current_statuses
+                    else "waiting" if "waiting" in current_statuses
+                    else "failed" if "failed" in current_statuses
                     else "completed"
                 )
+                obligation_states = [
+                    item.get("state") for item in obligation_projection.values()
+                ]
+                obligation_status = (
+                    "satisfied"
+                    if obligation_states and all(
+                        state == "satisfied" for state in obligation_states
+                    )
+                    else "incomplete" if "pending" in obligation_states
+                    else "blocked" if obligation_states
+                    else "satisfied" if overall == "completed"
+                    else "incomplete"
+                )
+                response_records = [
+                    record for record in current_records
+                    if record.get("effect") == "final_response"
+                ]
+                response_status = "not_required"
+                if response_records:
+                    response_state = str(response_records[-1].get("status") or "")
+                    response_status = {
+                        "completed": "completed",
+                        "waiting": "waiting",
+                    }.get(response_state, "failed")
                 if overall != "waiting":
                     self._redis_store.unregister_active_workflow(workflow_id)
                 return {
                     "workflow_id": workflow_id,
                     "status": overall,
+                    "obligation_status": obligation_status,
+                    "response_status": response_status,
                     "goal": definition.get("goal", ""),
                     "obligations": definition.get("obligations", []),
                     "revision": definition.get("revision", 0),
@@ -862,9 +1009,16 @@ class Mesh:
                 workflow_id,
                 epoch_id=f"replan:{revision + 1}:{self._node_id}",
             ):
+                projection = self._redis_store.get_obligation_projection(workflow_id)
+                target_obligation_ids = {
+                    str(obligation_id)
+                    for obligation_id, obligation in projection.items()
+                    if obligation.get("state") != "satisfied"
+                }
                 plan = await planner.amend(
                     str(definition.get("goal") or ""),
                     obligations=definition.get("obligations", []),
+                    target_obligation_ids=target_obligation_ids,
                     current_steps=current_steps,
                     reason=reason,
                     revision=revision,

--- a/jarviscore/core/mesh.py
+++ b/jarviscore/core/mesh.py
@@ -33,8 +33,15 @@ from typing import List, Dict, Any, Optional, Set
 import asyncio
 import logging
 import warnings
+from uuid import uuid4
 
 from .agent import Agent
+from jarviscore.orchestration.envelopes import (
+    ExecutionBudget,
+    neutral_context,
+    terminal_step_status,
+)
+from jarviscore.orchestration.budget import workflow_budget_scope
 
 logger = logging.getLogger(__name__)
 
@@ -168,7 +175,9 @@ class Mesh:
         self._blob_storage    = None
         self._nexus_store     = None   # NexusLocalStore — when nexus is configured
         self._athena_client   = None   # AthenaClient — when ATHENA_URL set
-        self._distributed_worker_task = None
+        self._distributed_worker_tasks: List[asyncio.Task] = []
+        self._distributed_step_tasks: Set[asyncio.Task] = set()
+        self._mesh_planner_task: Optional[asyncio.Task] = None
         self._agent_run_tasks: List[asyncio.Task] = []
 
         # Capability set — populated at start() based on what's reachable
@@ -180,6 +189,7 @@ class Mesh:
         self.mode = MeshMode("auto")
 
         self._started = False
+        self._node_id = f"mesh-{uuid4().hex[:12]}"
         self._logger = logging.getLogger("jarviscore.mesh")
         self._logger.info("Mesh created — capabilities will be detected at start()")
 
@@ -437,11 +447,22 @@ class Mesh:
 
         # ── 8. Distributed worker — when Redis is available ───────────────────
         if "redis" in self._capabilities:
-            self._distributed_worker_task = asyncio.create_task(
-                self._run_distributed_worker(),
-                name="distributed-worker",
+            if self._has_planning_llm():
+                self._mesh_planner_task = asyncio.create_task(
+                    self._run_mesh_planner_worker(),
+                    name=f"mesh-planner-{self._node_id}",
+                )
+            self._distributed_worker_tasks = [
+                asyncio.create_task(
+                    self._run_distributed_worker(agent),
+                    name=f"distributed-worker-{agent.agent_id}",
+                )
+                for agent in self.agents
+            ]
+            self._logger.info(
+                "✓ %d distributed worker(s) started (Redis-backed step claiming)",
+                len(self._distributed_worker_tasks),
             )
-            self._logger.info("✓ Distributed worker started (Redis-backed step claiming)")
 
         # ── 9. Prometheus metrics ─────────────────────────────────────────────
         if self._settings and self._settings.prometheus_enabled:
@@ -532,6 +553,352 @@ class Mesh:
         return await self._workflow_engine.execute(
             workflow_id, steps, timeout_per_step=timeout_per_step
         )
+
+    async def execute_goal(
+        self,
+        goal: str,
+        *,
+        workflow_id: Optional[str] = None,
+        context: Optional[Dict[str, Any]] = None,
+        timeout: Optional[float] = None,
+    ) -> Dict[str, Any]:
+        """Compile one source goal, publish its DAG, and observe peer claims."""
+        if not self._started:
+            raise RuntimeError("Mesh not started. Call await mesh.start() first.")
+        if self._redis_store is None:
+            raise RuntimeError("Mesh goal execution requires Redis for a shared durable DAG.")
+        source = (goal or "").strip()
+        if not source:
+            raise ValueError("A mesh goal cannot be empty.")
+        identity = workflow_id or f"wf-{uuid4().hex[:12]}"
+        public_context = neutral_context(context)
+        budget_options = dict(self.config.get("execution_budget") or {})
+        if timeout is not None:
+            budget_options.setdefault("max_seconds", timeout)
+        budget = ExecutionBudget.from_record(budget_options)
+        self._redis_store.register_workflow_goal(
+            identity, source, public_context, budget=budget.to_record()
+        )
+        try:
+            definition = self._redis_store.get_workflow_definition(identity)
+            if definition is None:
+                definition = await self._wait_for_workflow_definition(identity, timeout)
+            if definition is None:
+                raise RuntimeError(f"Workflow {identity!r} was not published before timeout")
+            return await self._wait_for_workflow_terminal(identity, definition, timeout)
+        except asyncio.CancelledError:
+            self._redis_store.cancel_workflow(
+                identity, reason="Goal execution was cancelled by its caller"
+            )
+            raise
+
+    def _planning_llm(self):
+        for agent in self.agents:
+            llm = getattr(agent, "llm", None)
+            if llm is not None:
+                return llm
+        raise RuntimeError(
+            "No local planning model is available. Add a started AutoAgent or "
+            "configure a node that can compile mesh goals."
+        )
+
+    def _has_planning_llm(self) -> bool:
+        return any(getattr(agent, "llm", None) is not None for agent in self.agents)
+
+    async def _run_mesh_planner_worker(self) -> None:
+        interval = float(self.config.get("distributed_poll_interval", 2.0))
+        lease_seconds = int(self.config.get("mesh_planning_lease_seconds", 300))
+        from jarviscore.planning.mesh_planner import MeshPlanner
+
+        while self._started:
+            try:
+                for workflow_id in self._redis_store.get_pending_workflow_goals():
+                    if self._redis_store.get_workflow_definition(workflow_id) is not None:
+                        continue
+                    if not self._redis_store.claim_workflow_planning(
+                        workflow_id, self._node_id, lease_seconds
+                    ):
+                        continue
+                    try:
+                        self._redis_store.save_workflow_planning_status(
+                            workflow_id, "planning", planner_id=self._node_id
+                        )
+                        source = self._redis_store.get_workflow_goal(workflow_id)
+                        if source is None:
+                            continue
+                        planner = MeshPlanner(
+                            self._planning_llm(),
+                            capabilities=self._mesh_capability_catalog(),
+                            response_capability=self.config.get(
+                                "mesh_response_capability"
+                            ),
+                        )
+                        with workflow_budget_scope(
+                            self._redis_store,
+                            workflow_id,
+                            epoch_id=f"planning:{self._node_id}",
+                        ):
+                            plan = await planner.plan(
+                                str(source.get("goal") or ""),
+                                context=source.get("context") or {},
+                            )
+                        self._redis_store.publish_workflow(
+                            workflow_id,
+                            goal=plan.goal,
+                            context=source.get("context") or {},
+                            budget=source.get("budget") or {},
+                            obligations=[item.to_dict() for item in plan.obligations],
+                            steps=[step.to_dict() for step in plan.steps],
+                            revision=plan.revision,
+                        )
+                    except asyncio.CancelledError:
+                        raise
+                    except Exception as exc:
+                        self._redis_store.save_workflow_planning_status(
+                            workflow_id,
+                            "failed",
+                            planner_id=self._node_id,
+                            error=f"{type(exc).__name__}: {exc}",
+                        )
+                    finally:
+                        self._redis_store.release_workflow_planning(
+                            workflow_id, self._node_id
+                        )
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:
+                self._logger.warning("[MeshPlanner] Planning attempt failed: %s", exc)
+            await asyncio.sleep(interval)
+
+    def _mesh_capability_catalog(self) -> Dict[str, Any]:
+        catalog: Dict[str, Any] = {}
+        for agent in self.agents:
+            role_description = str(
+                getattr(agent, "description", "") or agent.role
+            )
+            capability_descriptions = (
+                getattr(agent, "capability_descriptions", {}) or {}
+            )
+            contracts = getattr(agent, "capability_contracts", {}) or {}
+            for capability in agent.capabilities:
+                description = str(
+                    capability_descriptions.get(capability) or role_description
+                )
+                authority = contracts.get(capability)
+                if isinstance(authority, dict):
+                    catalog.setdefault(capability, {
+                        "description": description,
+                        "effects": list(authority.get("effects") or []),
+                        "systems": list(authority.get("systems") or []),
+                    })
+                else:
+                    catalog.setdefault(capability, description)
+        coordinator = self._p2p_coordinator
+        for info in getattr(coordinator, "_remote_agent_registry", {}).values():
+            description = str(info.get("description") or info.get("role") or "Remote peer")
+            contracts = info.get("capability_contracts") or {}
+            for capability in info.get("capabilities") or []:
+                authority = contracts.get(str(capability))
+                if isinstance(authority, dict):
+                    catalog.setdefault(str(capability), {
+                        "description": description,
+                        "effects": list(authority.get("effects") or []),
+                        "systems": list(authority.get("systems") or []),
+                    })
+                else:
+                    catalog.setdefault(str(capability), description)
+        return catalog
+
+    async def _wait_for_workflow_definition(
+        self, workflow_id: str, timeout: Optional[float]
+    ) -> Optional[Dict[str, Any]]:
+        deadline = (
+            asyncio.get_running_loop().time() + timeout
+            if timeout is not None else None
+        )
+        interval = float(self.config.get("distributed_poll_interval", 2.0))
+        while deadline is None or asyncio.get_running_loop().time() < deadline:
+            planning = self._redis_store.get_workflow_planning_status(workflow_id)
+            if planning and planning.get("status") == "failed":
+                raise RuntimeError(
+                    f"Workflow {workflow_id!r} planning failed: {planning.get('error')}"
+                )
+            definition = self._redis_store.get_workflow_definition(workflow_id)
+            if definition is not None:
+                return definition
+            await asyncio.sleep(interval)
+        return None
+
+    async def _wait_for_workflow_terminal(
+        self,
+        workflow_id: str,
+        definition: Dict[str, Any],
+        timeout: Optional[float],
+    ) -> Dict[str, Any]:
+        deadline = (
+            asyncio.get_running_loop().time() + timeout
+            if timeout is not None else None
+        )
+        interval = float(self.config.get("distributed_poll_interval", 2.0))
+        while deadline is None or asyncio.get_running_loop().time() < deadline:
+            latest = self._redis_store.get_workflow_definition(workflow_id)
+            if latest is not None:
+                definition = latest
+            step_ids = [str(step["id"]) for step in definition.get("steps", [])]
+            records = [self._redis_store.get_step_definition(workflow_id, step_id) or {}
+                       for step_id in step_ids]
+            statuses = [record.get("status") for record in records]
+            if statuses and all(
+                status in {"completed", "failed", "waiting", "blocked", "cancelled"}
+                for status in statuses
+            ):
+                steps = []
+                dependency_ids = {
+                    str(dependency)
+                    for step in definition.get("steps", [])
+                    for dependency in step.get("depends_on", [])
+                }
+                terminal_summaries = []
+                for step_id, record in zip(step_ids, records, strict=True):
+                    saved = self._redis_store.get_step_output(workflow_id, step_id)
+                    envelope = saved.get("output") if saved else None
+                    steps.append({**record, "output": envelope})
+                    if (
+                        step_id not in dependency_ids
+                        and record.get("status") == "completed"
+                        and isinstance(envelope, dict)
+                        and isinstance(envelope.get("result_summary"), str)
+                        and envelope["result_summary"].strip()
+                    ):
+                        terminal_summaries.append(envelope["result_summary"].strip())
+                overall = (
+                    "cancelled" if "cancelled" in statuses
+                    else "waiting" if "waiting" in statuses
+                    else "failed" if "failed" in statuses
+                    else "completed"
+                )
+                if overall != "waiting":
+                    self._redis_store.unregister_active_workflow(workflow_id)
+                return {
+                    "workflow_id": workflow_id,
+                    "status": overall,
+                    "goal": definition.get("goal", ""),
+                    "obligations": definition.get("obligations", []),
+                    "revision": definition.get("revision", 0),
+                    "result_summary": (
+                        terminal_summaries[0] if len(terminal_summaries) == 1 else ""
+                    ),
+                    "steps": steps,
+                }
+            await asyncio.sleep(interval)
+        raise TimeoutError(f"Workflow {workflow_id!r} did not finish within {timeout}s")
+
+    def cancel_goal(self, workflow_id: str, *, reason: str = "Goal cancelled") -> bool:
+        """Durably cancel shared work so no peer can claim or commit it later."""
+        if self._redis_store is None:
+            raise RuntimeError("Redis-backed Mesh is required to cancel a goal.")
+        return self._redis_store.cancel_workflow(workflow_id, reason=reason)
+
+    async def resume_goal(
+        self,
+        workflow_id: str,
+        step_id: str,
+        *,
+        context: Optional[Dict[str, Any]] = None,
+        timeout: Optional[float] = None,
+    ) -> Dict[str, Any]:
+        """Resume one waiting DAG step and continue the existing workflow."""
+        if not self._started or self._redis_store is None:
+            raise RuntimeError("A started Redis-backed Mesh is required to resume a goal.")
+        definition = self._redis_store.get_workflow_definition(workflow_id)
+        if definition is None:
+            raise KeyError(f"Workflow {workflow_id!r} was not found")
+        self._redis_store.resume_workflow_step(workflow_id, step_id, context=context)
+        return await self._wait_for_workflow_terminal(workflow_id, definition, timeout)
+
+    async def replan_goal(
+        self,
+        workflow_id: str,
+        *,
+        reason: str,
+        context: Optional[Dict[str, Any]] = None,
+        timeout: Optional[float] = None,
+    ) -> Dict[str, Any]:
+        """Amend unfinished DAG work under a short lease, then resume peer claims."""
+        if not self._started or self._redis_store is None:
+            raise RuntimeError("A started Redis-backed Mesh is required to replan a goal.")
+        definition = self._redis_store.get_workflow_definition(workflow_id)
+        if definition is None:
+            raise KeyError(f"Workflow {workflow_id!r} was not found")
+        revision = int(definition.get("revision", 0))
+        lease_seconds = int(self.config.get("mesh_planning_lease_seconds", 300))
+        if not self._redis_store.claim_workflow_planning(
+            workflow_id, self._node_id, lease_seconds
+        ):
+            raise RuntimeError(f"Workflow {workflow_id!r} is already being replanned")
+
+        from jarviscore.planning.mesh_planner import MeshPlanner
+
+        try:
+            self._redis_store.save_workflow_planning_status(
+                workflow_id, "planning", planner_id=self._node_id
+            )
+            current_steps = []
+            for step in definition.get("steps", []):
+                step_id = str(step["id"])
+                live = self._redis_store.get_step_definition(workflow_id, step_id) or step
+                saved = self._redis_store.get_step_output(workflow_id, step_id)
+                current_steps.append({
+                    **live,
+                    "output": saved.get("output") if saved else None,
+                })
+            planner = MeshPlanner(
+                self._planning_llm(),
+                capabilities=self._mesh_capability_catalog(),
+                response_capability=self.config.get("mesh_response_capability"),
+            )
+            with workflow_budget_scope(
+                self._redis_store,
+                workflow_id,
+                epoch_id=f"replan:{revision + 1}:{self._node_id}",
+            ):
+                plan = await planner.amend(
+                    str(definition.get("goal") or ""),
+                    obligations=definition.get("obligations", []),
+                    current_steps=current_steps,
+                    reason=reason,
+                    revision=revision,
+                    context={
+                        key: value
+                        for key, value in (context or {}).items()
+                        if not str(key).startswith("_")
+                    },
+                )
+            self._redis_store.amend_workflow(
+                workflow_id,
+                expected_revision=revision,
+                obligations=[item.to_dict() for item in plan.obligations],
+                steps=[step.to_dict() for step in plan.steps],
+                reason=reason,
+            )
+            self._redis_store.save_workflow_planning_status(
+                workflow_id, "published", planner_id=self._node_id
+            )
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            self._redis_store.save_workflow_planning_status(
+                workflow_id,
+                "failed",
+                planner_id=self._node_id,
+                error=f"{type(exc).__name__}: {exc}",
+            )
+            raise
+        finally:
+            self._redis_store.release_workflow_planning(workflow_id, self._node_id)
+
+        amended = self._redis_store.get_workflow_definition(workflow_id)
+        return await self._wait_for_workflow_terminal(workflow_id, amended, timeout)
 
     async def fanout(
         self,
@@ -676,6 +1043,12 @@ class Mesh:
         for agent in self.agents:
             agent.request_shutdown()
 
+        await asyncio.gather(*(
+            agent.peers.close()
+            for agent in self.agents
+            if getattr(agent, "peers", None) is not None
+        ), return_exceptions=True)
+
         # Unregister peer clients
         if self._p2p_coordinator:
             for agent in self.agents:
@@ -708,14 +1081,20 @@ class Mesh:
             self._auth_manager = None
             self._logger.info("✓ AuthenticationManager stopped")
 
-        # Cancel distributed worker
-        if self._distributed_worker_task and not self._distributed_worker_task.done():
-            self._distributed_worker_task.cancel()
-            try:
-                await self._distributed_worker_task
-            except asyncio.CancelledError:
-                pass
-        self._distributed_worker_task = None
+        # Cancel distributed workers and any steps they still own.
+        lifecycle_tasks = [*self._distributed_worker_tasks, *self._distributed_step_tasks]
+        if self._mesh_planner_task is not None:
+            lifecycle_tasks.append(self._mesh_planner_task)
+        for task in lifecycle_tasks:
+            if not task.done():
+                task.cancel()
+        await asyncio.gather(
+            *lifecycle_tasks,
+            return_exceptions=True,
+        )
+        self._distributed_worker_tasks.clear()
+        self._distributed_step_tasks.clear()
+        self._mesh_planner_task = None
 
         # Phase 9: Clear infrastructure references
         self._blob_storage = None
@@ -729,7 +1108,7 @@ class Mesh:
     # Distributed worker (autonomous step claiming across nodes)
     # ─────────────────────────────────────────────────────────────────
 
-    async def _run_distributed_worker(self) -> None:
+    async def _run_distributed_worker(self, agent: Agent) -> None:
         """
         Background task: scans active workflows in Redis for pending steps
         that match this node's agent capabilities, claims them atomically
@@ -739,83 +1118,357 @@ class Mesh:
         Mesh handles all routing. No manual wiring or step-ID knowledge needed.
         Runs only in distributed mode when a redis_store is available.
         """
-        capability_map: Dict[str, Any] = {}
-        for agent in self.agents:
-            for cap in ([agent.role] + list(getattr(agent, "capabilities", []))):
-                if cap and cap not in capability_map:
-                    capability_map[cap] = agent
-
-        if not capability_map:
+        capabilities = {agent.role, *getattr(agent, "capabilities", [])}
+        if not capabilities:
             return
 
         self._logger.info(
-            f"[DistributedWorker] Online | capabilities: {list(capability_map)}"
+            "[DistributedWorker] %s online | capabilities: %s",
+            agent.agent_id,
+            sorted(capabilities),
         )
 
         while self._started:
             try:
+                await self._service_capability_needs(agent, capabilities)
                 for workflow_id in self._redis_store.get_active_workflows():
+                    if self._redis_store.is_workflow_cancelled(workflow_id):
+                        self._redis_store.unregister_active_workflow(workflow_id)
+                        continue
                     for step_id in self._redis_store.get_all_step_ids(workflow_id):
                         step_def = self._redis_store.get_step_definition(
                             workflow_id, step_id
                         )
+                        if step_def and step_def.get("status") == "in_progress":
+                            self._redis_store.recover_expired_step_claim(
+                                workflow_id, step_id
+                            )
+                            step_def = self._redis_store.get_step_definition(
+                                workflow_id, step_id
+                            )
+                        if step_def and step_def.get("status") == "blocked":
+                            self._redis_store.requeue_blocked_step(workflow_id, step_id)
+                            step_def = self._redis_store.get_step_definition(
+                                workflow_id, step_id
+                            )
                         if not step_def or step_def.get("status") != "pending":
                             continue
-                        agent = capability_map.get(step_def.get("agent", ""))
-                        if not agent:
+                        requirement = (
+                            step_def.get("capability")
+                            or step_def.get("agent")
+                            or step_def.get("role")
+                        )
+                        if requirement not in capabilities:
                             continue
-                        # Respect dependencies — only claim when all deps are completed
+                        resume_agent_id = step_def.get("resume_agent_id")
+                        if resume_agent_id and resume_agent_id != agent.agent_id:
+                            continue
+                        blockers = self._redis_store.get_dependency_blockers(
+                            workflow_id, step_id
+                        )
+                        if blockers:
+                            self._redis_store.block_step(
+                                workflow_id, step_id, blockers
+                            )
+                            continue
                         if not self._redis_store.are_dependencies_met(workflow_id, step_id):
                             continue
+                        claim_id = f"{agent.agent_id}:{uuid4().hex}"
+                        lease_seconds = int(self.config.get("distributed_claim_lease_seconds", 60))
                         if self._redis_store.claim_step(
-                            workflow_id, step_id, agent.agent_id
+                            workflow_id, step_id, claim_id, lease_seconds=lease_seconds
                         ):
                             self._logger.info(
                                 f"[DistributedWorker] Claimed '{step_id}' "
                                 f"in '{workflow_id}' → {agent.agent_id}"
                             )
-                            asyncio.create_task(
-                                self._execute_distributed_step(
-                                    agent, workflow_id, step_id, step_def
-                                ),
-                                name=f"dist-{step_id}",
+                            await self._execute_distributed_step(
+                                agent, workflow_id, step_id, step_def,
+                                claim_id=claim_id,
+                                lease_seconds=lease_seconds,
                             )
             except asyncio.CancelledError:
                 raise
             except Exception as exc:
                 self._logger.warning(f"[DistributedWorker] Error: {exc}")
 
-            await asyncio.sleep(2.0)
+            await asyncio.sleep(float(self.config.get("distributed_poll_interval", 2.0)))
+
+    async def _service_capability_needs(
+        self, agent: Agent, capabilities: set[str]
+    ) -> None:
+        """Claim peer-resolvable gaps by capability, never by central assignment."""
+        lease_seconds = int(self.config.get("distributed_claim_lease_seconds", 60))
+        for workflow_id in self._redis_store.get_workflows_with_capability_needs():
+            if self._redis_store.is_workflow_cancelled(workflow_id):
+                continue
+            for need in self._redis_store.get_open_capability_needs(workflow_id):
+                need_id = str(need.get("id") or "")
+                if need.get("status") == "claimed":
+                    self._redis_store.recover_expired_capability_need(
+                        workflow_id, need_id
+                    )
+                    need = self._redis_store.get_capability_need(
+                        workflow_id, need_id
+                    ) or need
+                if need.get("status") != "open":
+                    continue
+                claim_id = f"{agent.agent_id}:{uuid4().hex}"
+                if not self._redis_store.claim_capability_need(
+                    workflow_id,
+                    need_id,
+                    claim_id,
+                    capabilities,
+                    lease_seconds=lease_seconds,
+                ):
+                    continue
+                workflow = self._redis_store.get_workflow_definition(workflow_id) or {}
+                context = dict(need.get("context") or {})
+                context.setdefault("objective", workflow.get("goal", ""))
+                lineage = [
+                    str(agent_id)
+                    for agent_id in context.get("peer_request_lineage", [])
+                    if agent_id
+                ]
+                requester_id = str(need.get("requester_agent_id") or "")
+                for agent_id in (requester_id, agent.agent_id):
+                    if agent_id and agent_id not in lineage:
+                        lineage.append(agent_id)
+                context.update({
+                    "workflow_id": workflow_id,
+                    "step_id": f"need:{need_id}",
+                    "execution_epoch_id": claim_id,
+                    "execution_budget": ExecutionBudget.from_record(
+                        workflow.get("budget")
+                    ).to_record(),
+                    "peer_requester_agent_id": need.get("requester_agent_id"),
+                    "peer_requester_step_id": need.get("requester_step_id"),
+                    "peer_request_lineage": lineage,
+                })
+                heartbeat = asyncio.create_task(
+                    self._renew_capability_need_claim(
+                        workflow_id, need_id, claim_id, lease_seconds
+                    ),
+                    name=f"capability-need-heartbeat-{need_id}",
+                )
+                try:
+                    try:
+                        with workflow_budget_scope(
+                            self._redis_store,
+                            workflow_id,
+                            epoch_id=f"capability:{claim_id}",
+                        ):
+                            result = await agent.execute_capability_request(
+                                str(need.get("capability") or ""),
+                                str(need.get("question") or ""),
+                                context,
+                            )
+                    except asyncio.CancelledError:
+                        raise
+                    except Exception as exc:
+                        result = {
+                            "status": "failure",
+                            "error": f"{type(exc).__name__}: {exc}",
+                        }
+                finally:
+                    heartbeat.cancel()
+                    await asyncio.gather(heartbeat, return_exceptions=True)
+                self._redis_store.fulfill_capability_need(
+                    workflow_id, need_id, claim_id, result
+                )
+
+    async def _renew_capability_need_claim(
+        self,
+        workflow_id: str,
+        need_id: str,
+        claim_id: str,
+        lease_seconds: int,
+    ) -> None:
+        interval = max(0.1, lease_seconds / 3)
+        while True:
+            await asyncio.sleep(interval)
+            if not self._redis_store.renew_capability_need_claim(
+                workflow_id, need_id, claim_id, lease_seconds
+            ):
+                return
 
     async def _execute_distributed_step(
-        self, agent: Any, workflow_id: str, step_id: str, step_def: dict
+        self,
+        agent: Any,
+        workflow_id: str,
+        step_id: str,
+        step_def: dict,
+        *,
+        claim_id: Optional[str] = None,
+        lease_seconds: int = 60,
     ) -> None:
         """Execute a claimed distributed step and persist the result to Redis."""
+        claim_id = claim_id or f"{agent.agent_id}:{uuid4().hex}"
+        if self._redis_store.get_step_status(workflow_id, step_id) == "pending":
+            if not self._redis_store.claim_step(
+                workflow_id, step_id, claim_id, lease_seconds=lease_seconds
+            ):
+                return
+        workflow = self._redis_store.get_workflow_definition(workflow_id) or {}
+        resume_context = step_def.get("resume_context") or {}
+        workflow_context = neutral_context(workflow.get("context") or {})
+        execution_budget = ExecutionBudget.from_record(
+            workflow.get("budget")
+        ).to_record()
+        systems = [str(value) for value in step_def.get("systems", []) if str(value)]
+        effect = str(step_def.get("effect") or "read")
+        previous_step_results = self._redis_store.get_dependency_outputs(
+            workflow_id, step_id
+        )
+        workflow_evidence = None
+        if effect == "final_response":
+            workflow_evidence = self._redis_store.get_workflow_evidence(
+                workflow_id, exclude_step_id=step_id
+            )
+            previous_step_results = workflow_evidence.artifacts
         task = {
             "id": step_id,
             "agent": agent.role,
             "task": step_def.get("task", ""),
             "context": {
-                "previous_step_results": {},
+                **workflow_context,
+                **resume_context,
+                "execution_budget": execution_budget,
+                "objective": workflow.get("goal", ""),
+                "workflow_plan": workflow,
+                "previous_step_results": previous_step_results,
+                "previous_step_interpretations": (
+                    workflow_evidence.interpretations
+                    if workflow_evidence is not None
+                    else self._redis_store.get_dependency_interpretations(
+                        workflow_id, step_id
+                    )
+                ),
                 "workflow_id": workflow_id,
                 "step_id": step_id,
+                "execution_epoch_id": claim_id,
+                "capability": str(
+                    step_def.get("capability")
+                    or step_def.get("agent")
+                    or step_def.get("role")
+                    or ""
+                ),
+                "effect": effect,
+                "systems": systems,
+                **({
+                    "workflow_evidence": workflow_evidence.to_record(),
+                    "workflow_step_states": workflow_evidence.states,
+                } if workflow_evidence is not None else {}),
+                **({"system": systems[0]} if len(systems) == 1 else {}),
+                **({"_resume": True} if step_def.get("resume_agent_id") else {}),
             },
         }
-        try:
-            result = await agent.execute_task(task)
-        except Exception as exc:
-            self._logger.error(
-                f"[DistributedWorker] '{step_id}' in '{workflow_id}' failed: {exc}"
-            )
-            self._redis_store.update_step_status(workflow_id, step_id, "failed")
-            return
-
-        self._redis_store.save_step_output(workflow_id, step_id, output=result)
-        self._redis_store.update_step_status(workflow_id, step_id, "completed")
-        s = result.get("status", "?") if isinstance(result, dict) else "done"
-        self._logger.info(
-            f"[DistributedWorker] '{step_id}' in '{workflow_id}' complete (status={s})"
+        heartbeat = asyncio.create_task(
+            self._renew_distributed_claim(
+                workflow_id, step_id, claim_id, lease_seconds
+            ),
+            name=f"claim-heartbeat-{step_id}",
         )
+        try:
+            try:
+                with workflow_budget_scope(
+                    self._redis_store,
+                    workflow_id,
+                    epoch_id=f"step:{claim_id}",
+                ):
+                    authorization = None
+                    if effect != "final_response":
+                        authorization = await agent.authorize_dependencies(
+                            str(task["task"]),
+                            task["context"]["previous_step_results"],
+                            task["context"]["previous_step_interpretations"],
+                        )
+                        task["context"]["dependency_authorization"] = {
+                            "decision": authorization.decision,
+                            "reason": authorization.reason,
+                        }
+                    if (
+                        authorization is not None
+                        and authorization.decision == "block"
+                        and getattr(agent, "llm", None) is None
+                    ):
+                        result = {
+                            "status": "blocked",
+                            "error": authorization.reason,
+                            "dependency_authorization": task["context"][
+                                "dependency_authorization"
+                            ],
+                        }
+                    else:
+                        result = await agent.execute_task(task)
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:
+                self._logger.error(
+                    f"[DistributedWorker] '{step_id}' in '{workflow_id}' failed: {exc}"
+                )
+                result = {
+                    "status": "failure",
+                    "error": f"{type(exc).__name__}: {exc}",
+                }
+        finally:
+            heartbeat.cancel()
+            await asyncio.gather(heartbeat, return_exceptions=True)
+
+        s = result.get("status", "?") if isinstance(result, dict) else "done"
+        if s == "epoch_exhausted":
+            continued = self._redis_store.continue_claimed_step(
+                workflow_id,
+                step_id,
+                claim_id,
+                resume_agent_id=agent.agent_id,
+            )
+            if not continued:
+                self._logger.warning(
+                    "[DistributedWorker] Could not continue exhausted epoch for "
+                    "'%s' in '%s'",
+                    step_id,
+                    workflow_id,
+                )
+            return
+        terminal = terminal_step_status(s)
+        committed = self._redis_store.finish_claimed_step(
+            workflow_id,
+            step_id,
+            claim_id,
+            result,
+            status=terminal,
+        )
+        if not committed:
+            self._logger.warning(
+                "[DistributedWorker] Rejected stale result for '%s' in '%s' from %s",
+                step_id,
+                workflow_id,
+                agent.agent_id,
+            )
+            return
+        self._logger.info(
+            "[DistributedWorker] '%s' in '%s' terminal (agent=%s, status=%s)",
+            step_id,
+            workflow_id,
+            agent.agent_id,
+            s,
+        )
+
+    async def _renew_distributed_claim(
+        self,
+        workflow_id: str,
+        step_id: str,
+        claim_id: str,
+        lease_seconds: int,
+    ) -> None:
+        interval = max(0.1, lease_seconds / 3)
+        while True:
+            await asyncio.sleep(interval)
+            if not self._redis_store.renew_step_claim(
+                workflow_id, step_id, claim_id, lease_seconds
+            ):
+                return
 
     # Phase 9: Infrastructure helpers
     # ─────────────────────────────────────────────────────────────────
@@ -1075,9 +1728,16 @@ class Mesh:
                 agent_id=agent.agent_id,
                 agent_role=agent.role,
                 agent_registry=self._agent_registry,
-                node_id=node_id
+                node_id=node_id,
+                redis_store=self._redis_store,
             )
             agent.peers = peer_client
+            request_handler = getattr(agent, "_handle_peer_request", None)
+            if callable(request_handler):
+                peer_client.set_request_handler(request_handler)
+            notification_handler = getattr(agent, "_handle_peer_notify", None)
+            if callable(notification_handler):
+                peer_client.set_notification_handler(notification_handler)
 
             # Register with coordinator for remote message routing (P2P only)
             if is_p2p and self._p2p_coordinator:

--- a/jarviscore/docs/changelog.md
+++ b/jarviscore/docs/changelog.md
@@ -26,6 +26,53 @@ All notable changes to JarvisCore Framework are documented here. This project fo
 
 ## Unreleased
 
+### Added
+
+- Redis-backed `Mesh.execute_goal()` compiles a natural-language goal into a
+  source-grounded, capability-addressed DAG. Planning is a temporary leased
+  operation; peers claim ready steps independently without an executor router.
+- `Mesh.resume_goal()` resumes waiting work with executor affinity, and
+  `Mesh.replan_goal()` replaces only unfinished work through a revision-fenced
+  DAG amendment while preserving the original goal, completed steps and outputs.
+- AutoAgent kernels expose `list_peers`, `ask_peer`, `broadcast_update`,
+  `read_mailbox`, `inspect_workflow`, and `read_workflow_step`. Inbound peer
+  requests work without application listener wiring, and notifications enter
+  the durable mailbox before becoming reasoning context.
+- Generated-code sandboxes receive a restricted `mesh` facade for peer listing
+  and delegation. The child process cannot mutate Mesh lifecycle or registry state.
+- Redis workflow claims now use renewable leases, unique attempt tokens and
+  fenced terminal writes, with append-only audit events for planning, claims,
+  completion, failure, waiting, resume, recovery and DAG amendment.
+- Distributed context, peer mandates, evidence and runtime limits now share one
+  canonical envelope model. Capability requests have explicit terminal states,
+  lineage-cycle prevention, lease heartbeats and bounded direct-Kernel execution.
+- Step evaluation now includes an agent-owned goal convergence decision
+  (`continue`, `complete`, `replan`) so newly observed facts can retire obsolete
+  conditional work without domain-specific routing rules.
+- Final-response peers receive every workflow artifact, interpretation and step
+  state through one `WorkflowEvidence` snapshot.
+- Semantic dependency relevance is decided by the recipient peer from the
+  upstream artifact and interpretation; Redis enforces execution readiness but
+  does not turn a partial result into a global business decision.
+- HITL now requires a canonical human-only category. Data requests additionally
+  require proof that autonomous paths are exhausted and the missing decision or
+  fact is exclusive to the human; confidence and token spend cannot escalate.
+- Provider reads now preserve Calendar participant/state fields, export Google
+  Workspace document content, and inspect HubSpot contact-deal associations so
+  peers can decide from provider evidence rather than incomplete metadata.
+- Failed registered atoms can enter an evidence-bound Coder repair lifecycle.
+  Only a contract-valid replacement that succeeds against the original
+  invocation can become immutable registry version `v+1`; authentication and
+  provider refusals do not automatically imply source repair.
+- Pre-effect review can return `already_satisfied` with supporting evidence,
+  completing a redundant mutation as a successful no-op.
+- LLM calls across planning, evaluation, reviews, distributed steps and nested
+  peer mandates reserve and settle against one Redis-backed workflow token/cost
+  account. Parallel peers no longer each receive the full workflow allowance.
+- Peer tool schema and remote failures remain typed failures. Malformed calls do
+  not count as peer-resolution attempts, while failed requests that actually
+  reached a peer retain that attempt evidence.
+
 </div>
 
 ---

--- a/jarviscore/docs/changelog.md
+++ b/jarviscore/docs/changelog.md
@@ -32,17 +32,20 @@ All notable changes to JarvisCore Framework are documented here. This project fo
   source-grounded, capability-addressed DAG. Planning is a temporary leased
   operation; peers claim ready steps independently without an executor router.
 - `Mesh.resume_goal()` resumes waiting work with executor affinity, and
-  `Mesh.replan_goal()` replaces only unfinished work through a revision-fenced
-  DAG amendment while preserving the original goal, completed steps and outputs.
+  `Mesh.replan_goal()` appends new work only for unresolved obligations through
+  a revision-fenced DAG amendment while preserving the original goal and every
+  prior attempt and output.
 - Terminal Mesh observation now separates execution completion from obligation
   satisfaction. Evidence-bearing failures and semantic `hold`/`reject` outcomes
   enter a bounded, revision-leased reconciliation decision: actionable gaps add
   new remediation work without replaying completed effects, while unactionable
-  gaps settle durably. Results expose `obligation_status` independently of `status`.
-- AutoAgent kernels expose `list_peers`, `ask_peer`, `broadcast_update`,
-  `read_mailbox`, `inspect_workflow`, and `read_workflow_step`. Inbound peer
-  requests work without application listener wiring, and notifications enter
-  the durable mailbox before becoming reasoning context.
+  gaps settle durably. Results expose `obligation_status` and `response_status`
+  independently of execution `status`.
+- AutoAgent kernels expose `list_peers`, `ask_peer`, `ask_capability`,
+  `broadcast_update`, `read_mailbox`, `inspect_workflow`, and
+  `read_workflow_step`. Inbound peer requests work without application listener
+  wiring, and notifications enter the durable mailbox before becoming reasoning
+  context.
 - Generated-code sandboxes receive a restricted `mesh` facade for peer listing
   and delegation. The child process cannot mutate Mesh lifecycle or registry state.
 - Redis workflow claims now use renewable leases, unique attempt tokens and
@@ -54,8 +57,10 @@ All notable changes to JarvisCore Framework are documented here. This project fo
 - Step evaluation now includes an agent-owned goal convergence decision
   (`continue`, `complete`, `replan`) so newly observed facts can retire obsolete
   conditional work without domain-specific routing rules.
-- Final-response peers receive every workflow artifact, interpretation and step
-  state through one `WorkflowEvidence` snapshot.
+- Final-response peers receive every workflow artifact, interpretation, step
+  state and current obligation projection through one `WorkflowEvidence`
+  snapshot. Response selection uses the current revision while retaining older
+  responses for audit.
 - Semantic dependency relevance is decided by the recipient peer from the
   upstream artifact and interpretation; Redis enforces execution readiness but
   does not turn a partial result into a global business decision.

--- a/jarviscore/docs/changelog.md
+++ b/jarviscore/docs/changelog.md
@@ -24,7 +24,7 @@ All notable changes to JarvisCore Framework are documented here. This project fo
 
 <div class="changelog-release" markdown>
 
-## Unreleased
+## 1.11.0 <span class="changelog-date">2026-09-11</span>
 
 ### Added
 
@@ -34,6 +34,11 @@ All notable changes to JarvisCore Framework are documented here. This project fo
 - `Mesh.resume_goal()` resumes waiting work with executor affinity, and
   `Mesh.replan_goal()` replaces only unfinished work through a revision-fenced
   DAG amendment while preserving the original goal, completed steps and outputs.
+- Terminal Mesh observation now separates execution completion from obligation
+  satisfaction. Evidence-bearing failures and semantic `hold`/`reject` outcomes
+  enter a bounded, revision-leased reconciliation decision: actionable gaps add
+  new remediation work without replaying completed effects, while unactionable
+  gaps settle durably. Results expose `obligation_status` independently of `status`.
 - AutoAgent kernels expose `list_peers`, `ask_peer`, `broadcast_update`,
   `read_mailbox`, `inspect_workflow`, and `read_workflow_step`. Inbound peer
   requests work without application listener wiring, and notifications enter

--- a/jarviscore/docs/concepts/architecture.md
+++ b/jarviscore/docs/concepts/architecture.md
@@ -76,6 +76,87 @@ async def main():
 
 Every piece of infrastructure is opt-in. If none of the infrastructure environment variables are set, the Mesh runs in pure in-process mode using only in-memory state.
 
+### Decentralised goal execution
+
+With Redis enabled, `Mesh.execute_goal()` registers the exact source goal and
+public context before any planning begins. Any planning-capable node may acquire
+a short lease, compile a complete capability-addressed DAG, and publish it
+atomically. The lease grants permission to compile that revision only: it does
+not assign agents or retain authority after publication.
+
+Each peer independently scans the shared DAG and atomically claims ready work
+matching its capabilities. Claims have renewable leases and fenced completion
+tokens, so an expired executor cannot overwrite a newer attempt. Dependency
+outputs, failures, waiting states, resumptions and graph amendments remain in the
+shared ledger. Steps request capabilities, never named agent instances.
+
+The distributed runtime therefore has two distinct planes:
+
+| Plane | Responsibility |
+|---|---|
+| SWIM/ZMQ | Peer membership, capability announcements and direct messages |
+| Redis | Immutable source goals, versioned DAGs, claims, outputs, mailboxes and audit events |
+
+Neither plane is a master agent. A node may submit a goal without planning or
+executing it, and a planning node relinquishes authority after atomic publication.
+
+### One durable execution model
+
+Distributed execution is carried by a canonical `WorkflowEnvelope`: source goal,
+neutral source context, obligations, DAG steps, revision and `ExecutionBudget`.
+Caller context cannot supply provider authority; each peer reconstructs systems
+and effects from its own capability contract.
+
+When an agent needs specialist help it creates a scoped `CapabilityMandate`.
+`PeerClient.request_capability()` owns discovery, lineage-cycle prevention,
+durable publication, claiming, lease renewal, fencing, timeout, cancellation and
+direct-P2P fallback. The LLM-facing tool only states the capability and question.
+Incoming peer mandates run through one bounded Kernel OODA execution rather than
+starting another unrestricted planner.
+
+After each goal step, the existing evaluator also returns an agent-owned goal
+decision: `continue`, `complete` or `replan`. This lets evidence invalidate
+obsolete conditional work without provider-specific rules. Final-response peers
+receive one `WorkflowEvidence` snapshot containing every artifact, semantic
+interpretation and step state, not only direct dependency outputs.
+
+Before a provider mutation, the agent performs a focused effect-intent review
+against the source objective, source context and evidence gathered in its OODA
+loop. The review may allow the effect, redirect the agent to missing evidence,
+or return `already_satisfied` with evidence that the requested real-world
+outcome already exists. The latter completes as a successful no-op instead of
+repeating the mutation. Invalid reviews fail closed. This protects conditional
+effects without encoding provider sequences or domain decisions in atoms.
+
+The workflow budget caps the existing Kernel lease and goal loop. Every LLM call
+made during planning, evaluation, dependency review, effect review, direct step
+execution or peer fulfillment reserves capacity from one Redis-backed workflow
+account before dispatch and settles provider-reported tokens and cost afterward.
+Parallel peers therefore share one balance rather than receiving independent
+copies of the token allowance. Wall-clock time, steps, replans, peer depth and
+peer wait time also derive from the same durable envelope.
+
+Provider atoms remain typed API primitives. Provider-native reads preserve the
+identity and state needed for agent judgment, such as Calendar attendees and
+organizers, HubSpot object associations, and Google Workspace export content.
+They do not decide whether records are duplicates or which business action to
+take.
+
+When a registered atom fails, the registry records the execution failure and
+demotes its stage. Coder may open repair only from that observed failure, inspect
+the exact source/version, and submit corrected source under the same atom name.
+The replacement must pass the atom contract and execute successfully against the
+original invocation before registration. Registration writes immutable version
+`v+1`, retains the prior source, records `repair_of_version`, and promotes the
+new current version from its execution evidence. Authentication, invalid task
+input, permissions, rate limits and truthful provider refusals are not by
+themselves evidence that atom source should be rewritten.
+
+HITL is admissible only for account authorization, explicit approval of a
+consequential action, or data proven both human-exclusive and unreachable after
+autonomous paths are exhausted. Low confidence, token pressure and routine
+execution failure replan or terminate honestly; they never become human work.
+
 ---
 
 ## The OODA Loop

--- a/jarviscore/docs/concepts/architecture.md
+++ b/jarviscore/docs/concepts/architecture.md
@@ -87,8 +87,9 @@ not assign agents or retain authority after publication.
 Each peer independently scans the shared DAG and atomically claims ready work
 matching its capabilities. Claims have renewable leases and fenced completion
 tokens, so an expired executor cannot overwrite a newer attempt. Dependency
-outputs, failures, waiting states, resumptions and graph amendments remain in the
-shared ledger. Steps request capabilities, never named agent instances.
+outputs, failures, waiting states, resumptions and append-only graph amendments
+remain in the shared ledger. Steps request capabilities, never named agent
+instances.
 
 The distributed runtime therefore has two distinct planes:
 
@@ -107,6 +108,18 @@ neutral source context, obligations, DAG steps, revision and `ExecutionBudget`.
 Caller context cannot supply provider authority; each peer reconstructs systems
 and effects from its own capability contract.
 
+Step attempts are immutable execution history. Redis also maintains one current
+projection for each source obligation: pending, unresolved or satisfied, with the
+step IDs that currently supply its evidence and the step IDs they superseded. A
+new revision appends steps only for unresolved obligation IDs. It does not ask a
+planner to reproduce the full DAG, and it does not reset satisfied obligations
+that the delta does not cover.
+
+This produces three independent terminal facts: current-revision execution
+status, source-obligation status and current final-response status. A failed
+response cannot erase successful provider work, and a completed attempt cannot
+by itself hide an unresolved domain requirement.
+
 When an agent needs specialist help it creates a scoped `CapabilityMandate`.
 `PeerClient.request_capability()` owns discovery, lineage-cycle prevention,
 durable publication, claiming, lease renewal, fencing, timeout, cancellation and
@@ -118,7 +131,9 @@ After each goal step, the existing evaluator also returns an agent-owned goal
 decision: `continue`, `complete` or `replan`. This lets evidence invalidate
 obsolete conditional work without provider-specific rules. Final-response peers
 receive one `WorkflowEvidence` snapshot containing every artifact, semantic
-interpretation and step state, not only direct dependency outputs.
+interpretation, step state and current obligation projection, not only direct
+dependency outputs. The selected user response always comes from the current
+revision; earlier responses remain audit history.
 
 Before a provider mutation, the agent performs a focused effect-intent review
 against the source objective, source context and evidence gathered in its OODA

--- a/jarviscore/docs/guides/autoagent.md
+++ b/jarviscore/docs/guides/autoagent.md
@@ -396,6 +396,64 @@ Workflow execution is crash-safe. If the process restarts with the same `workflo
 
 ---
 
+## Distributed Mesh Goals
+
+Do not confuse the two goal APIs:
+
+- `await agent.execute_goal(...)` runs one AutoAgent's Plan, Execute, Evaluate
+    loop described below.
+- `await mesh.execute_goal(...)` compiles a source goal into a Redis-backed DAG
+    whose steps are claimed independently by capable peers.
+
+An AutoAgent participates in a distributed goal through its normal
+`execute_task()` method. No subclass change is required. Declare provider
+authority when planning needs to distinguish reads, proposals and effects:
+
+```python
+class PipelineAgent(AutoAgent):
+        role = "pipeline"
+        capabilities = ["pipeline_inspection"]
+        capability_descriptions = {
+                "pipeline_inspection": "Inspect and reconcile CRM pipeline state.",
+        }
+        capability_contracts = {
+                "pipeline_inspection": {
+                        "effects": ["read", "propose"],
+                        "systems": ["hubspot"],
+                },
+        }
+```
+
+The distributed task context includes the exact source objective, workflow and
+obligation ledger, durable dependency artifacts, dependency interpretations,
+current capability/effect/systems, and the shared execution budget. A normal
+successful AutoAgent result satisfies the obligations covered by its step.
+Applications that distinguish attempt completion from evidence satisfaction may
+override `execute_task()` and add the optional semantic `interpretation`
+envelope described in [Durable Goal Execution](goal-execution.md#optional-semantic-interpretations).
+
+When attached to a started Mesh, AutoAgent reasoning receives these peer and
+workflow tools automatically:
+
+| Tool | Purpose |
+|---|---|
+| `list_peers()` | Read online peers and capabilities |
+| `ask_peer(role, question)` | Request help from a specific peer role |
+| `ask_capability(capability, question)` | Request any peer owning a capability |
+| `broadcast_update(message)` | Notify every peer without creating a request |
+| `read_mailbox(limit=10)` | Read durable unread peer notifications |
+| `inspect_workflow()` | Read this goal, obligations, steps and live statuses |
+| `read_workflow_step(step_id)` | Read one durable step definition and output |
+
+The peer decides its own tools and provider actions. `ask_capability` selects an
+authority boundary, not an agent implementation. Workflow inspection requires
+Redis; mailbox reading requires a configured mailbox.
+
+For result status, selective revisions, cancellation and deployment rules, see
+[Durable Goal Execution](goal-execution.md).
+
+---
+
 ## Goal-Oriented Execution
 
 Setting `goal_oriented = True` switches the agent from a single OODA loop to a Plan, Execute, Evaluate loop. The agent decomposes the goal into steps, executes each through the Kernel, evaluates the outcome, and replans automatically if a step fails.

--- a/jarviscore/docs/guides/customagent.md
+++ b/jarviscore/docs/guides/customagent.md
@@ -288,6 +288,55 @@ async def execute_task(self, task: dict) -> dict:
     return {"status": "success", "output": result}
 ```
 
+### Participating in `Mesh.execute_goal()`
+
+Existing CustomAgent handlers remain compatible with durable distributed goals.
+The framework routes a capability-addressed step through `execute_task()` and a
+normal completed result satisfies the obligation IDs covered by that step.
+
+When your domain distinguishes successful execution from sufficient evidence,
+add an optional `interpretation` beside `output`:
+
+```python
+async def execute_task(self, task: dict) -> dict:
+    artifact = await self.inspect(task["task"])
+    plan = task["context"]["workflow_plan"]
+    step = next(item for item in plan["steps"] if item["id"] == task["id"])
+    covered = list(step["covers"])
+    verified = artifact.get("verified") is True
+
+    return {
+        "status": "success",
+        "output": artifact,
+        "interpretation": {
+            "meaning": "The required evidence was verified." if verified
+                       else "The attempt completed without verifying the evidence.",
+            "satisfied_requirements": covered if verified else [],
+            "unmet_requirements": [] if verified else covered,
+            "evidence_refs": artifact.get("evidence_refs", []),
+            "verdict": "satisfied" if verified else "unsatisfied",
+            "decision": "proceed" if verified else "hold",
+        },
+    }
+```
+
+Use the exact IDs from `step["covers"]`; do not put requirement prose in those
+lists. Assess every covered ID once. JarvisCore stores the artifact and
+interpretation separately, reduces current obligation truth generically, and
+may append remediation for unresolved IDs. Your agent retains ownership of what
+the evidence means.
+
+The distributed context also provides `previous_step_results`,
+`previous_step_interpretations`, `capability`, `effect`, `systems` and the shared
+`execution_budget`. See [Durable Goal Execution](goal-execution.md#task-context-received-by-agents)
+for the full contract.
+
+CustomAgent does not gain a planning model. A pure CustomAgent node can claim
+and execute an already-published DAG, but `Mesh.execute_goal()` needs at least
+one started node with an LLM-backed agent capable of acquiring the temporary
+planning lease. Use `mesh.workflow()` when your application already knows the
+steps.
+
 ---
 
 ## Planning: a library, not a mode

--- a/jarviscore/docs/guides/goal-execution.md
+++ b/jarviscore/docs/guides/goal-execution.md
@@ -1,0 +1,233 @@
+---
+icon: material/graph
+---
+
+# Durable Goal Execution
+
+`Mesh.execute_goal()` turns one natural-language objective into durable,
+capability-addressed work. Redis holds the source goal, obligations, revisions,
+claims and outputs; peers claim work independently. Planning does not create a
+manager agent and the node that publishes a plan has no execution authority.
+
+This API is different from the other two ways to run work:
+
+| API | Use it when | Who defines the steps |
+|---|---|---|
+| `agent.execute_goal()` | One `AutoAgent` should run its own Plan, Execute, Evaluate loop | That AutoAgent |
+| `mesh.workflow()` | Your application already knows the DAG | Your Python code |
+| `mesh.execute_goal()` | The goal should be compiled into distributed, capability-addressed work | A temporary planning lease |
+
+## Define capability authority
+
+Every participating agent declares capability names. For provider work, add a
+capability contract so planning knows which effects and systems that capability
+may use:
+
+```python
+from jarviscore import AutoAgent, Mesh
+
+
+class RevenueOperations(AutoAgent):
+    role = "revenue_operations"
+    capabilities = ["pipeline_inspection"]
+    capability_descriptions = {
+        "pipeline_inspection": "Inspect and reconcile CRM pipeline state.",
+    }
+    capability_contracts = {
+        "pipeline_inspection": {
+            "effects": ["read", "propose"],
+            "systems": ["hubspot"],
+        },
+    }
+
+
+mesh = Mesh(config={
+    "mesh_response_capability": "action_briefing",
+    "execution_budget": {"max_seconds": 900, "max_tokens": 240_000},
+})
+mesh.add(RevenueOperations)
+```
+
+Effects are `read`, `propose`, `write`, `notify`, `destructive` or
+`final_response`. A `write`, `notify` or `destructive` step names exactly one
+authorized system. The claiming peer still decides which atom or provider call
+to use.
+
+At least one started node needs an agent with an LLM for initial planning and
+reconciliation decisions. A pure `CustomAgent` node can execute published work,
+but it does not gain an LLM planner automatically.
+
+## Execute and inspect a goal
+
+```python
+await mesh.start()
+
+result = await mesh.execute_goal(
+    "Inspect the active opportunity and prepare a decision brief.",
+    workflow_id="opportunity-2026-09-11",
+    context={"tenant_id": "acme"},
+)
+
+print(result["status"])
+print(result["obligation_status"])
+print(result["response_status"])
+```
+
+Caller context is copied without private keys or execution authority. The
+framework derives capability, effect and systems from the published step and
+injects them into the claiming agent's task context.
+
+## Task context received by agents
+
+Both `AutoAgent.execute_task()` and `CustomAgent.execute_task()` receive the
+same distributed context:
+
+| Key | Meaning |
+|---|---|
+| `objective` | Exact immutable source goal |
+| `workflow_plan` | Goal, obligation ledger and all revisioned step definitions |
+| `previous_step_results` | Durable dependency artifacts; all workflow artifacts for a final response |
+| `previous_step_interpretations` | Semantic assessments from dependencies |
+| `workflow_id`, `step_id` | Durable execution identity |
+| `capability`, `effect`, `systems` | Authority declared by the published step |
+| `execution_budget` | Shared workflow budget |
+| `workflow_evidence` | Final-response snapshot of artifacts, interpretations, states and obligations |
+
+Existing agents do not need to change. A successful result without an
+`interpretation` is reduced from execution status: a completed attempt satisfies
+the obligations covered by that step.
+
+## Optional semantic interpretations
+
+Return an interpretation when domain evidence can distinguish "the attempt
+completed" from "the source requirement is satisfied". This is how an agent
+can hold or reject its assigned path without teaching JarvisCore domain rules.
+
+```python
+async def execute_task(self, task):
+    artifact = await self.inspect_pipeline(task)
+    plan = task["context"]["workflow_plan"]
+    step = next(item for item in plan["steps"] if item["id"] == task["id"])
+    covered = list(step["covers"])
+
+    if artifact["stage"] is None:
+        interpretation = {
+            "meaning": "The deal exists, but its current stage is not verified.",
+            "satisfied_requirements": [],
+            "unmet_requirements": covered,
+            "evidence_refs": [artifact["record_id"]],
+            "verdict": "unsatisfied",
+            "decision": "hold",
+        }
+    else:
+        interpretation = {
+            "meaning": "The current deal stage was read from the CRM.",
+            "satisfied_requirements": covered,
+            "unmet_requirements": [],
+            "evidence_refs": [artifact["record_id"]],
+            "verdict": "satisfied",
+            "decision": "proceed",
+        }
+
+    return {
+        "status": "success",
+        "output": artifact,
+        "interpretation": interpretation,
+    }
+```
+
+`satisfied_requirements` and `unmet_requirements` contain the stable obligation
+IDs from the current step's `covers` list, not paraphrased descriptions. Assess
+each covered ID exactly once. Recommended verdicts are `satisfied`, `partial`
+and `unsatisfied`; recommended decisions are `proceed`, `hold` and `reject`.
+
+A final-response step normally has `covers=[]`. It presents current workflow
+truth and should not claim to satisfy source obligations.
+
+## Current obligation truth
+
+Attempts are immutable execution history. The obligation projection records
+which attempts currently represent each source requirement:
+
+```text
+revision 1: inspect_deal       -> obligation stage = unresolved
+revision 2: inspect_deal_by_id -> obligation stage = satisfied
+```
+
+The revision 1 output remains available for audit. Revision 2 supersedes it only
+for the obligation IDs covered by the new step. Satisfied obligations not named
+by the delta retain their current source attempt and are not rerun.
+
+Automatic reconciliation starts only after the current revision is terminal,
+an unresolved obligation has semantic evidence, an LLM planner is available and
+the revision budget permits another attempt. The planner may append remediation
+or settle the remaining goal as blocked. It cannot rewrite the source obligation
+ledger or mutate earlier attempts.
+
+`Mesh.replan_goal()` uses the same append-only mechanism for explicit
+continuation. Call it only while obligations remain unresolved:
+
+```python
+result = await mesh.replan_goal(
+    "opportunity-2026-09-11",
+    reason="A direct CRM record-read capability is now available.",
+)
+```
+
+## Read terminal status correctly
+
+The result reports three independent facts:
+
+| Field | Values | Question answered |
+|---|---|---|
+| `status` | `completed`, `failed`, `waiting`, `cancelled` | Did the current revision execute? |
+| `obligation_status` | `satisfied`, `blocked`, `incomplete` | Is the source goal fulfilled? |
+| `response_status` | `completed`, `failed`, `waiting`, `not_required` | Was the current user-facing response produced? |
+
+Do not infer goal truth from `status` alone. For example, provider actions may
+be complete while response synthesis fails:
+
+```python
+{
+    "status": "failed",
+    "obligation_status": "satisfied",
+    "response_status": "failed",
+}
+```
+
+`revision` identifies the current plan. `steps` retains attempts from every
+revision; filter with `step["plan_revision"] == result["revision"]` when you
+need only current execution. `result_summary` is selected from the current
+revision's final response.
+
+## Waiting, cancellation and shutdown
+
+Resume a waiting step with the same workflow and step identity:
+
+```python
+result = await mesh.resume_goal(
+    workflow_id,
+    step_id,
+    context={"human_response": "approved"},
+)
+```
+
+Cancellation is durable. It fences future claims and prevents an expired
+executor from committing after cancellation:
+
+```python
+mesh.cancel_goal(workflow_id, reason="Request withdrawn")
+```
+
+Cancelling the coroutine running `execute_goal()` also cancels the durable
+workflow before re-raising `CancelledError`.
+
+## Deployment rules
+
+- Redis is required for `Mesh.execute_goal()`, resume, replan and cancellation.
+- Use stable `workflow_id` values for retry and observation.
+- Run compatible framework versions on every node that can claim the same DAG.
+- Bound reconciliation with `mesh_max_reconciliation_revisions` and the shared
+  `execution_budget`.
+- Configure `mesh_response_capability` only when a peer owns
+  `final_response` authority.

--- a/jarviscore/docs/guides/index.md
+++ b/jarviscore/docs/guides/index.md
@@ -38,6 +38,13 @@ Step-by-step implementation guides, from your first agent to production deployme
 
     [Read more →](workflows.md)
 
+-   :material-graph: **Durable Goal Execution**
+
+    Compile a source goal into peer-claimed work with obligation truth,
+    selective reconciliation, resume and cancellation.
+
+    [Read more →](goal-execution.md)
+
 -   :material-rocket-launch: **Production Deployment**
 
     Deploy JarvisCore agents to production with Docker, Kubernetes, and cloud providers.

--- a/jarviscore/docs/guides/integrations.md
+++ b/jarviscore/docs/guides/integrations.md
@@ -225,16 +225,24 @@ Personal task management and projects.
 ---
 
 #### Google Drive
-File storage, sharing, and folder management.
+File storage, Google Docs content readback, sharing, and folder management.
 
 | Atom | Description |
 |---|---|
+| `google_drive_search_files` | Search files and folders with Drive query syntax |
 | `google_drive_upload_file` | Upload a file to a specific folder |
 | `google_drive_download_file` | Download a file by ID |
+| `google_drive_export_file` | Export a Google Workspace file to a requested MIME type |
+| `google_drive_get_document` | Read a Google Doc body through the official Docs API |
+| `google_drive_create_document` | Create a Google Doc in a Drive folder |
+| `google_drive_append_document_text` | Append text to an existing Google Doc |
 | `google_drive_create_folder` | Create a new folder |
 | `google_drive_share_file` | Set sharing permissions on a file or folder |
 
-**Required env:** `GOOGLE_DRIVE_CREDENTIALS_JSON`
+Authentication is supplied through a Nexus `google_drive` connection; raw
+Google credentials are not passed to atoms or agent context. Document readback
+requires the connected Google project to have the Google Docs API enabled in
+addition to Drive access. See [Nexus Credentials](nexus.md).
 
 ---
 

--- a/jarviscore/docs/guides/migration.md
+++ b/jarviscore/docs/guides/migration.md
@@ -11,6 +11,85 @@ This guide covers migrating an existing multi-agent system to JarvisCore from **
 
 ---
 
+## Upgrading JarvisCore 1.10 to 1.11
+
+JarvisCore 1.11 is a backward-compatible minor release. Existing
+`mesh.run_task()`, `mesh.workflow()`, `AutoAgent.execute_task()` and
+`CustomAgent.execute_task()` code does not require a rewrite.
+
+```bash
+pip install --upgrade "jarviscore-framework==1.11.0"
+```
+
+The behavioral changes apply primarily to Redis-backed `Mesh.execute_goal()`:
+
+| 1.10 assumption | 1.11 behavior |
+|---|---|
+| A terminal attempt determines goal truth | Attempts and current source-obligation truth are separate |
+| Replan returns a replacement DAG | Replan appends a selective delta and retains prior attempts |
+| `status` is enough to classify the outcome | Read `status`, `obligation_status` and `response_status` |
+| Every terminal response is equivalent | `result_summary` comes from the current revision |
+| Partial semantic labels may be free-form | Requirement lists should contain stable IDs from `step["covers"]` |
+
+### AutoAgent users
+
+No change is required for normal successful results. If your subclass adds
+domain semantic assessment, return the optional `interpretation` envelope and
+use obligation IDs supplied in the distributed task context. AutoAgent reasoning
+also gains peer, mailbox and workflow-inspection tools while attached to a Mesh.
+See [Distributed Mesh Goals](autoagent.md#distributed-mesh-goals).
+
+`AutoAgent.execute_goal()` remains the single-agent Plan, Execute, Evaluate API.
+It is not an alias for distributed `Mesh.execute_goal()`.
+
+### CustomAgent users
+
+No change is required for `on_peer_request()` or a standard `execute_task()`
+result. Add an interpretation only when your application needs to distinguish a
+completed attempt from sufficient evidence. A pure CustomAgent process still
+does not acquire an LLM planner automatically; it can execute a published goal
+or use an application-declared `mesh.workflow()` DAG. See
+[Participating in `Mesh.execute_goal()`](customagent.md#participating-in-meshexecute_goal).
+
+### Result consumers
+
+If you need only current execution, filter retained history by revision:
+
+```python
+current_steps = [
+    step for step in result["steps"]
+    if step.get("plan_revision", 1) == result["revision"]
+]
+```
+
+Do not treat a failed user response as proof that provider work failed:
+
+```python
+if result["obligation_status"] == "satisfied":
+    business_work_is_complete = True
+
+if result["response_status"] == "failed":
+    queue_response_recovery = True
+```
+
+### Deployment
+
+Redis records without a stored obligation projection remain readable and are
+initialized from their workflow definition. Even so, do not run mixed 1.10 and
+1.11 claimants against an active workflow: older nodes do not implement selective
+supersession or current-revision response selection.
+
+1. Drain or cancel active distributed goals.
+2. Upgrade every node that shares the Redis DAG.
+3. Restart the nodes and verify the same framework version everywhere.
+4. Resume or submit goals with stable workflow IDs.
+
+Review `mesh_max_reconciliation_revisions`, `mesh_response_capability` and the
+shared `execution_budget` before enabling automatic remediation. The complete
+contract is in [Durable Goal Execution](goal-execution.md).
+
+---
+
 ## Migrating from CrewAI
 
 ### Concept Mapping

--- a/jarviscore/docs/guides/workflows.md
+++ b/jarviscore/docs/guides/workflows.md
@@ -8,6 +8,13 @@ JarvisCore's `WorkflowBuilder` lets you compose multi-agent workflows as Directe
 
 This guide covers the full `WorkflowBuilder` API, the result reference syntax for chaining step outputs, Redis-backed persistence, and production patterns.
 
+Use this API when your application knows the steps and assigns agent roles. If
+the source is a natural-language objective and peers should own work by
+capability rather than preassigned role, use Redis-backed
+[`Mesh.execute_goal()`](goal-execution.md) instead. `Mesh.execute_goal()` creates
+an immutable obligation ledger and append-only revision history; those semantics
+do not apply automatically to a `WorkflowBuilder` DAG.
+
 ---
 
 ## Core Concepts

--- a/jarviscore/docs/reference/agent-api.md
+++ b/jarviscore/docs/reference/agent-api.md
@@ -186,7 +186,9 @@ The P2P listener loop. Runs continuously in the background when the agent is sta
 from jarviscore import Mesh
 ```
 
-The central orchestrator. Manages agent lifecycle, workflow execution, and infrastructure detection.
+The runtime host for agent lifecycle, workflow execution and infrastructure
+detection. Distributed goal work is peer-claimed; Mesh does not assign a master
+agent or retain planning authority.
 
 ### Constructor
 
@@ -203,6 +205,9 @@ Mesh(config: Optional[Dict[str, Any]] = None)
 | `distributed_poll_interval` | `float` | `2.0` | Redis DAG polling interval in seconds |
 | `distributed_claim_lease_seconds` | `int` | `60` | Renewable execution-claim lease duration |
 | `mesh_planning_lease_seconds` | `int` | `300` | Goal compilation or amendment lease duration |
+| `mesh_max_reconciliation_revisions` | `int` | `3` | Maximum bounded semantic reconciliation revision |
+| `mesh_response_capability` | `str` | `None` | Capability that owns the optional `final_response` step |
+| `execution_budget` | `dict` | `ExecutionBudget` defaults | Shared limits for the complete distributed goal |
 
 The Mesh auto-detects available infrastructure at `start()` time. Do not pass `mode=`: that argument is deprecated and has no effect.
 
@@ -256,7 +261,7 @@ async def execute_goal(
     *,
     workflow_id: Optional[str] = None,
     context: Optional[Dict[str, Any]] = None,
-    timeout: float = 900.0,
+    timeout: Optional[float] = None,
 ) -> Dict[str, Any]
 ```
 
@@ -309,19 +314,38 @@ from jarviscore.orchestration import (
 `WorkflowEnvelope` is the canonical source/context/DAG record.
 `CapabilityMandate` is the scoped peer-request lifecycle.
 `WorkflowEvidence` is the complete artifact/interpretation/state snapshot used
-for final synthesis. These types serialize compatibly with existing Redis records.
+for final synthesis, including the current obligation projection. These types
+serialize compatibly with existing Redis records.
 
 `Mesh.execute_goal()` results distinguish process lifecycle from source-goal truth:
 
 - `status` reports whether the distributed execution completed, failed, waited or
     was cancelled.
 - `obligation_status` reports `satisfied`, `blocked` or `incomplete`.
+- `response_status` reports `completed`, `failed`, `waiting` or `not_required`
+    for the current revision's user-facing response.
+
+The remaining result fields are:
+
+| Field | Description |
+|---|---|
+| `workflow_id` | Durable caller-supplied or generated identity |
+| `goal` | Exact source goal |
+| `obligations` | Independently verifiable source requirements |
+| `revision` | Current published plan revision |
+| `result_summary` | Current revision's terminal user response, when present |
+| `steps` | Immutable attempts from every revision, each carrying `plan_revision` |
 
 A terminal step with an actionable semantic gap can trigger a bounded DAG
-revision. Reconciliation preserves completed steps and effects, adds new work
-against their durable artifacts, and emits a fresh final response. If no available
-capability can advance the gap, the current revision settles as `blocked` rather
-than looping or claiming that execution completion satisfied the goal.
+revision. Reconciliation appends new work only for unresolved obligation IDs,
+preserves satisfied obligations and completed effects, records supersession
+lineage, and emits a fresh final response. If no available capability can advance
+the gap, the current revision settles as `blocked` rather than looping or claiming
+that execution completion satisfied the goal.
+
+`status`, `obligation_status` and `response_status` are independent. A response
+failure can therefore coexist with satisfied business obligations. See
+[Durable Goal Execution](../guides/goal-execution.md#read-terminal-status-correctly).
 
 #### resume_goal
 
@@ -339,6 +363,21 @@ Resume a waiting step with optional human or external context. The original
 executor affinity is retained and blocked descendants become claimable after
 the resumed step succeeds.
 
+#### cancel_goal
+
+```python
+def cancel_goal(
+    workflow_id: str,
+    *,
+    reason: str = "Goal cancelled",
+) -> bool
+```
+
+Durably cancel shared work. Cancellation fences later claims and terminal writes,
+including writes from an executor whose lease expired before cancellation.
+Requires Redis. Cancelling the coroutine running `execute_goal()` performs the
+same durable cancellation before re-raising `CancelledError`.
+
 #### replan_goal
 
 ```python
@@ -351,10 +390,13 @@ async def replan_goal(
 ) -> Dict[str, Any]
 ```
 
-Compile a replacement for unfinished work under a short planning lease. The
-commit uses revision compare-and-swap and cannot remove or mutate completed
-steps or their outputs. The original source goal and obligation ledger remain
-authoritative; peers resume normal capability-based claiming after publication.
+Compile an append-only delta for currently unresolved obligations under a short
+planning lease. The commit uses revision compare-and-swap, assigns new
+`plan_revision` values, and cannot remove, reuse or mutate earlier step IDs and
+outputs. Only obligations covered by the delta gain supersession lineage; other
+satisfied obligations keep their authoritative attempts. The source goal and
+obligation ledger remain immutable, and peers resume capability-based claiming
+after publication.
 
 #### stop
 

--- a/jarviscore/docs/reference/agent-api.md
+++ b/jarviscore/docs/reference/agent-api.md
@@ -311,6 +311,18 @@ from jarviscore.orchestration import (
 `WorkflowEvidence` is the complete artifact/interpretation/state snapshot used
 for final synthesis. These types serialize compatibly with existing Redis records.
 
+`Mesh.execute_goal()` results distinguish process lifecycle from source-goal truth:
+
+- `status` reports whether the distributed execution completed, failed, waited or
+    was cancelled.
+- `obligation_status` reports `satisfied`, `blocked` or `incomplete`.
+
+A terminal step with an actionable semantic gap can trigger a bounded DAG
+revision. Reconciliation preserves completed steps and effects, adds new work
+against their durable artifacts, and emits a fresh final response. If no available
+capability can advance the gap, the current revision settles as `blocked` rather
+than looping or claiming that execution completion satisfied the goal.
+
 #### resume_goal
 
 ```python

--- a/jarviscore/docs/reference/agent-api.md
+++ b/jarviscore/docs/reference/agent-api.md
@@ -36,7 +36,7 @@ from jarviscore.profiles import AutoAgent
 
 | Variable | Default | Description |
 |---|---|---|
-| `HITL_ENABLED` | `false` | Enable `AdaptiveHITLPolicy`. Escalates on low-confidence or high-risk Kernel actions. |
+| `HITL_ENABLED` | `false` | Enable typed human-only HITL. Routine failure, low confidence and token spend never escalate. |
 | `BROWSER_ENABLED` | `false` | Activate `BrowserSubAgent` for web automation tasks. |
 | `MAX_GOAL_STEPS` | `30` | Hard step ceiling for goal-oriented agents. |
 | `MAX_REPLAN_ATTEMPTS` | `8` | Maximum replanning cycles before the goal is marked failed. |
@@ -200,6 +200,9 @@ Mesh(config: Optional[Dict[str, Any]] = None)
 | `p2p_enabled` | `bool` | from `P2P_ENABLED` env | Enable SWIM/ZMQ peer transport |
 | `checkpoint_interval` | `int` | `1` | Save workflow checkpoints every N steps |
 | `max_parallel` | `int` | `5` | Maximum parallel step execution |
+| `distributed_poll_interval` | `float` | `2.0` | Redis DAG polling interval in seconds |
+| `distributed_claim_lease_seconds` | `int` | `60` | Renewable execution-claim lease duration |
+| `mesh_planning_lease_seconds` | `int` | `300` | Goal compilation or amendment lease duration |
 
 The Mesh auto-detects available infrastructure at `start()` time. Do not pass `mode=`: that argument is deprecated and has no effect.
 
@@ -244,6 +247,102 @@ Each step dict:
 | `complexity` | `str` | No | Model tier hint: `"nano"`, `"standard"`, or `"heavy"` |
 
 Raises `RuntimeError` if `start()` has not been called or if the workflow engine is unavailable.
+
+#### execute_goal
+
+```python
+async def execute_goal(
+    goal: str,
+    *,
+    workflow_id: Optional[str] = None,
+    context: Optional[Dict[str, Any]] = None,
+    timeout: float = 900.0,
+) -> Dict[str, Any]
+```
+
+Register an immutable source goal, wait for any planning-capable node to publish
+a capability-addressed Redis DAG, and observe independent peer claims until the
+workflow reaches `completed`, `failed`, or `waiting`. Requires Redis.
+
+Set `config["execution_budget"]` on `Mesh` to bound the complete execution:
+
+```python
+mesh = Mesh(config={
+    "execution_budget": {
+        "max_seconds": 900,
+        "max_tokens": 240_000,
+        "max_steps": 30,
+        "max_replans": 8,
+        "max_peer_depth": 2,
+        "peer_timeout_seconds": 300,
+    }
+})
+```
+
+The framework stores this as `ExecutionBudget` in the durable
+`WorkflowEnvelope`. Caller context cannot override it. Token usage is enforced
+through one Redis-backed account per workflow: each model call reserves capacity
+before dispatch and settles exact provider-reported usage and cost afterward.
+Planning, evaluators, dependency/effect reviews, direct steps and nested peer
+mandates all debit that same account.
+
+### Atom repair lifecycle
+
+Coder exposes `inspect_atom_for_repair` and `repair_atom` only after an atom has
+failed during the current run. A repair candidate is bound to the atom's name,
+provider, version and failed invocation. `register_function` rejects candidates
+without successful execution evidence and rejects stale or renamed repairs. A
+successful repair becomes the next immutable FunctionRegistry version while the
+superseded source remains available for audit.
+
+### Distributed execution envelopes
+
+```python
+from jarviscore.orchestration import (
+    CapabilityMandate,
+    ExecutionBudget,
+    WorkflowEnvelope,
+    WorkflowEvidence,
+)
+```
+
+`WorkflowEnvelope` is the canonical source/context/DAG record.
+`CapabilityMandate` is the scoped peer-request lifecycle.
+`WorkflowEvidence` is the complete artifact/interpretation/state snapshot used
+for final synthesis. These types serialize compatibly with existing Redis records.
+
+#### resume_goal
+
+```python
+async def resume_goal(
+    workflow_id: str,
+    step_id: str,
+    *,
+    context: Optional[Dict[str, Any]] = None,
+    timeout: float = 900.0,
+) -> Dict[str, Any]
+```
+
+Resume a waiting step with optional human or external context. The original
+executor affinity is retained and blocked descendants become claimable after
+the resumed step succeeds.
+
+#### replan_goal
+
+```python
+async def replan_goal(
+    workflow_id: str,
+    *,
+    reason: str,
+    context: Optional[Dict[str, Any]] = None,
+    timeout: float = 900.0,
+) -> Dict[str, Any]
+```
+
+Compile a replacement for unfinished work under a short planning lease. The
+commit uses revision compare-and-swap and cannot remove or mutate completed
+steps or their outputs. The original source goal and obligation ledger remain
+authoritative; peers resume normal capability-based claiming after publication.
 
 #### stop
 

--- a/jarviscore/docs/reference/configuration.md
+++ b/jarviscore/docs/reference/configuration.md
@@ -123,6 +123,23 @@ Start Redis locally for development:
 docker run -d -p 6379:6379 redis:7-alpine
 ```
 
+### Distributed goal configuration
+
+These values are `Mesh(config={...})` keys, not environment variables:
+
+| Key | Default | Description |
+|---|---|---|
+| `distributed_poll_interval` | `2.0` | Redis DAG polling interval in seconds |
+| `distributed_claim_lease_seconds` | `60` | Renewable execution-claim lease duration |
+| `mesh_planning_lease_seconds` | `300` | Initial planning and amendment lease duration |
+| `mesh_max_reconciliation_revisions` | `3` | Bounded automatic semantic revisions |
+| `mesh_response_capability` | `None` | Capability authorized for the optional final response |
+| `execution_budget` | framework defaults | Shared `max_seconds`, `max_steps`, `max_replans`, `max_tokens`, `max_peer_depth` and `peer_timeout_seconds` |
+
+Caller task context cannot override execution authority or the workflow budget.
+All nodes sharing one distributed DAG should run the same JarvisCore minor
+version. See [Durable Goal Execution](../guides/goal-execution.md).
+
 ---
 
 ## Memory: Athena MemOS

--- a/jarviscore/execution/atom_contract.py
+++ b/jarviscore/execution/atom_contract.py
@@ -198,6 +198,12 @@ def read_contract(source: str, *, system: str = "", expected_name: str = "") -> 
 
     legacy = any(a.arg == LEGACY_AUTH_PARAMETER for a in fn.args.args)
     uses_nexus = AUTH_CALL in source
+    retrieves_token = any(
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "_get_nexus_token"
+        for node in ast.walk(fn)
+    )
     policy = AtomPolicy()
     for statement in tree.body:
         if isinstance(statement, ast.Assign) and any(
@@ -216,24 +222,25 @@ def read_contract(source: str, *, system: str = "", expected_name: str = "") -> 
                 problems.append(f"{POLICY_NAME} must be a literal dict")
             break
 
-    if policy.effect not in {"read", "write", "destructive"}:
-        problems.append("ATOM_POLICY.effect must be read, write, or destructive")
+    if policy.effect not in {"read", "write", "notify", "destructive"}:
+        problems.append("ATOM_POLICY.effect must be read, write, notify, or destructive")
     if policy.approval not in {"never", "required"}:
         problems.append("ATOM_POLICY.approval must be never or required")
-    if policy.effect == "destructive":
-        if not policy.requires_approval:
-            problems.append("destructive atoms require approval")
+    if policy.effect in {"write", "notify", "destructive"}:
         if not policy.idempotency_fields:
-            problems.append("destructive atoms require idempotency_fields")
+            problems.append(f"{policy.effect} atoms require idempotency_fields")
         if not policy.consequence:
-            problems.append("destructive atoms require a consequence")
+            problems.append(f"{policy.effect} atoms require a consequence")
         parameter_names = {argument.arg for argument in fn.args.args}
         missing_identity = set(policy.idempotency_fields) - parameter_names
         if missing_identity:
             problems.append(
-                "destructive idempotency_fields must name parameters: "
+                "mutation idempotency_fields must name parameters: "
                 + ", ".join(sorted(missing_identity))
             )
+    if policy.effect == "destructive":
+        if not policy.requires_approval:
+            problems.append("destructive atoms require approval")
     elif _performs_delete(fn, functions_by_name):
         problems.append("atoms that perform HTTP DELETE require a destructive ATOM_POLICY")
 
@@ -244,6 +251,11 @@ def read_contract(source: str, *, system: str = "", expected_name: str = "") -> 
     if system and not fn.name.startswith(f"{system.lower()}_"):
         problems.append(f"`{fn.name}` should start with `{system.lower()}_`")
     if not legacy:
+        if retrieves_token:
+            problems.append(
+                f"`{fn.name}` must not retrieve provider tokens; {AUTH_CALL} "
+                "attaches credentials outside the atom"
+            )
         if not isinstance(fn, ast.AsyncFunctionDef):
             problems.append(f"`{fn.name}` must be `async def` — {AUTH_CALL} is awaited")
         if not uses_nexus:

--- a/jarviscore/execution/code_registry.py
+++ b/jarviscore/execution/code_registry.py
@@ -408,6 +408,14 @@ class FunctionRegistry:
             ),
             "strategy": metadata.get("strategy", "sandbox"),
             "agent_id": metadata.get("agent_id"),
+            "repair_of_version": metadata.get("repair_of_version"),
+            "repair_failure": metadata.get("repair_failure"),
+            "catalogue_managed": metadata.get(
+                "catalogue_managed", existing.get("catalogue_managed", False)
+            ),
+            "catalogue_source_hash": metadata.get(
+                "catalogue_source_hash", existing.get("catalogue_source_hash")
+            ),
             "load_status": "loaded" if function_name in self.functions else "source_only",
             "oauth_metadata": metadata.get("oauth_metadata"),
         }
@@ -1549,7 +1557,7 @@ def create_function_registry(
         FunctionRegistry instance
     """
     registry = FunctionRegistry(storage_path, blob_storage, redis_store)
-    if seed and not registry.function_metadata:
+    if seed:
         _seed_shipped_atoms(registry)
     return registry
 
@@ -1557,12 +1565,8 @@ def create_function_registry(
 def _seed_shipped_atoms(registry: FunctionRegistry) -> None:
     """Load the packaged atoms so a fresh registry is not an empty one.
 
-    The catalogue ships with the package and the docs describe it as available
-    from startup, but nothing loaded it, so every deployment began with an empty
-    registry and agents rewrote integrations that were already on disk. Seeding
-    happens only when the registry holds nothing: a registry with contents has a
-    history, and re-seeding over it would overwrite execution counts that were
-    earned by real runs.
+    Merge missing shipped atoms on every open so an existing workspace receives
+    framework additions without replacing atoms or execution history it already has.
     """
     try:
         from jarviscore.integrations.seed_registry import seed_registry
@@ -1574,7 +1578,7 @@ def _seed_shipped_atoms(registry: FunctionRegistry) -> None:
         return
 
     try:
-        report = seed_registry(registry)
+        report = seed_registry(registry, missing_only=True)
     except Exception as exc:  # noqa: BLE001 - a broken catalogue must not stop the agent
         logger.warning(
             "Atom catalogue failed to load, registry starts empty "

--- a/jarviscore/execution/coder_sandbox.py
+++ b/jarviscore/execution/coder_sandbox.py
@@ -363,6 +363,7 @@ class CoderSandbox:
         bash_timeout: int = 120,
         output_subdir: str = "output",
         nexus_call_proxy=None,  # Optional[NexusCallProxy]
+        mesh_proxy=None,
         blob_storage=None,      # Optional[BlobStorage]
         artifact_prefix: str = "artifacts",
     ):
@@ -378,6 +379,7 @@ class CoderSandbox:
         self._bash = BashExecutor(self.workspace, timeout=bash_timeout)
         self._git = GitHelper(self._bash, self.workspace)
         self._nexus_call_proxy = nexus_call_proxy  # NexusCallProxy | None
+        self._mesh_proxy = mesh_proxy
 
         logger.info(
             "CoderSandbox initialized: workspace=%s timeout=%ds nexus=%s",
@@ -479,6 +481,17 @@ class CoderSandbox:
                 try:
                     if request["operation"] == "nexus_call":
                         payload = request["payload"]
+                        method = str(payload.get("method") or "GET").upper()
+                        mutation = context.get("_mutation_authority")
+                        if method not in {"GET", "HEAD", "OPTIONS"} and not (
+                            isinstance(mutation, dict)
+                            and mutation.get("atom")
+                            and mutation.get("action_id")
+                        ):
+                            raise RuntimeError(
+                                "Provider mutations must use a registered atom with "
+                                "declared policy and idempotency identity."
+                            )
                         requested_provider = payload.get("provider")
                         provider = str(
                             requested_provider
@@ -497,7 +510,7 @@ class CoderSandbox:
                             provider or str(connection_id),
                         )
                         result = await call(
-                            payload["method"], payload["url"], **payload.get("kwargs", {})
+                            method, payload["url"], **payload.get("kwargs", {})
                         )
                     elif request["operation"] == "fetch_artifact":
                         if self.blob_storage is None:
@@ -509,6 +522,23 @@ class CoderSandbox:
                         if isinstance(content, str):
                             content = content.encode()
                         result = {"content": base64.b64encode(content).decode("ascii")}
+                    elif request["operation"] == "mesh_list_peers":
+                        if self._mesh_proxy is None:
+                            raise RuntimeError("No mesh is attached to this agent.")
+                        result = self._mesh_proxy.list_peers()
+                        if hasattr(result, "__await__"):
+                            result = await result
+                    elif request["operation"] == "mesh_delegate":
+                        if self._mesh_proxy is None:
+                            raise RuntimeError("No mesh is attached to this agent.")
+                        payload = request["payload"]
+                        result = await self._mesh_proxy.delegate(
+                            to=str(payload.get("to") or ""),
+                            task=str(payload.get("task") or ""),
+                            context=payload.get("context"),
+                            capability=payload.get("capability"),
+                            timeout=payload.get("timeout"),
+                        )
                     else:
                         raise RuntimeError("Unknown sandbox RPC operation.")
                     response = {"id": request["id"], "result": self._rpc_jsonable(result)}
@@ -1081,6 +1111,7 @@ def create_coder_sandbox(
     timeout: int = 300,
     bash_timeout: int = 120,
     nexus_call_proxy=None,  # Optional[NexusCallProxy] — wires nexus_call() into sandbox
+    mesh_proxy=None,
     blob_storage=None,      # Optional[BlobStorage] — where a run's files end up
     artifact_prefix: str = "artifacts",
 ) -> CoderSandbox:
@@ -1104,6 +1135,7 @@ def create_coder_sandbox(
         timeout=timeout,
         bash_timeout=bash_timeout,
         nexus_call_proxy=nexus_call_proxy,
+        mesh_proxy=mesh_proxy,
         blob_storage=blob_storage,
         artifact_prefix=artifact_prefix,
     )

--- a/jarviscore/execution/llm.py
+++ b/jarviscore/execution/llm.py
@@ -8,10 +8,12 @@ import logging
 import random
 import re
 import time
+import json
 from typing import Optional, Dict, List, Any
 from enum import Enum
 
 from jarviscore.promo import PROMO_MODEL
+from jarviscore.orchestration.budget import current_workflow_budget
 
 logger = logging.getLogger(__name__)
 
@@ -388,12 +390,40 @@ class UnifiedLLMClient:
         if not messages:
             messages = [{"role": "user", "content": prompt}]
 
-        # Acquire concurrency slot before dispatching to any provider.
-        # _semaphore is None when LLM_MAX_CONCURRENT=0 (unlimited).
-        if self._semaphore:
-            async with self._semaphore:
-                return await self._generate_inner(messages, temperature, max_tokens, **kwargs)
-        return await self._generate_inner(messages, temperature, max_tokens, **kwargs)
+        budget_account = current_workflow_budget()
+        reservation_id = None
+        if budget_account is not None:
+            input_reservation = len(
+                json.dumps(
+                    messages, ensure_ascii=False, default=str
+                ).encode("utf-8")
+            )
+            reservation_id = budget_account.reserve(input_reservation + max_tokens)
+
+        try:
+            # Acquire concurrency slot before dispatching to any provider.
+            # _semaphore is None when LLM_MAX_CONCURRENT=0 (unlimited).
+            if self._semaphore:
+                async with self._semaphore:
+                    result = await self._generate_inner(
+                        messages, temperature, max_tokens, **kwargs
+                    )
+            else:
+                result = await self._generate_inner(
+                    messages, temperature, max_tokens, **kwargs
+                )
+        except Exception:
+            if budget_account is not None and reservation_id is not None:
+                budget_account.release(reservation_id)
+            raise
+        if budget_account is not None and reservation_id is not None:
+            usage = result.get("tokens") or {}
+            budget_account.settle(
+                reservation_id,
+                int(usage.get("total") or 0),
+                float(result.get("cost_usd") or 0.0),
+            )
+        return result
 
 
 

--- a/jarviscore/execution/sandbox_worker.py
+++ b/jarviscore/execution/sandbox_worker.py
@@ -7,7 +7,6 @@ import base64
 import contextlib
 import io
 import json
-import os
 import socket
 import sys
 from pathlib import Path
@@ -52,11 +51,43 @@ class ParentRPC:
         return response.get("result")
 
 
+class MeshFacade:
+    """The only mesh operations generated code may request from its parent."""
+
+    def __init__(self, rpc: ParentRPC):
+        self._rpc = rpc
+
+    async def list_peers(self):
+        return await asyncio.to_thread(self._rpc.call, "mesh_list_peers", {})
+
+    async def delegate(
+        self,
+        *,
+        to: str,
+        task: str,
+        context: dict | None = None,
+        capability: str | None = None,
+        timeout: float | None = None,
+    ):
+        return await asyncio.to_thread(
+            self._rpc.call,
+            "mesh_delegate",
+            {
+                "to": to,
+                "task": task,
+                "context": _jsonable(context or {}),
+                "capability": capability,
+                "timeout": timeout,
+            },
+        )
+
+
 async def execute(request: dict) -> dict:
     workspace = Path(request["workspace"]).resolve()
     output_dir = Path(request["output_dir"]).resolve()
     output_dir.mkdir(parents=True, exist_ok=True)
     rpc = ParentRPC(int(request["rpc_fd"]))
+    mesh = MeshFacade(rpc)
     bash = BashExecutor(workspace, timeout=int(request.get("bash_timeout", 120)))
     git = GitHelper(bash, workspace)
 
@@ -95,7 +126,7 @@ async def execute(request: dict) -> dict:
         "__builtins__": __builtins__, "result": None,
         "workspace": workspace, "output_dir": output_dir,
         "blob_path": blob_path, "fetch_artifact": fetch_artifact,
-        "bash": bash, "git": git, "nexus_call": nexus_call,
+        "bash": bash, "git": git, "nexus_call": nexus_call, "mesh": mesh,
         "Path": pathlib.Path, "json": json, "re": re, "datetime": datetime,
         "math": math, "hashlib": hashlib, "uuid": uuid, "shutil": shutil,
         "tempfile": tempfile, "textwrap": textwrap,
@@ -116,7 +147,7 @@ async def execute(request: dict) -> dict:
                 if returned is not None:
                     namespace["result"] = returned
         return {"result": _jsonable(namespace.get("result")), "stdout": stdout.getvalue()}
-    except Exception as exc:
+    except Exception as exc:  # noqa: BLE001 - serialize child failures to the parent process
         return {"error": str(exc), "error_type": type(exc).__name__, "stdout": stdout.getvalue()}
 
 

--- a/jarviscore/integrations/atoms/azure_storage/azure_storage_download_blob.py
+++ b/jarviscore/integrations/atoms/azure_storage/azure_storage_download_blob.py
@@ -1,11 +1,7 @@
 async def azure_storage_download_blob(account_name: str, container_name: str, blob_name: str) -> dict:
     """Storage download blob via the azure_storage API."""
     try:
-        access_token = _get_nexus_token(None)
-    except Exception as e:
-        return {'success': False, 'data': None, 'error': f'Auth error: {str(e)}'}
-    try:
-        resp = await nexus_call('GET', f'https://{account_name}.blob.core.windows.net/{container_name}/{blob_name}', headers={'Authorization': f'Bearer {access_token}', 'x-ms-version': '2020-10-02'})
+        resp = await nexus_call('GET', f'https://{account_name}.blob.core.windows.net/{container_name}/{blob_name}', headers={'x-ms-version': '2020-10-02'})
         if resp['status_code'] != 200:
             return {'success': False, 'data': None, 'error': f"Download blob failed: {resp['status_code']} {resp['body']}"}
         return {'success': True, 'data': {'blob_name': blob_name, 'content_type': resp['headers'].get('Content-Type'), 'content': resp['content'].decode('utf-8', errors='replace'), 'size_bytes': len(resp['content'])}, 'error': None}

--- a/jarviscore/integrations/atoms/azure_storage/azure_storage_list_containers.py
+++ b/jarviscore/integrations/atoms/azure_storage/azure_storage_list_containers.py
@@ -2,11 +2,7 @@ async def azure_storage_list_containers(account_name: str) -> dict:
     """Storage list containers via the azure_storage API."""
     import xml.etree.ElementTree as ET
     try:
-        access_token = _get_nexus_token(None)
-    except Exception as e:
-        return {'success': False, 'data': None, 'error': f'Auth error: {str(e)}'}
-    try:
-        resp = await nexus_call('GET', f'https://{account_name}.blob.core.windows.net/', headers={'Authorization': f'Bearer {access_token}', 'x-ms-version': '2020-10-02'}, params={'comp': 'list'})
+        resp = await nexus_call('GET', f'https://{account_name}.blob.core.windows.net/', headers={'x-ms-version': '2020-10-02'}, params={'comp': 'list'})
         if resp['status_code'] != 200:
             return {'success': False, 'data': None, 'error': f"List containers failed: {resp['status_code']} {resp['body']}"}
         root = ET.fromstring(resp['body'])

--- a/jarviscore/integrations/atoms/azure_storage/azure_storage_upload_blob.py
+++ b/jarviscore/integrations/atoms/azure_storage/azure_storage_upload_blob.py
@@ -1,11 +1,7 @@
 async def azure_storage_upload_blob(account_name: str, container_name: str, blob_name: str, content: bytes, content_type: str='application/octet-stream') -> dict:
     """Storage upload blob via the azure_storage API."""
     try:
-        access_token = _get_nexus_token(None)
-    except Exception as e:
-        return {'success': False, 'data': None, 'error': f'Auth error: {str(e)}'}
-    try:
-        resp = await nexus_call('PUT', f'https://{account_name}.blob.core.windows.net/{container_name}/{blob_name}', headers={'Authorization': f'Bearer {access_token}', 'x-ms-version': '2020-10-02', 'x-ms-blob-type': 'BlockBlob', 'Content-Type': content_type}, data=content)
+        resp = await nexus_call('PUT', f'https://{account_name}.blob.core.windows.net/{container_name}/{blob_name}', headers={'x-ms-version': '2020-10-02', 'x-ms-blob-type': 'BlockBlob', 'Content-Type': content_type}, data=content)
         if resp['status_code'] != 201:
             return {'success': False, 'data': None, 'error': f"Upload blob failed: {resp['status_code']} {resp['body']}"}
         return {'success': True, 'data': {'account': account_name, 'container': container_name, 'blob': blob_name, 'uploaded': True}, 'error': None}

--- a/jarviscore/integrations/atoms/clickup/clickup_create_comment.py
+++ b/jarviscore/integrations/atoms/clickup/clickup_create_comment.py
@@ -1,11 +1,7 @@
 async def clickup_create_comment(task_id: str, comment_text: str) -> dict:
     """Create comment via the clickup API."""
     try:
-        access_token = _get_nexus_token(None)
-    except Exception as e:
-        return {'success': False, 'data': None, 'error': f'Auth error: {str(e)}'}
-    try:
-        resp = await nexus_call('POST', f'https://api.clickup.com/api/v2/task/{task_id}/comment', json={'comment_text': comment_text}, headers={'Authorization': access_token, 'Content-Type': 'application/json'})
+        resp = await nexus_call('POST', f'https://api.clickup.com/api/v2/task/{task_id}/comment', json={'comment_text': comment_text}, headers={'Content-Type': 'application/json'})
         if resp['status_code'] not in (200, 201):
             return {'success': False, 'data': None, 'error': f"Create comment failed: {resp['status_code']} {resp['body']}"}
         return {'success': True, 'data': resp['json'], 'error': None}

--- a/jarviscore/integrations/atoms/clickup/clickup_create_task.py
+++ b/jarviscore/integrations/atoms/clickup/clickup_create_task.py
@@ -1,10 +1,6 @@
 async def clickup_create_task(list_id: str, name: str, description: str=None, priority: int=None, status: str=None) -> dict:
     """Create task via the clickup API."""
     try:
-        access_token = _get_nexus_token(None)
-    except Exception as e:
-        return {'success': False, 'data': None, 'error': f'Auth error: {str(e)}'}
-    try:
         payload = {'name': name}
         if description:
             payload['description'] = description
@@ -12,7 +8,7 @@ async def clickup_create_task(list_id: str, name: str, description: str=None, pr
             payload['priority'] = priority
         if status:
             payload['status'] = status
-        resp = await nexus_call('POST', f'https://api.clickup.com/api/v2/list/{list_id}/task', json=payload, headers={'Authorization': access_token, 'Content-Type': 'application/json'})
+        resp = await nexus_call('POST', f'https://api.clickup.com/api/v2/list/{list_id}/task', json=payload, headers={'Content-Type': 'application/json'})
         if resp['status_code'] not in (200, 201):
             return {'success': False, 'data': None, 'error': f"Create task failed: {resp['status_code']} {resp['body']}"}
         return {'success': True, 'data': resp['json'], 'error': None}

--- a/jarviscore/integrations/atoms/clickup/clickup_get_lists.py
+++ b/jarviscore/integrations/atoms/clickup/clickup_get_lists.py
@@ -1,11 +1,7 @@
 async def clickup_get_lists(space_id: str) -> dict:
     """Get lists via the clickup API."""
     try:
-        access_token = _get_nexus_token(None)
-    except Exception as e:
-        return {'success': False, 'data': None, 'error': f'Auth error: {str(e)}'}
-    try:
-        resp = await nexus_call('GET', f'https://api.clickup.com/api/v2/space/{space_id}/list', headers={'Authorization': access_token})
+        resp = await nexus_call('GET', f'https://api.clickup.com/api/v2/space/{space_id}/list')
         if resp['status_code'] != 200:
             return {'success': False, 'data': None, 'error': f"Get lists failed: {resp['status_code']} {resp['body']}"}
         lists = resp['json'].get('lists', [])

--- a/jarviscore/integrations/atoms/clickup/clickup_get_spaces.py
+++ b/jarviscore/integrations/atoms/clickup/clickup_get_spaces.py
@@ -1,7 +1,7 @@
-async def _get_workspace_id(access_token: str) -> str:
+async def _get_workspace_id() -> str:
     if True .get('workspace_id'):
         return None
-    resp = await nexus_call('GET', 'https://api.clickup.com/api/v2/team', headers={'Authorization': access_token})
+    resp = await nexus_call('GET', 'https://api.clickup.com/api/v2/team')
     if not resp['ok']:
         raise RuntimeError(resp['body'])
     teams = resp['json'].get('teams', [])
@@ -12,12 +12,11 @@ async def _get_workspace_id(access_token: str) -> str:
 async def clickup_get_spaces() -> dict:
     """Get spaces via the clickup API."""
     try:
-        access_token = _get_nexus_token(None)
-        workspace_id = await _get_workspace_id(access_token)
+        workspace_id = await _get_workspace_id()
     except Exception as e:
         return {'success': False, 'data': None, 'error': f'Auth error: {str(e)}'}
     try:
-        resp = await nexus_call('GET', f'https://api.clickup.com/api/v2/team/{workspace_id}/space', headers={'Authorization': access_token})
+        resp = await nexus_call('GET', f'https://api.clickup.com/api/v2/team/{workspace_id}/space')
         if resp['status_code'] != 200:
             return {'success': False, 'data': None, 'error': f"Get spaces failed: {resp['status_code']} {resp['body']}"}
         spaces = resp['json'].get('spaces', [])

--- a/jarviscore/integrations/atoms/clickup/clickup_get_task.py
+++ b/jarviscore/integrations/atoms/clickup/clickup_get_task.py
@@ -1,11 +1,7 @@
 async def clickup_get_task(task_id: str) -> dict:
     """Get task via the clickup API."""
     try:
-        access_token = _get_nexus_token(None)
-    except Exception as e:
-        return {'success': False, 'data': None, 'error': f'Auth error: {str(e)}'}
-    try:
-        resp = await nexus_call('GET', f'https://api.clickup.com/api/v2/task/{task_id}', headers={'Authorization': access_token})
+        resp = await nexus_call('GET', f'https://api.clickup.com/api/v2/task/{task_id}')
         if resp['status_code'] != 200:
             return {'success': False, 'data': None, 'error': f"Get task failed: {resp['status_code']} {resp['body']}"}
         return {'success': True, 'data': resp['json'], 'error': None}

--- a/jarviscore/integrations/atoms/clickup/clickup_update_task.py
+++ b/jarviscore/integrations/atoms/clickup/clickup_update_task.py
@@ -1,10 +1,6 @@
 async def clickup_update_task(task_id: str, name: str=None, description: str=None, status: str=None, priority: int=None) -> dict:
     """Update task via the clickup API."""
     try:
-        access_token = _get_nexus_token(None)
-    except Exception as e:
-        return {'success': False, 'data': None, 'error': f'Auth error: {str(e)}'}
-    try:
         payload = {}
         if name:
             payload['name'] = name
@@ -14,7 +10,7 @@ async def clickup_update_task(task_id: str, name: str=None, description: str=Non
             payload['status'] = status
         if priority:
             payload['priority'] = priority
-        resp = await nexus_call('PUT', f'https://api.clickup.com/api/v2/task/{task_id}', json=payload, headers={'Authorization': access_token, 'Content-Type': 'application/json'})
+        resp = await nexus_call('PUT', f'https://api.clickup.com/api/v2/task/{task_id}', json=payload, headers={'Content-Type': 'application/json'})
         if resp['status_code'] != 200:
             return {'success': False, 'data': None, 'error': f"Update task failed: {resp['status_code']} {resp['body']}"}
         return {'success': True, 'data': resp['json'], 'error': None}

--- a/jarviscore/integrations/atoms/discord/discord_get_connections.py
+++ b/jarviscore/integrations/atoms/discord/discord_get_connections.py
@@ -1,11 +1,7 @@
 async def discord_get_connections() -> dict:
     """Get connections. GET https://discord.com/api/v10/users/@me/connections"""
     try:
-        access_token = _get_nexus_token(None)
-    except Exception as e:
-        return {'success': False, 'data': None, 'error': f'Auth error: {str(e)}'}
-    try:
-        resp = await nexus_call('GET', 'https://discord.com/api/v10/users/@me/connections', headers={'Authorization': f'Bearer {access_token}'})
+        resp = await nexus_call('GET', 'https://discord.com/api/v10/users/@me/connections')
         if resp['status_code'] != 200:
             return {'success': False, 'data': None, 'error': f"Get connections failed: {resp['status_code']} {resp['body']}"}
         connections = resp['json']

--- a/jarviscore/integrations/atoms/discord/discord_get_guilds.py
+++ b/jarviscore/integrations/atoms/discord/discord_get_guilds.py
@@ -1,11 +1,7 @@
 async def discord_get_guilds() -> dict:
     """Get guilds. GET https://discord.com/api/v10/users/@me/guilds"""
     try:
-        access_token = _get_nexus_token(None)
-    except Exception as e:
-        return {'success': False, 'data': None, 'error': f'Auth error: {str(e)}'}
-    try:
-        resp = await nexus_call('GET', 'https://discord.com/api/v10/users/@me/guilds', headers={'Authorization': f'Bearer {access_token}'})
+        resp = await nexus_call('GET', 'https://discord.com/api/v10/users/@me/guilds')
         if resp['status_code'] != 200:
             return {'success': False, 'data': None, 'error': f"Get guilds failed: {resp['status_code']} {resp['body']}"}
         guilds = resp['json']

--- a/jarviscore/integrations/atoms/discord/discord_get_me.py
+++ b/jarviscore/integrations/atoms/discord/discord_get_me.py
@@ -1,11 +1,7 @@
 async def discord_get_me() -> dict:
     """Get me. GET https://discord.com/api/v10/users/@me"""
     try:
-        access_token = _get_nexus_token(None)
-    except Exception as e:
-        return {'success': False, 'data': None, 'error': f'Auth error: {str(e)}'}
-    try:
-        resp = await nexus_call('GET', 'https://discord.com/api/v10/users/@me', headers={'Authorization': f'Bearer {access_token}'})
+        resp = await nexus_call('GET', 'https://discord.com/api/v10/users/@me')
         if resp['status_code'] != 200:
             return {'success': False, 'data': None, 'error': f"Get me failed: {resp['status_code']} {resp['body']}"}
         return {'success': True, 'data': resp['json'], 'error': None}

--- a/jarviscore/integrations/atoms/dropbox/dropbox_create_folder.py
+++ b/jarviscore/integrations/atoms/dropbox/dropbox_create_folder.py
@@ -1,11 +1,7 @@
 async def dropbox_create_folder(dropbox_path: str, autorename: bool=False) -> dict:
     """Create folder. POST https://api.dropboxapi.com/2/files/create_folder_v2"""
     try:
-        access_token = _get_nexus_token(None)
-    except Exception as e:
-        return {'success': False, 'data': None, 'error': f'Auth error: {str(e)}'}
-    try:
-        resp = await nexus_call('POST', 'https://api.dropboxapi.com/2/files/create_folder_v2', json={'path': dropbox_path, 'autorename': autorename}, headers={'Authorization': f'Bearer {access_token}', 'Content-Type': 'application/json'})
+        resp = await nexus_call('POST', 'https://api.dropboxapi.com/2/files/create_folder_v2', json={'path': dropbox_path, 'autorename': autorename}, headers={'Content-Type': 'application/json'})
         if resp['status_code'] != 200:
             return {'success': False, 'data': None, 'error': f"Create folder failed: {resp['status_code']} {resp['body']}"}
         return {'success': True, 'data': resp['json'].get('metadata'), 'error': None}

--- a/jarviscore/integrations/atoms/dropbox/dropbox_download_file.py
+++ b/jarviscore/integrations/atoms/dropbox/dropbox_download_file.py
@@ -2,11 +2,7 @@ async def dropbox_download_file(dropbox_path: str, destination_path: str) -> dic
     """Download file. POST https://content.dropboxapi.com/2/files/download"""
     import os
     try:
-        access_token = _get_nexus_token(None)
-    except Exception as e:
-        return {'success': False, 'data': None, 'error': f'Auth error: {str(e)}'}
-    try:
-        resp = await nexus_call('POST', 'https://content.dropboxapi.com/2/files/download', headers={'Authorization': f'Bearer {access_token}', 'Dropbox-API-Arg': f'{{"path": "{dropbox_path}"}}'})
+        resp = await nexus_call('POST', 'https://content.dropboxapi.com/2/files/download', headers={'Dropbox-API-Arg': f'{{"path": "{dropbox_path}"}}'})
         if resp['status_code'] != 200:
             return {'success': False, 'data': None, 'error': f"Download failed: {resp['status_code']} {resp['body']}"}
         os.makedirs(os.path.dirname(os.path.abspath(destination_path)), exist_ok=True)

--- a/jarviscore/integrations/atoms/dropbox/dropbox_get_shared_link.py
+++ b/jarviscore/integrations/atoms/dropbox/dropbox_get_shared_link.py
@@ -1,13 +1,9 @@
 async def dropbox_get_shared_link(dropbox_path: str) -> dict:
     """Get shared link. POST https://api.dropboxapi.com/2/sharing/create_shared_link_with_settings"""
     try:
-        access_token = _get_nexus_token(None)
-    except Exception as e:
-        return {'success': False, 'data': None, 'error': f'Auth error: {str(e)}'}
-    try:
-        resp = await nexus_call('POST', 'https://api.dropboxapi.com/2/sharing/create_shared_link_with_settings', json={'path': dropbox_path, 'settings': {'requested_visibility': 'public'}}, headers={'Authorization': f'Bearer {access_token}', 'Content-Type': 'application/json'})
+        resp = await nexus_call('POST', 'https://api.dropboxapi.com/2/sharing/create_shared_link_with_settings', json={'path': dropbox_path, 'settings': {'requested_visibility': 'public'}}, headers={'Content-Type': 'application/json'})
         if resp['status_code'] == 409 and 'shared_link_already_exists' in resp['body']:
-            existing_resp = await nexus_call('POST', 'https://api.dropboxapi.com/2/sharing/list_shared_links', json={'path': dropbox_path, 'direct_only': True}, headers={'Authorization': f'Bearer {access_token}', 'Content-Type': 'application/json'})
+            existing_resp = await nexus_call('POST', 'https://api.dropboxapi.com/2/sharing/list_shared_links', json={'path': dropbox_path, 'direct_only': True}, headers={'Content-Type': 'application/json'})
             if existing_resp['status_code'] != 200:
                 return {'success': False, 'data': None, 'error': f"Fetch existing link failed: {existing_resp['status_code']} {existing_resp['body']}"}
             links = existing_resp['json'].get('links', [])

--- a/jarviscore/integrations/atoms/dropbox/dropbox_list_folder.py
+++ b/jarviscore/integrations/atoms/dropbox/dropbox_list_folder.py
@@ -1,17 +1,13 @@
 async def dropbox_list_folder(dropbox_path: str='', recursive: bool=False) -> dict:
     """List folder. POST https://api.dropboxapi.com/2/files/list_folder"""
     try:
-        access_token = _get_nexus_token(None)
-    except Exception as e:
-        return {'success': False, 'data': None, 'error': f'Auth error: {str(e)}'}
-    try:
-        resp = await nexus_call('POST', 'https://api.dropboxapi.com/2/files/list_folder', json={'path': dropbox_path, 'recursive': recursive}, headers={'Authorization': f'Bearer {access_token}', 'Content-Type': 'application/json'})
+        resp = await nexus_call('POST', 'https://api.dropboxapi.com/2/files/list_folder', json={'path': dropbox_path, 'recursive': recursive}, headers={'Content-Type': 'application/json'})
         if resp['status_code'] != 200:
             return {'success': False, 'data': None, 'error': f"List folder failed: {resp['status_code']} {resp['body']}"}
         result = resp['json']
         entries = result.get('entries', [])
         while result.get('has_more'):
-            cursor_resp = await nexus_call('POST', 'https://api.dropboxapi.com/2/files/list_folder/continue', json={'cursor': result['cursor']}, headers={'Authorization': f'Bearer {access_token}', 'Content-Type': 'application/json'})
+            cursor_resp = await nexus_call('POST', 'https://api.dropboxapi.com/2/files/list_folder/continue', json={'cursor': result['cursor']}, headers={'Content-Type': 'application/json'})
             if cursor_resp['status_code'] != 200:
                 break
             result = cursor_resp['json']

--- a/jarviscore/integrations/atoms/dropbox/dropbox_upload_file.py
+++ b/jarviscore/integrations/atoms/dropbox/dropbox_upload_file.py
@@ -2,13 +2,9 @@ async def dropbox_upload_file(file_path: str, dropbox_path: str, overwrite: bool
     """Upload file. POST https://content.dropboxapi.com/2/files/upload"""
     import os
     try:
-        access_token = _get_nexus_token(None)
-    except Exception as e:
-        return {'success': False, 'data': None, 'error': f'Auth error: {str(e)}'}
-    try:
         mode = 'overwrite' if overwrite else 'add'
         with open(file_path, 'rb') as f:
-            resp = await nexus_call('POST', 'https://content.dropboxapi.com/2/files/upload', headers={'Authorization': f'Bearer {access_token}', 'Content-Type': 'application/octet-stream', 'Dropbox-API-Arg': f'{{"path": "{dropbox_path}", "mode": "{mode}", "autorename": true}}'}, data=f)
+            resp = await nexus_call('POST', 'https://content.dropboxapi.com/2/files/upload', headers={'Content-Type': 'application/octet-stream', 'Dropbox-API-Arg': f'{{"path": "{dropbox_path}", "mode": "{mode}", "autorename": true}}'}, data=f)
         if resp['status_code'] != 200:
             return {'success': False, 'data': None, 'error': f"Upload failed: {resp['status_code']} {resp['body']}"}
         return {'success': True, 'data': resp['json'], 'error': None}

--- a/jarviscore/integrations/atoms/dynamics/dynamics_create_account.py
+++ b/jarviscore/integrations/atoms/dynamics/dynamics_create_account.py
@@ -1,10 +1,6 @@
 async def dynamics_create_account(org_url: str, name: str, email: str=None, phone: str=None, website: str=None) -> dict:
     """Create account via the dynamics API."""
     try:
-        access_token = _get_nexus_token(None)
-    except Exception as e:
-        return {'success': False, 'data': None, 'error': f'Auth error: {str(e)}'}
-    try:
         payload = {'name': name}
         if email:
             payload['emailaddress1'] = email
@@ -12,7 +8,7 @@ async def dynamics_create_account(org_url: str, name: str, email: str=None, phon
             payload['telephone1'] = phone
         if website:
             payload['websiteurl'] = website
-        resp = await nexus_call('POST', f"{org_url.rstrip('/')}/api/data/v9.2/accounts", headers={'Authorization': f'Bearer {access_token}', 'OData-MaxVersion': '4.0', 'OData-Version': '4.0', 'Accept': 'application/json', 'Content-Type': 'application/json', 'Prefer': 'return=representation'}, json=payload)
+        resp = await nexus_call('POST', f"{org_url.rstrip('/')}/api/data/v9.2/accounts", headers={'OData-MaxVersion': '4.0', 'OData-Version': '4.0', 'Accept': 'application/json', 'Content-Type': 'application/json', 'Prefer': 'return=representation'}, json=payload)
         if resp['status_code'] not in (200, 201):
             return {'success': False, 'data': None, 'error': f"Create account failed: {resp['status_code']} {resp['body']}"}
         return {'success': True, 'data': resp['json'], 'error': None}

--- a/jarviscore/integrations/atoms/dynamics/dynamics_get_accounts.py
+++ b/jarviscore/integrations/atoms/dynamics/dynamics_get_accounts.py
@@ -1,11 +1,7 @@
 async def dynamics_get_accounts(org_url: str, max_results: int=50) -> dict:
     """Get accounts via the dynamics API."""
     try:
-        access_token = _get_nexus_token(None)
-    except Exception as e:
-        return {'success': False, 'data': None, 'error': f'Auth error: {str(e)}'}
-    try:
-        resp = await nexus_call('GET', f"{org_url.rstrip('/')}/api/data/v9.2/accounts", headers={'Authorization': f'Bearer {access_token}', 'OData-MaxVersion': '4.0', 'OData-Version': '4.0', 'Accept': 'application/json'}, params={'$top': max_results, '$select': 'accountid,name,emailaddress1,telephone1,websiteurl'})
+        resp = await nexus_call('GET', f"{org_url.rstrip('/')}/api/data/v9.2/accounts", headers={'OData-MaxVersion': '4.0', 'OData-Version': '4.0', 'Accept': 'application/json'}, params={'$top': max_results, '$select': 'accountid,name,emailaddress1,telephone1,websiteurl'})
         if resp['status_code'] != 200:
             return {'success': False, 'data': None, 'error': f"Get accounts failed: {resp['status_code']} {resp['body']}"}
         accounts = resp['json'].get('value', [])

--- a/jarviscore/integrations/atoms/dynamics/dynamics_get_contacts.py
+++ b/jarviscore/integrations/atoms/dynamics/dynamics_get_contacts.py
@@ -1,11 +1,7 @@
 async def dynamics_get_contacts(org_url: str, max_results: int=50) -> dict:
     """Get contacts via the dynamics API."""
     try:
-        access_token = _get_nexus_token(None)
-    except Exception as e:
-        return {'success': False, 'data': None, 'error': f'Auth error: {str(e)}'}
-    try:
-        resp = await nexus_call('GET', f"{org_url.rstrip('/')}/api/data/v9.2/contacts", headers={'Authorization': f'Bearer {access_token}', 'OData-MaxVersion': '4.0', 'OData-Version': '4.0', 'Accept': 'application/json'}, params={'$top': max_results, '$select': 'contactid,fullname,emailaddress1,telephone1,jobtitle'})
+        resp = await nexus_call('GET', f"{org_url.rstrip('/')}/api/data/v9.2/contacts", headers={'OData-MaxVersion': '4.0', 'OData-Version': '4.0', 'Accept': 'application/json'}, params={'$top': max_results, '$select': 'contactid,fullname,emailaddress1,telephone1,jobtitle'})
         if resp['status_code'] != 200:
             return {'success': False, 'data': None, 'error': f"Get contacts failed: {resp['status_code']} {resp['body']}"}
         contacts = resp['json'].get('value', [])

--- a/jarviscore/integrations/atoms/freshbooks/freshbooks_create_client.py
+++ b/jarviscore/integrations/atoms/freshbooks/freshbooks_create_client.py
@@ -1,7 +1,7 @@
-async def _get_account_id(access_token: str) -> str:
+async def _get_account_id() -> str:
     if True .get('account_id'):
         return None
-    resp = await nexus_call('GET', 'https://api.freshbooks.com/auth/api/v1/users/me', headers={'Authorization': f'Bearer {access_token}', 'Content-Type': 'application/json'})
+    resp = await nexus_call('GET', 'https://api.freshbooks.com/auth/api/v1/users/me', headers={'Content-Type': 'application/json'})
     if not resp['ok']:
         raise RuntimeError(resp['body'])
     memberships = resp['json'].get('response', {}).get('business_memberships', [])
@@ -12,8 +12,7 @@ async def _get_account_id(access_token: str) -> str:
 async def freshbooks_create_client(email: str, organization: str=None, first_name: str=None, last_name: str=None, phone: str=None) -> dict:
     """Create client via the freshbooks API."""
     try:
-        access_token = _get_nexus_token(None)
-        account_id = await _get_account_id(access_token)
+        account_id = await _get_account_id()
     except Exception as e:
         return {'success': False, 'data': None, 'error': f'Auth error: {str(e)}'}
     try:
@@ -26,7 +25,7 @@ async def freshbooks_create_client(email: str, organization: str=None, first_nam
             client['lname'] = last_name
         if phone:
             client['mob_phone'] = phone
-        resp = await nexus_call('POST', f'https://api.freshbooks.com/accounting/account/{account_id}/users/clients', json={'client': client}, headers={'Authorization': f'Bearer {access_token}', 'Content-Type': 'application/json'})
+        resp = await nexus_call('POST', f'https://api.freshbooks.com/accounting/account/{account_id}/users/clients', json={'client': client}, headers={'Content-Type': 'application/json'})
         if resp['status_code'] not in (200, 201):
             return {'success': False, 'data': None, 'error': f"Create client failed: {resp['status_code']} {resp['body']}"}
         return {'success': True, 'data': resp['json'].get('response', {}).get('result', {}).get('client'), 'error': None}

--- a/jarviscore/integrations/atoms/freshbooks/freshbooks_create_expense.py
+++ b/jarviscore/integrations/atoms/freshbooks/freshbooks_create_expense.py
@@ -1,7 +1,7 @@
-async def _get_account_id(access_token: str) -> str:
+async def _get_account_id() -> str:
     if True .get('account_id'):
         return None
-    resp = await nexus_call('GET', 'https://api.freshbooks.com/auth/api/v1/users/me', headers={'Authorization': f'Bearer {access_token}', 'Content-Type': 'application/json'})
+    resp = await nexus_call('GET', 'https://api.freshbooks.com/auth/api/v1/users/me', headers={'Content-Type': 'application/json'})
     if not resp['ok']:
         raise RuntimeError(resp['body'])
     memberships = resp['json'].get('response', {}).get('business_memberships', [])
@@ -12,8 +12,7 @@ async def _get_account_id(access_token: str) -> str:
 async def freshbooks_create_expense(amount: str, currency_code: str, date: str, staff_id: str, category_id: str, notes: str=None, client_id: str=None) -> dict:
     """Create expense via the freshbooks API."""
     try:
-        access_token = _get_nexus_token(None)
-        account_id = await _get_account_id(access_token)
+        account_id = await _get_account_id()
     except Exception as e:
         return {'success': False, 'data': None, 'error': f'Auth error: {str(e)}'}
     try:
@@ -23,7 +22,7 @@ async def freshbooks_create_expense(amount: str, currency_code: str, date: str, 
         if client_id:
             expense['clientid'] = client_id
         expense['categoryid'] = category_id
-        resp = await nexus_call('POST', f'https://api.freshbooks.com/accounting/account/{account_id}/expenses/expenses', json={'expense': expense}, headers={'Authorization': f'Bearer {access_token}', 'Content-Type': 'application/json'})
+        resp = await nexus_call('POST', f'https://api.freshbooks.com/accounting/account/{account_id}/expenses/expenses', json={'expense': expense}, headers={'Content-Type': 'application/json'})
         if resp['status_code'] not in (200, 201):
             return {'success': False, 'data': None, 'error': f"Create expense failed: {resp['status_code']} {resp['body']}"}
         return {'success': True, 'data': resp['json'].get('response', {}).get('result', {}).get('expense'), 'error': None}

--- a/jarviscore/integrations/atoms/freshbooks/freshbooks_create_invoice.py
+++ b/jarviscore/integrations/atoms/freshbooks/freshbooks_create_invoice.py
@@ -1,7 +1,7 @@
-async def _get_account_id(access_token: str) -> str:
+async def _get_account_id() -> str:
     if True .get('account_id'):
         return None
-    resp = await nexus_call('GET', 'https://api.freshbooks.com/auth/api/v1/users/me', headers={'Authorization': f'Bearer {access_token}', 'Content-Type': 'application/json'})
+    resp = await nexus_call('GET', 'https://api.freshbooks.com/auth/api/v1/users/me', headers={'Content-Type': 'application/json'})
     if not resp['ok']:
         raise RuntimeError(resp['body'])
     memberships = resp['json'].get('response', {}).get('business_memberships', [])
@@ -12,15 +12,14 @@ async def _get_account_id(access_token: str) -> str:
 async def freshbooks_create_invoice(client_id: str, lines: list, create_date: str, notes: str=None) -> dict:
     """Create invoice via the freshbooks API."""
     try:
-        access_token = _get_nexus_token(None)
-        account_id = await _get_account_id(access_token)
+        account_id = await _get_account_id()
     except Exception as e:
         return {'success': False, 'data': None, 'error': f'Auth error: {str(e)}'}
     try:
         invoice = {'customerid': client_id, 'lines': lines, 'create_date': create_date}
         if notes:
             invoice['notes'] = notes
-        resp = await nexus_call('POST', f'https://api.freshbooks.com/accounting/account/{account_id}/invoices/invoices', json={'invoice': invoice}, headers={'Authorization': f'Bearer {access_token}', 'Content-Type': 'application/json'})
+        resp = await nexus_call('POST', f'https://api.freshbooks.com/accounting/account/{account_id}/invoices/invoices', json={'invoice': invoice}, headers={'Content-Type': 'application/json'})
         if resp['status_code'] not in (200, 201):
             return {'success': False, 'data': None, 'error': f"Create invoice failed: {resp['status_code']} {resp['body']}"}
         return {'success': True, 'data': resp['json'].get('response', {}).get('result', {}).get('invoice'), 'error': None}

--- a/jarviscore/integrations/atoms/freshbooks/freshbooks_get_client.py
+++ b/jarviscore/integrations/atoms/freshbooks/freshbooks_get_client.py
@@ -1,7 +1,7 @@
-async def _get_account_id(access_token: str) -> str:
+async def _get_account_id() -> str:
     if True .get('account_id'):
         return None
-    resp = await nexus_call('GET', 'https://api.freshbooks.com/auth/api/v1/users/me', headers={'Authorization': f'Bearer {access_token}', 'Content-Type': 'application/json'})
+    resp = await nexus_call('GET', 'https://api.freshbooks.com/auth/api/v1/users/me', headers={'Content-Type': 'application/json'})
     if not resp['ok']:
         raise RuntimeError(resp['body'])
     memberships = resp['json'].get('response', {}).get('business_memberships', [])
@@ -12,12 +12,11 @@ async def _get_account_id(access_token: str) -> str:
 async def freshbooks_get_client(client_id: str) -> dict:
     """Get client via the freshbooks API."""
     try:
-        access_token = _get_nexus_token(None)
-        account_id = await _get_account_id(access_token)
+        account_id = await _get_account_id()
     except Exception as e:
         return {'success': False, 'client_id': client_id, 'data': None, 'error': f'Auth error: {str(e)}'}
     try:
-        resp = await nexus_call('GET', f'https://api.freshbooks.com/accounting/account/{account_id}/users/clients/{client_id}', headers={'Authorization': f'Bearer {access_token}', 'Content-Type': 'application/json'})
+        resp = await nexus_call('GET', f'https://api.freshbooks.com/accounting/account/{account_id}/users/clients/{client_id}', headers={'Content-Type': 'application/json'})
         if resp['status_code'] != 200:
             return {'success': False, 'client_id': client_id, 'data': None, 'error': f"Get client failed: {resp['status_code']} {resp['body']}"}
         return {'success': True, 'client_id': client_id, 'data': resp['json'].get('response', {}).get('result', {}).get('client'), 'error': None}

--- a/jarviscore/integrations/atoms/freshbooks/freshbooks_get_expense.py
+++ b/jarviscore/integrations/atoms/freshbooks/freshbooks_get_expense.py
@@ -1,7 +1,7 @@
-async def _get_account_id(access_token: str) -> str:
+async def _get_account_id() -> str:
     if True .get('account_id'):
         return None
-    resp = await nexus_call('GET', 'https://api.freshbooks.com/auth/api/v1/users/me', headers={'Authorization': f'Bearer {access_token}', 'Content-Type': 'application/json'})
+    resp = await nexus_call('GET', 'https://api.freshbooks.com/auth/api/v1/users/me', headers={'Content-Type': 'application/json'})
     if not resp['ok']:
         raise RuntimeError(resp['body'])
     memberships = resp['json'].get('response', {}).get('business_memberships', [])
@@ -12,12 +12,11 @@ async def _get_account_id(access_token: str) -> str:
 async def freshbooks_get_expense(expense_id: str) -> dict:
     """Get expense via the freshbooks API."""
     try:
-        access_token = _get_nexus_token(None)
-        account_id = await _get_account_id(access_token)
+        account_id = await _get_account_id()
     except Exception as e:
         return {'success': False, 'expense_id': expense_id, 'data': None, 'error': f'Auth error: {str(e)}'}
     try:
-        resp = await nexus_call('GET', f'https://api.freshbooks.com/accounting/account/{account_id}/expenses/expenses/{expense_id}', headers={'Authorization': f'Bearer {access_token}', 'Content-Type': 'application/json'})
+        resp = await nexus_call('GET', f'https://api.freshbooks.com/accounting/account/{account_id}/expenses/expenses/{expense_id}', headers={'Content-Type': 'application/json'})
         if resp['status_code'] != 200:
             return {'success': False, 'expense_id': expense_id, 'data': None, 'error': f"Get expense failed: {resp['status_code']} {resp['body']}"}
         return {'success': True, 'expense_id': expense_id, 'data': resp['json'].get('response', {}).get('result', {}).get('expense'), 'error': None}

--- a/jarviscore/integrations/atoms/freshbooks/freshbooks_get_invoice.py
+++ b/jarviscore/integrations/atoms/freshbooks/freshbooks_get_invoice.py
@@ -1,7 +1,7 @@
-async def _get_account_id(access_token: str) -> str:
+async def _get_account_id() -> str:
     if True .get('account_id'):
         return None
-    resp = await nexus_call('GET', 'https://api.freshbooks.com/auth/api/v1/users/me', headers={'Authorization': f'Bearer {access_token}', 'Content-Type': 'application/json'})
+    resp = await nexus_call('GET', 'https://api.freshbooks.com/auth/api/v1/users/me', headers={'Content-Type': 'application/json'})
     if not resp['ok']:
         raise RuntimeError(resp['body'])
     memberships = resp['json'].get('response', {}).get('business_memberships', [])
@@ -12,12 +12,11 @@ async def _get_account_id(access_token: str) -> str:
 async def freshbooks_get_invoice(invoice_id: str) -> dict:
     """Get invoice via the freshbooks API."""
     try:
-        access_token = _get_nexus_token(None)
-        account_id = await _get_account_id(access_token)
+        account_id = await _get_account_id()
     except Exception as e:
         return {'success': False, 'invoice_id': invoice_id, 'data': None, 'error': f'Auth error: {str(e)}'}
     try:
-        resp = await nexus_call('GET', f'https://api.freshbooks.com/accounting/account/{account_id}/invoices/invoices/{invoice_id}', headers={'Authorization': f'Bearer {access_token}', 'Content-Type': 'application/json'})
+        resp = await nexus_call('GET', f'https://api.freshbooks.com/accounting/account/{account_id}/invoices/invoices/{invoice_id}', headers={'Content-Type': 'application/json'})
         if resp['status_code'] != 200:
             return {'success': False, 'invoice_id': invoice_id, 'data': None, 'error': f"Get invoice failed: {resp['status_code']} {resp['body']}"}
         return {'success': True, 'invoice_id': invoice_id, 'data': resp['json'].get('response', {}).get('result', {}).get('invoice'), 'error': None}

--- a/jarviscore/integrations/atoms/freshbooks/freshbooks_get_payment.py
+++ b/jarviscore/integrations/atoms/freshbooks/freshbooks_get_payment.py
@@ -1,7 +1,7 @@
-async def _get_account_id(access_token: str) -> str:
+async def _get_account_id() -> str:
     if True .get('account_id'):
         return None
-    resp = await nexus_call('GET', 'https://api.freshbooks.com/auth/api/v1/users/me', headers={'Authorization': f'Bearer {access_token}', 'Content-Type': 'application/json'})
+    resp = await nexus_call('GET', 'https://api.freshbooks.com/auth/api/v1/users/me', headers={'Content-Type': 'application/json'})
     if not resp['ok']:
         raise RuntimeError(resp['body'])
     memberships = resp['json'].get('response', {}).get('business_memberships', [])
@@ -12,12 +12,11 @@ async def _get_account_id(access_token: str) -> str:
 async def freshbooks_get_payment(payment_id: str) -> dict:
     """Get payment via the freshbooks API."""
     try:
-        access_token = _get_nexus_token(None)
-        account_id = await _get_account_id(access_token)
+        account_id = await _get_account_id()
     except Exception as e:
         return {'success': False, 'payment_id': payment_id, 'data': None, 'error': f'Auth error: {str(e)}'}
     try:
-        resp = await nexus_call('GET', f'https://api.freshbooks.com/accounting/account/{account_id}/payments/payments/{payment_id}', headers={'Authorization': f'Bearer {access_token}', 'Content-Type': 'application/json'})
+        resp = await nexus_call('GET', f'https://api.freshbooks.com/accounting/account/{account_id}/payments/payments/{payment_id}', headers={'Content-Type': 'application/json'})
         if resp['status_code'] != 200:
             return {'success': False, 'payment_id': payment_id, 'data': None, 'error': f"Get payment failed: {resp['status_code']} {resp['body']}"}
         return {'success': True, 'payment_id': payment_id, 'data': resp['json'].get('response', {}).get('result', {}).get('payment'), 'error': None}

--- a/jarviscore/integrations/atoms/freshbooks/freshbooks_record_payment.py
+++ b/jarviscore/integrations/atoms/freshbooks/freshbooks_record_payment.py
@@ -1,7 +1,7 @@
-async def _get_account_id(access_token: str) -> str:
+async def _get_account_id() -> str:
     if True .get('account_id'):
         return None
-    resp = await nexus_call('GET', 'https://api.freshbooks.com/auth/api/v1/users/me', headers={'Authorization': f'Bearer {access_token}', 'Content-Type': 'application/json'})
+    resp = await nexus_call('GET', 'https://api.freshbooks.com/auth/api/v1/users/me', headers={'Content-Type': 'application/json'})
     if not resp['ok']:
         raise RuntimeError(resp['body'])
     memberships = resp['json'].get('response', {}).get('business_memberships', [])
@@ -12,15 +12,14 @@ async def _get_account_id(access_token: str) -> str:
 async def freshbooks_record_payment(invoice_id: str, amount: str, date: str, payment_type: str='Check', notes: str=None) -> dict:
     """Record payment via the freshbooks API."""
     try:
-        access_token = _get_nexus_token(None)
-        account_id = await _get_account_id(access_token)
+        account_id = await _get_account_id()
     except Exception as e:
         return {'success': False, 'data': None, 'error': f'Auth error: {str(e)}'}
     try:
         payment = {'invoiceid': invoice_id, 'amount': {'amount': amount}, 'date': date, 'type': payment_type}
         if notes:
             payment['notes'] = notes
-        resp = await nexus_call('POST', f'https://api.freshbooks.com/accounting/account/{account_id}/payments/payments', json={'payment': payment}, headers={'Authorization': f'Bearer {access_token}', 'Content-Type': 'application/json'})
+        resp = await nexus_call('POST', f'https://api.freshbooks.com/accounting/account/{account_id}/payments/payments', json={'payment': payment}, headers={'Content-Type': 'application/json'})
         if resp['status_code'] not in (200, 201):
             return {'success': False, 'data': None, 'error': f"Record payment failed: {resp['status_code']} {resp['body']}"}
         return {'success': True, 'data': resp['json'].get('response', {}).get('result', {}).get('payment'), 'error': None}

--- a/jarviscore/integrations/atoms/gmail/gmail_create_draft.py
+++ b/jarviscore/integrations/atoms/gmail/gmail_create_draft.py
@@ -1,3 +1,11 @@
+ATOM_POLICY = {
+    "effect": "write",
+    "approval": "never",
+    "idempotency_fields": ["to", "subject", "body"],
+    "consequence": "Creates one Gmail draft without sending it.",
+}
+
+
 async def gmail_create_draft(to: str, subject: str, body: str) -> dict:
     """Create draft via the gmail API."""
     import base64

--- a/jarviscore/integrations/atoms/google_calendar/google_calendar_create_event.py
+++ b/jarviscore/integrations/atoms/google_calendar/google_calendar_create_event.py
@@ -1,3 +1,11 @@
+ATOM_POLICY = {
+    "effect": "write",
+    "approval": "never",
+    "idempotency_fields": ["summary", "start_datetime", "end_datetime", "calendar_id"],
+    "consequence": "Creates one Google Calendar event in the selected free slot.",
+}
+
+
 async def google_calendar_create_event(summary: str, start_datetime: str, end_datetime: str, description: str='', location: str='', attendees: list=None, calendar_id: str='primary') -> dict:
     """Calendar create event via the google_calendar API."""
     _h = {'Content-Type': 'application/json'}
@@ -8,4 +16,13 @@ async def google_calendar_create_event(summary: str, start_datetime: str, end_da
     if not resp['ok']:
         return {'success': False, 'error': resp['body']}
     data = resp['json']
-    return {'success': True, 'event_id': data.get('id'), 'html_link': data.get('htmlLink'), 'summary': summary}
+    return {
+        'success': True,
+        'event_id': data.get('id'),
+        'html_link': data.get('htmlLink'),
+        'summary': summary,
+        'starts_at': start_datetime,
+        'ends_at': end_datetime,
+        'attendees': list(attendees or []),
+        'calendar_id': calendar_id,
+    }

--- a/jarviscore/integrations/atoms/google_calendar/google_calendar_list_events.py
+++ b/jarviscore/integrations/atoms/google_calendar/google_calendar_list_events.py
@@ -10,5 +10,26 @@ async def google_calendar_list_events(calendar_id: str='primary', time_min: str=
     if not resp['ok']:
         return {'success': False, 'error': resp['body']}
     data = resp['json']
-    events = [{'id': e['id'], 'summary': e.get('summary'), 'start': e.get('start', {}).get('dateTime', e.get('start', {}).get('date')), 'end': e.get('end', {}).get('dateTime', e.get('end', {}).get('date')), 'location': e.get('location'), 'description': e.get('description')} for e in data.get('items', [])]
+    events = [{
+        'id': e['id'],
+        'summary': e.get('summary'),
+        'start': e.get('start', {}).get('dateTime', e.get('start', {}).get('date')),
+        'end': e.get('end', {}).get('dateTime', e.get('end', {}).get('date')),
+        'location': e.get('location'),
+        'description': e.get('description'),
+        'attendees': [
+            {
+                'email': attendee.get('email'),
+                'displayName': attendee.get('displayName'),
+                'responseStatus': attendee.get('responseStatus'),
+                'self': attendee.get('self', False),
+            }
+            for attendee in e.get('attendees', [])
+        ],
+        'organizer': e.get('organizer'),
+        'status': e.get('status'),
+        'htmlLink': e.get('htmlLink'),
+        'created': e.get('created'),
+        'updated': e.get('updated'),
+    } for e in data.get('items', [])]
     return {'success': True, 'events': events, 'count': len(events)}

--- a/jarviscore/integrations/atoms/google_drive/google_drive_append_document_text.py
+++ b/jarviscore/integrations/atoms/google_drive/google_drive_append_document_text.py
@@ -1,0 +1,43 @@
+ATOM_POLICY = {
+    'effect': 'write',
+    'approval': 'never',
+    'idempotency_fields': ['document_id', 'content'],
+    'consequence': 'Appends supplied text to one existing Google Docs document.',
+}
+
+
+async def google_drive_append_document_text(document_id: str, content: str) -> dict:
+    """Append text to an existing Google Docs document."""
+    document = await nexus_call(
+        'GET',
+        f'https://docs.googleapis.com/v1/documents/{document_id}',
+        provider='google_drive',
+    )
+    if not document['ok']:
+        return {'success': False, 'document_id': document_id, 'error': document['body']}
+    body = document['json'].get('body', {}).get('content', [])
+    end_index = max(
+        [int(item.get('endIndex') or 1) for item in body] or [1]
+    )
+    updated = await nexus_call(
+        'POST',
+        f'https://docs.googleapis.com/v1/documents/{document_id}:batchUpdate',
+        provider='google_drive',
+        headers={'Content-Type': 'application/json'},
+        json={
+            'requests': [{
+                'insertText': {
+                    'location': {'index': max(1, end_index - 1)},
+                    'text': content,
+                },
+            }],
+        },
+    )
+    if not updated['ok']:
+        return {'success': False, 'document_id': document_id, 'error': updated['body']}
+    return {
+        'success': True,
+        'document_id': document_id,
+        'inserted_characters': len(content),
+        'error': None,
+    }

--- a/jarviscore/integrations/atoms/google_drive/google_drive_create_document.py
+++ b/jarviscore/integrations/atoms/google_drive/google_drive_create_document.py
@@ -1,0 +1,46 @@
+ATOM_POLICY = {
+    "effect": "write",
+    "approval": "never",
+    "idempotency_fields": ["folder_id", "title"],
+    "consequence": "Creates one Google Doc in an existing Drive folder.",
+}
+
+
+async def google_drive_create_document(folder_id: str, title: str, content: str) -> dict:
+    """Create and populate one Google Doc in an existing Drive folder."""
+    metadata = {
+        "name": title,
+        "mimeType": "application/vnd.google-apps.document",
+        "parents": [folder_id],
+    }
+    created = await nexus_call(
+        "POST",
+        "https://www.googleapis.com/drive/v3/files",
+        headers={"Content-Type": "application/json"},
+        params={"fields": "id,name,webViewLink,parents"},
+        json=metadata,
+    )
+    if not created["ok"]:
+        return {"success": False, "error": created["body"]}
+    document = created["json"]
+    document_id = document.get("id")
+    populated = await nexus_call(
+        "POST",
+        f"https://docs.googleapis.com/v1/documents/{document_id}:batchUpdate",
+        provider="google_drive",
+        headers={"Content-Type": "application/json"},
+        json={"requests": [{"insertText": {"location": {"index": 1}, "text": content}}]},
+    )
+    if not populated["ok"]:
+        return {
+            "success": False,
+            "document_id": document_id,
+            "error": populated["body"],
+        }
+    return {
+        "success": True,
+        "document_id": document_id,
+        "title": document.get("name") or title,
+        "web_view_link": document.get("webViewLink"),
+        "folder_id": folder_id,
+    }

--- a/jarviscore/integrations/atoms/google_drive/google_drive_create_folder.py
+++ b/jarviscore/integrations/atoms/google_drive/google_drive_create_folder.py
@@ -1,17 +1,26 @@
+ATOM_POLICY = {
+    "effect": "write",
+    "approval": "never",
+    "idempotency_fields": ["parent_folder_id", "folder_name"],
+    "consequence": "Creates one Google Drive folder.",
+}
+
+
 async def google_drive_create_folder(folder_name: str, parent_folder_id: str=None) -> dict:
     """Drive create folder. POST https://www.googleapis.com/drive/v3/files"""
-    scopes = ['https://www.googleapis.com/auth/drive']
-    try:
-        access_token = _get_nexus_token(None, scopes)
-    except Exception as e:
-        return {'success': False, 'data': None, 'error': f'Nexus token error: {str(e)}'}
     try:
         metadata = {'name': folder_name, 'mimeType': 'application/vnd.google-apps.folder'}
         if parent_folder_id:
             metadata['parents'] = [parent_folder_id]
-        resp = await nexus_call('POST', 'https://www.googleapis.com/drive/v3/files', json=metadata, headers={'Authorization': f'Bearer {access_token}', 'Content-Type': 'application/json'})
-        if resp['status_code'] not in (200, 201):
-            return {'success': False, 'data': None, 'error': f"Create folder failed: {resp['status_code']} {resp['body']}"}
+        resp = await nexus_call(
+            'POST',
+            'https://www.googleapis.com/drive/v3/files',
+            provider='google_drive',
+            params={'fields': 'id,name,webViewLink,parents'},
+            json=metadata,
+        )
+        if not resp['ok']:
+            return {'success': False, 'data': None, 'error': resp['body']}
         return {'success': True, 'data': resp['json'], 'error': None}
     except Exception as e:
         return {'success': False, 'data': None, 'error': str(e)}

--- a/jarviscore/integrations/atoms/google_drive/google_drive_download_file.py
+++ b/jarviscore/integrations/atoms/google_drive/google_drive_download_file.py
@@ -1,29 +1,21 @@
-def gdrive_download_file(auth_info: dict, file_id: str, destination_path: str) -> dict:
-    import requests
+async def google_drive_download_file(file_id: str, destination_path: str) -> dict:
+    """Download one Drive file to a sandbox path."""
     import os
-    scopes = ["https://www.googleapis.com/auth/drive.readonly"]
     try:
-        access_token = _get_nexus_token(auth_info, scopes)
-    except Exception as e:
-        return {"success": False, "file_id": file_id, "data": None, "error": f"Nexus token error: {str(e)}"}
-
-    try:
-        resp = requests.get(
+        resp = await nexus_call(
+            'GET',
             f"https://www.googleapis.com/drive/v3/files/{file_id}",
             params={"alt": "media"},
-            headers={"Authorization": f"Bearer {access_token}"},
-            timeout=60,
-            stream=True
+            provider='google_drive',
         )
-        if resp.status_code != 200:
-            return {"success": False, "file_id": file_id, "data": None, "error": f"Download failed: {resp.status_code} {resp.text}"}
+        if not resp['ok']:
+            return {"success": False, "file_id": file_id, "data": None, "error": resp['body']}
 
         os.makedirs(os.path.dirname(destination_path), exist_ok=True) if os.path.dirname(destination_path) else None
         with open(destination_path, "wb") as f:
-            for chunk in resp.iter_content(chunk_size=8192):
-                f.write(chunk)
+            f.write(resp['content'])
 
-        return {"success": True, "file_id": file_id, "data": {"destination_path": destination_path}, "error": None}
+        return {"success": True, "file_id": file_id, "data": {"destination_path": destination_path, "bytes": len(resp['content'])}, "error": None}
 
     except Exception as e:
         return {"success": False, "file_id": file_id, "data": None, "error": str(e)}

--- a/jarviscore/integrations/atoms/google_drive/google_drive_export_file.py
+++ b/jarviscore/integrations/atoms/google_drive/google_drive_export_file.py
@@ -1,0 +1,37 @@
+async def google_drive_export_file(file_id: str, mime_type: str='text/plain') -> dict:
+    """Export a Google Workspace file in a requested MIME type."""
+    import base64
+
+    resp = await nexus_call(
+        'GET',
+        f'https://www.googleapis.com/drive/v3/files/{file_id}/export',
+        params={'mimeType': mime_type},
+        provider='google_drive',
+    )
+    if not resp['ok']:
+        return {'success': False, 'file_id': file_id, 'mime_type': mime_type, 'content': None, 'error': resp['body']}
+    content = resp.get('content', b'')
+    textual = mime_type.startswith('text/') or mime_type in {
+        'application/json', 'application/xml', 'application/xhtml+xml'
+    }
+    if isinstance(content, bytes) and textual:
+        content = content.decode('utf-8')
+    if isinstance(content, bytes):
+        return {
+            'success': True,
+            'file_id': file_id,
+            'mime_type': mime_type,
+            'content': None,
+            'content_base64': base64.b64encode(content).decode('ascii'),
+            'encoding': 'base64',
+            'error': None,
+        }
+    return {
+        'success': True,
+        'file_id': file_id,
+        'mime_type': mime_type,
+        'content': content,
+        'content_base64': None,
+        'encoding': 'utf-8' if textual else None,
+        'error': None,
+    }

--- a/jarviscore/integrations/atoms/google_drive/google_drive_get_document.py
+++ b/jarviscore/integrations/atoms/google_drive/google_drive_get_document.py
@@ -1,0 +1,37 @@
+async def google_drive_get_document(document_id: str) -> dict:
+    """Read a Google Docs document with its text and structural metadata."""
+    resp = await nexus_call(
+        'GET',
+        f'https://docs.googleapis.com/v1/documents/{document_id}',
+        provider='google_drive',
+    )
+    if not resp['ok']:
+        return {
+            'success': False,
+            'document_id': document_id,
+            'title': None,
+            'text': None,
+            'paragraph_count': 0,
+            'content_length': 0,
+            'error': resp['body'],
+        }
+    document = resp['json'] or {}
+    paragraphs = []
+    for item in document.get('body', {}).get('content', []):
+        paragraph = item.get('paragraph')
+        if not isinstance(paragraph, dict):
+            continue
+        paragraphs.append(''.join(
+            str((element.get('textRun') or {}).get('content') or '')
+            for element in paragraph.get('elements', [])
+        ))
+    text = ''.join(paragraphs)
+    return {
+        'success': True,
+        'document_id': document_id,
+        'title': document.get('title'),
+        'text': text,
+        'paragraph_count': len(paragraphs),
+        'content_length': len(text.strip()),
+        'error': None,
+    }

--- a/jarviscore/integrations/atoms/google_drive/google_drive_search_files.py
+++ b/jarviscore/integrations/atoms/google_drive/google_drive_search_files.py
@@ -1,0 +1,23 @@
+async def google_drive_search_files(query: str, page_size: int=100, page_token: str=None) -> dict:
+    """Search Drive files using a Google Drive query expression."""
+    params = {
+        'q': query,
+        'pageSize': page_size,
+        'fields': 'nextPageToken,files(id,name,mimeType,parents,webViewLink,modifiedTime)',
+    }
+    if page_token:
+        params['pageToken'] = page_token
+    resp = await nexus_call(
+        'GET',
+        'https://www.googleapis.com/drive/v3/files',
+        provider='google_drive',
+        params=params,
+    )
+    if not resp['ok']:
+        return {'success': False, 'error': resp['body']}
+    data = resp['json']
+    return {
+        'success': True,
+        'files': data.get('files', []),
+        'next_page_token': data.get('nextPageToken'),
+    }

--- a/jarviscore/integrations/atoms/google_drive/google_drive_share_file.py
+++ b/jarviscore/integrations/atoms/google_drive/google_drive_share_file.py
@@ -1,15 +1,23 @@
+ATOM_POLICY = {
+    "effect": "write",
+    "approval": "required",
+    "idempotency_fields": ["file_id", "email", "role"],
+    "consequence": "Grants one recipient access to a Google Drive file.",
+}
+
+
 async def google_drive_share_file(file_id: str, email: str, role: str='reader') -> dict:
     """Drive share file via the google_drive API."""
-    scopes = ['https://www.googleapis.com/auth/drive']
-    try:
-        access_token = _get_nexus_token(None, scopes)
-    except Exception as e:
-        return {'success': False, 'file_id': file_id, 'data': None, 'error': f'Nexus token error: {str(e)}'}
     try:
         permission = {'type': 'user', 'role': role, 'emailAddress': email}
-        resp = await nexus_call('POST', f'https://www.googleapis.com/drive/v3/files/{file_id}/permissions', json=permission, headers={'Authorization': f'Bearer {access_token}', 'Content-Type': 'application/json'})
-        if resp['status_code'] not in (200, 201):
-            return {'success': False, 'file_id': file_id, 'data': None, 'error': f"Share failed: {resp['status_code']} {resp['body']}"}
+        resp = await nexus_call(
+            'POST',
+            f'https://www.googleapis.com/drive/v3/files/{file_id}/permissions',
+            provider='google_drive',
+            json=permission,
+        )
+        if not resp['ok']:
+            return {'success': False, 'file_id': file_id, 'data': None, 'error': resp['body']}
         return {'success': True, 'file_id': file_id, 'data': resp['json'], 'error': None}
     except Exception as e:
         return {'success': False, 'file_id': file_id, 'data': None, 'error': str(e)}

--- a/jarviscore/integrations/atoms/google_drive/google_drive_upload_file.py
+++ b/jarviscore/integrations/atoms/google_drive/google_drive_upload_file.py
@@ -1,11 +1,15 @@
+ATOM_POLICY = {
+    "effect": "write",
+    "approval": "never",
+    "idempotency_fields": ["folder_id", "file_name", "file_path"],
+    "consequence": "Uploads one file to Google Drive.",
+}
+
+
 async def google_drive_upload_file(file_path: str, folder_id: str=None, file_name: str=None) -> dict:
     """Drive upload file. POST https://www.googleapis.com/upload/drive/v3/files?uploadType=multipart"""
+    import json
     import os
-    scopes = ['https://www.googleapis.com/auth/drive.file']
-    try:
-        access_token = _get_nexus_token(None, scopes)
-    except Exception as e:
-        return {'success': False, 'data': None, 'error': f'Nexus token error: {str(e)}'}
     try:
         name = file_name or os.path.basename(file_path)
         metadata = {'name': name}
@@ -16,10 +20,19 @@ async def google_drive_upload_file(file_path: str, folder_id: str=None, file_nam
         import mimetypes
         mime_type = mimetypes.guess_type(file_path)[0] or 'application/octet-stream'
         boundary = 'boundary_gdrive_upload'
-        body = (f'--{boundary}\r\nContent-Type: application/json; charset=UTF-8\r\n\r\n{{"name": "{name}"' + (f', "parents": ["{folder_id}"]' if folder_id else '') + f'}}\r\n--{boundary}\r\nContent-Type: {mime_type}\r\n\r\n').encode() + file_content + f'\r\n--{boundary}--'.encode()
-        resp = await nexus_call('POST', 'https://www.googleapis.com/upload/drive/v3/files?uploadType=multipart', headers={'Authorization': f'Bearer {access_token}', 'Content-Type': f'multipart/related; boundary={boundary}'}, data=body)
-        if resp['status_code'] not in (200, 201):
-            return {'success': False, 'data': None, 'error': f"Upload failed: {resp['status_code']} {resp['body']}"}
+        body = (
+            f'--{boundary}\r\nContent-Type: application/json; charset=UTF-8\r\n\r\n'
+            f'{json.dumps(metadata)}\r\n--{boundary}\r\nContent-Type: {mime_type}\r\n\r\n'
+        ).encode() + file_content + f'\r\n--{boundary}--'.encode()
+        resp = await nexus_call(
+            'POST',
+            'https://www.googleapis.com/upload/drive/v3/files?uploadType=multipart',
+            provider='google_drive',
+            headers={'Content-Type': f'multipart/related; boundary={boundary}'},
+            data=body,
+        )
+        if not resp['ok']:
+            return {'success': False, 'data': None, 'error': resp['body']}
         return {'success': True, 'data': resp['json'], 'error': None}
     except Exception as e:
         return {'success': False, 'data': None, 'error': str(e)}

--- a/jarviscore/integrations/atoms/hubspot/hubspot_associate_deal_contact.py
+++ b/jarviscore/integrations/atoms/hubspot/hubspot_associate_deal_contact.py
@@ -1,0 +1,49 @@
+ATOM_POLICY = {
+    'effect': 'write',
+    'approval': 'never',
+    'idempotency_fields': ['deal_id', 'contact_id'],
+    'consequence': 'Associates one existing HubSpot deal with one existing contact.',
+}
+
+
+async def hubspot_associate_deal_contact(deal_id: str, contact_id: str) -> dict:
+    """Associate a HubSpot deal with a contact and verify the association."""
+    associated = await nexus_call(
+        'PUT',
+        f'https://api.hubapi.com/crm/v4/objects/deals/{deal_id}/associations/default/contacts/{contact_id}',
+        provider='hubspot',
+    )
+    if not associated['ok']:
+        return {
+            'success': False,
+            'deal_id': deal_id,
+            'contact_id': contact_id,
+            'association_verified': False,
+            'error': associated['body'],
+        }
+    verified = await nexus_call(
+        'GET',
+        f'https://api.hubapi.com/crm/v4/objects/contacts/{contact_id}/associations/deals',
+        provider='hubspot',
+        params={'limit': 100},
+    )
+    if not verified['ok']:
+        return {
+            'success': False,
+            'deal_id': deal_id,
+            'contact_id': contact_id,
+            'association_verified': False,
+            'error': verified['body'],
+        }
+    matches = [
+        str(item.get('toObjectId'))
+        for item in verified['json'].get('results', [])
+    ]
+    association_verified = str(deal_id) in matches
+    return {
+        'success': association_verified,
+        'deal_id': deal_id,
+        'contact_id': contact_id,
+        'association_verified': association_verified,
+        'error': None if association_verified else 'Association was not present on readback.',
+    }

--- a/jarviscore/integrations/atoms/hubspot/hubspot_create_deal.py
+++ b/jarviscore/integrations/atoms/hubspot/hubspot_create_deal.py
@@ -1,4 +1,12 @@
-async def hubspot_create_deal(deal_name: str, stage: str, amount: float=None, pipeline: str='default', close_date: str=None) -> dict:
+ATOM_POLICY = {
+    "effect": "write",
+    "approval": "never",
+    "idempotency_fields": ["deal_name", "stage", "pipeline", "contact_id"],
+    "consequence": "Creates one HubSpot deal when no matching deal exists.",
+}
+
+
+async def hubspot_create_deal(deal_name: str, stage: str, amount: float=None, pipeline: str='default', close_date: str=None, contact_id: str=None) -> dict:
     """Create deal. POST https://api.hubapi.com/crm/v3/objects/deals"""
     _h = {'Content-Type': 'application/json'}
     props = {'dealname': deal_name, 'dealstage': stage, 'pipeline': pipeline}
@@ -10,4 +18,41 @@ async def hubspot_create_deal(deal_name: str, stage: str, amount: float=None, pi
     if not resp['ok']:
         return {'success': False, 'error': resp['body']}
     data = resp['json']
-    return {'success': True, 'id': data.get('id'), 'deal_name': deal_name, 'stage': stage}
+    deal_id = data.get('id')
+    association_verified = None
+    association_error = None
+    if contact_id and deal_id:
+        associated = await nexus_call(
+            'PUT',
+            f'https://api.hubapi.com/crm/v4/objects/deals/{deal_id}/associations/default/contacts/{contact_id}',
+            provider='hubspot',
+        )
+        if associated['ok']:
+            verified = await nexus_call(
+                'GET',
+                f'https://api.hubapi.com/crm/v4/objects/contacts/{contact_id}/associations/deals',
+                provider='hubspot',
+                params={'limit': 100},
+            )
+            if verified['ok']:
+                association_verified = str(deal_id) in {
+                    str(item.get('toObjectId'))
+                    for item in verified['json'].get('results', [])
+                }
+                if not association_verified:
+                    association_error = 'Association was not present on readback.'
+            else:
+                association_verified = False
+                association_error = verified['body']
+        else:
+            association_verified = False
+            association_error = associated['body']
+    return {
+        'success': True,
+        'id': deal_id,
+        'deal_name': deal_name,
+        'stage': stage,
+        'contact_id': contact_id,
+        'association_verified': association_verified,
+        'association_error': association_error,
+    }

--- a/jarviscore/integrations/atoms/hubspot/hubspot_list_contact_deals.py
+++ b/jarviscore/integrations/atoms/hubspot/hubspot_list_contact_deals.py
@@ -1,0 +1,21 @@
+async def hubspot_list_contact_deals(contact_id: str, limit: int=100, after: str=None) -> dict:
+    """List HubSpot deals associated with one contact."""
+    params = {'limit': limit}
+    if after:
+        params['after'] = after
+    resp = await nexus_call(
+        'GET',
+        f'https://api.hubapi.com/crm/v4/objects/contacts/{contact_id}/associations/deals',
+        params=params,
+        provider='hubspot',
+    )
+    if not resp['ok']:
+        return {'success': False, 'contact_id': contact_id, 'deals': [], 'error': resp['body']}
+    data = resp['json']
+    return {
+        'success': True,
+        'contact_id': contact_id,
+        'deals': data.get('results', []),
+        'paging': data.get('paging'),
+        'error': None,
+    }

--- a/jarviscore/integrations/atoms/hubspot/hubspot_search_contacts.py
+++ b/jarviscore/integrations/atoms/hubspot/hubspot_search_contacts.py
@@ -1,0 +1,23 @@
+async def hubspot_search_contacts(query: str, limit: int=50, after: int=0) -> dict:
+    """Search HubSpot contacts by the provider's searchable contact properties."""
+    body = {
+        'query': query,
+        'limit': limit,
+        'after': after,
+        'properties': ['email', 'firstname', 'lastname', 'company'],
+    }
+    resp = await nexus_call(
+        'POST',
+        'https://api.hubapi.com/crm/v3/objects/contacts/search',
+        provider='hubspot',
+        json=body,
+    )
+    if not resp['ok']:
+        return {'success': False, 'error': resp['body']}
+    data = resp['json']
+    return {
+        'success': True,
+        'contacts': data.get('results', []),
+        'paging': data.get('paging'),
+        'total': data.get('total'),
+    }

--- a/jarviscore/integrations/atoms/hubspot/hubspot_search_deals.py
+++ b/jarviscore/integrations/atoms/hubspot/hubspot_search_deals.py
@@ -1,0 +1,24 @@
+async def hubspot_search_deals(query: str, limit: int=50, after: int=0) -> dict:
+    """Search HubSpot deals by provider-searchable deal properties."""
+    body = {
+        'query': query,
+        'limit': limit,
+        'after': after,
+        'properties': ['dealname', 'dealstage', 'pipeline', 'amount', 'closedate'],
+    }
+    resp = await nexus_call(
+        'POST',
+        'https://api.hubapi.com/crm/v3/objects/deals/search',
+        provider='hubspot',
+        json=body,
+    )
+    if not resp['ok']:
+        return {'success': False, 'deals': [], 'error': resp['body']}
+    data = resp['json']
+    return {
+        'success': True,
+        'deals': data.get('results', []),
+        'paging': data.get('paging'),
+        'total': data.get('total'),
+        'error': None,
+    }

--- a/jarviscore/integrations/atoms/linear/linear_get_issue.py
+++ b/jarviscore/integrations/atoms/linear/linear_get_issue.py
@@ -1,12 +1,8 @@
 async def linear_get_issue(issue_id: str) -> dict:
     """Get issue. POST https://api.linear.app/graphql"""
-    try:
-        access_token = _get_nexus_token(None)
-    except Exception as e:
-        return {'success': False, 'data': None, 'error': f'Auth error: {str(e)}'}
     query = '\n    query($id: String!) {\n        issue(id: $id) {\n            id\n            identifier\n            title\n            description\n            priority\n            state {\n                name\n            }\n            assignee {\n                name\n                email\n            }\n            team {\n                name\n                key\n            }\n            labels {\n                nodes {\n                    name\n                }\n            }\n            createdAt\n            updatedAt\n        }\n    }\n    '
     try:
-        resp = await nexus_call('POST', 'https://api.linear.app/graphql', json={'query': query, 'variables': {'id': issue_id}}, headers={'Authorization': f'Bearer {access_token}', 'Content-Type': 'application/json'})
+        resp = await nexus_call('POST', 'https://api.linear.app/graphql', json={'query': query, 'variables': {'id': issue_id}}, headers={'Content-Type': 'application/json'})
         if resp['status_code'] != 200:
             return {'success': False, 'data': None, 'error': f"Get issue failed: {resp['status_code']} {resp['body']}"}
         data = resp['json']

--- a/jarviscore/integrations/atoms/linear/linear_get_issues.py
+++ b/jarviscore/integrations/atoms/linear/linear_get_issues.py
@@ -1,13 +1,9 @@
 async def linear_get_issues(team_id: str=None, max_results: int=50) -> dict:
     """Get issues. POST https://api.linear.app/graphql"""
-    try:
-        access_token = _get_nexus_token(None)
-    except Exception as e:
-        return {'success': False, 'data': None, 'error': f'Auth error: {str(e)}'}
     filter_clause = f'filter: {{ team: {{ id: {{ eq: "{team_id}" }} }} }},' if team_id else ''
     query = f'\n    query {{\n        issues({filter_clause} first: {max_results}) {{\n            nodes {{\n                id\n                identifier\n                title\n                description\n                priority\n                state {{\n                    name\n                }}\n                assignee {{\n                    name\n                }}\n                createdAt\n                updatedAt\n            }}\n        }}\n    }}\n    '
     try:
-        resp = await nexus_call('POST', 'https://api.linear.app/graphql', json={'query': query}, headers={'Authorization': f'Bearer {access_token}', 'Content-Type': 'application/json'})
+        resp = await nexus_call('POST', 'https://api.linear.app/graphql', json={'query': query}, headers={'Content-Type': 'application/json'})
         if resp['status_code'] != 200:
             return {'success': False, 'data': None, 'error': f"Get issues failed: {resp['status_code']} {resp['body']}"}
         data = resp['json']

--- a/jarviscore/integrations/atoms/linear/linear_get_me.py
+++ b/jarviscore/integrations/atoms/linear/linear_get_me.py
@@ -1,12 +1,8 @@
 async def linear_get_me() -> dict:
     """Get me. POST https://api.linear.app/graphql"""
-    try:
-        access_token = _get_nexus_token(None)
-    except Exception as e:
-        return {'success': False, 'data': None, 'error': f'Auth error: {str(e)}'}
     query = '\n    query {\n        viewer {\n            id\n            name\n            email\n            displayName\n            avatarUrl\n            createdAt\n        }\n    }\n    '
     try:
-        resp = await nexus_call('POST', 'https://api.linear.app/graphql', json={'query': query}, headers={'Authorization': f'Bearer {access_token}', 'Content-Type': 'application/json'})
+        resp = await nexus_call('POST', 'https://api.linear.app/graphql', json={'query': query}, headers={'Content-Type': 'application/json'})
         if resp['status_code'] != 200:
             return {'success': False, 'data': None, 'error': f"Get me failed: {resp['status_code']} {resp['body']}"}
         data = resp['json']

--- a/jarviscore/integrations/atoms/linear/linear_get_teams.py
+++ b/jarviscore/integrations/atoms/linear/linear_get_teams.py
@@ -1,12 +1,8 @@
 async def linear_get_teams() -> dict:
     """Get teams. POST https://api.linear.app/graphql"""
-    try:
-        access_token = _get_nexus_token(None)
-    except Exception as e:
-        return {'success': False, 'data': None, 'error': f'Auth error: {str(e)}'}
     query = '\n    query {\n        teams {\n            nodes {\n                id\n                name\n                key\n                description\n                issueCount\n                createdAt\n            }\n        }\n    }\n    '
     try:
-        resp = await nexus_call('POST', 'https://api.linear.app/graphql', json={'query': query}, headers={'Authorization': f'Bearer {access_token}', 'Content-Type': 'application/json'})
+        resp = await nexus_call('POST', 'https://api.linear.app/graphql', json={'query': query}, headers={'Content-Type': 'application/json'})
         if resp['status_code'] != 200:
             return {'success': False, 'data': None, 'error': f"Get teams failed: {resp['status_code']} {resp['body']}"}
         data = resp['json']

--- a/jarviscore/integrations/atoms/linear/linear_search_issues.py
+++ b/jarviscore/integrations/atoms/linear/linear_search_issues.py
@@ -1,12 +1,8 @@
 async def linear_search_issues(query: str, max_results: int=20) -> dict:
     """Search issues. POST https://api.linear.app/graphql"""
-    try:
-        access_token = _get_nexus_token(None)
-    except Exception as e:
-        return {'success': False, 'data': None, 'error': f'Auth error: {str(e)}'}
     gql = '\n    query($term: String!, $first: Int!) {\n        issues(filter: { title: { containsIgnoreCase: $term } }, first: $first) {\n            nodes {\n                id\n                identifier\n                title\n                priority\n                state {\n                    name\n                }\n                assignee {\n                    name\n                }\n                team {\n                    name\n                    key\n                }\n                createdAt\n            }\n        }\n    }\n    '
     try:
-        resp = await nexus_call('POST', 'https://api.linear.app/graphql', json={'query': gql, 'variables': {'term': query, 'first': max_results}}, headers={'Authorization': f'Bearer {access_token}', 'Content-Type': 'application/json'})
+        resp = await nexus_call('POST', 'https://api.linear.app/graphql', json={'query': gql, 'variables': {'term': query, 'first': max_results}}, headers={'Content-Type': 'application/json'})
         if resp['status_code'] != 200:
             return {'success': False, 'data': None, 'error': f"Search issues failed: {resp['status_code']} {resp['body']}"}
         data = resp['json']

--- a/jarviscore/integrations/atoms/msgraph/msgraph_create_event.py
+++ b/jarviscore/integrations/atoms/msgraph/msgraph_create_event.py
@@ -1,10 +1,6 @@
 async def msgraph_create_event(subject: str, start_datetime: str, end_datetime: str, timezone: str='UTC', attendees: list=None, body: str=None, location: str=None) -> dict:
     """Create event. POST https://graph.microsoft.com/v1.0/me/events"""
     try:
-        access_token = _get_nexus_token(None)
-    except Exception as e:
-        return {'success': False, 'data': None, 'error': f'Auth error: {str(e)}'}
-    try:
         payload = {'subject': subject, 'start': {'dateTime': start_datetime, 'timeZone': timezone}, 'end': {'dateTime': end_datetime, 'timeZone': timezone}}
         if attendees:
             payload['attendees'] = [{'emailAddress': {'address': a}, 'type': 'required'} for a in attendees]
@@ -12,7 +8,7 @@ async def msgraph_create_event(subject: str, start_datetime: str, end_datetime: 
             payload['body'] = {'contentType': 'Text', 'content': body}
         if location:
             payload['location'] = {'displayName': location}
-        resp = await nexus_call('POST', 'https://graph.microsoft.com/v1.0/me/events', headers={'Authorization': f'Bearer {access_token}', 'Content-Type': 'application/json'}, json=payload)
+        resp = await nexus_call('POST', 'https://graph.microsoft.com/v1.0/me/events', headers={'Content-Type': 'application/json'}, json=payload)
         if resp['status_code'] != 201:
             return {'success': False, 'data': None, 'error': f"Create event failed: {resp['status_code']} {resp['body']}"}
         return {'success': True, 'data': resp['json'], 'error': None}

--- a/jarviscore/integrations/atoms/msgraph/msgraph_create_meeting.py
+++ b/jarviscore/integrations/atoms/msgraph/msgraph_create_meeting.py
@@ -1,14 +1,10 @@
 async def msgraph_create_meeting(subject: str, start_datetime: str, end_datetime: str, timezone: str='UTC', participants: list=None) -> dict:
     """Create meeting. POST https://graph.microsoft.com/v1.0/me/onlineMeetings"""
     try:
-        access_token = _get_nexus_token(None)
-    except Exception as e:
-        return {'success': False, 'data': None, 'error': f'Auth error: {str(e)}'}
-    try:
         payload = {'subject': subject, 'startDateTime': f'{start_datetime}', 'endDateTime': f'{end_datetime}'}
         if participants:
             payload['participants'] = {'attendees': [{'upn': p} for p in participants]}
-        resp = await nexus_call('POST', 'https://graph.microsoft.com/v1.0/me/onlineMeetings', headers={'Authorization': f'Bearer {access_token}', 'Content-Type': 'application/json'}, json=payload)
+        resp = await nexus_call('POST', 'https://graph.microsoft.com/v1.0/me/onlineMeetings', headers={'Content-Type': 'application/json'}, json=payload)
         if resp['status_code'] != 201:
             return {'success': False, 'data': None, 'error': f"Create meeting failed: {resp['status_code']} {resp['body']}"}
         data = resp['json']

--- a/jarviscore/integrations/atoms/msgraph/msgraph_delete_event.py
+++ b/jarviscore/integrations/atoms/msgraph/msgraph_delete_event.py
@@ -3,11 +3,7 @@ ATOM_POLICY = {"effect": "destructive", "approval": "required", "idempotency_fie
 async def msgraph_delete_event(event_id: str) -> dict:
     """Delete event via the msgraph API."""
     try:
-        access_token = _get_nexus_token(None)
-    except Exception as e:
-        return {'success': False, 'data': None, 'error': f'Auth error: {str(e)}'}
-    try:
-        resp = await nexus_call('DELETE', f'https://graph.microsoft.com/v1.0/me/events/{event_id}', headers={'Authorization': f'Bearer {access_token}'})
+        resp = await nexus_call('DELETE', f'https://graph.microsoft.com/v1.0/me/events/{event_id}')
         if resp['status_code'] != 204:
             return {'success': False, 'data': None, 'error': f"Delete event failed: {resp['status_code']} {resp['body']}"}
         return {'success': True, 'data': {'event_id': event_id, 'deleted': True}, 'error': None}

--- a/jarviscore/integrations/atoms/msgraph/msgraph_get_channels.py
+++ b/jarviscore/integrations/atoms/msgraph/msgraph_get_channels.py
@@ -1,11 +1,7 @@
 async def msgraph_get_channels(team_id: str) -> dict:
     """Get channels via the msgraph API."""
     try:
-        access_token = _get_nexus_token(None)
-    except Exception as e:
-        return {'success': False, 'data': None, 'error': f'Auth error: {str(e)}'}
-    try:
-        resp = await nexus_call('GET', f'https://graph.microsoft.com/v1.0/teams/{team_id}/channels', headers={'Authorization': f'Bearer {access_token}'})
+        resp = await nexus_call('GET', f'https://graph.microsoft.com/v1.0/teams/{team_id}/channels')
         if resp['status_code'] != 200:
             return {'success': False, 'data': None, 'error': f"Get channels failed: {resp['status_code']} {resp['body']}"}
         channels = resp['json'].get('value', [])

--- a/jarviscore/integrations/atoms/msgraph/msgraph_get_chats.py
+++ b/jarviscore/integrations/atoms/msgraph/msgraph_get_chats.py
@@ -1,11 +1,7 @@
 async def msgraph_get_chats(max_results: int=20) -> dict:
     """Get chats. GET https://graph.microsoft.com/v1.0/me/chats"""
     try:
-        access_token = _get_nexus_token(None)
-    except Exception as e:
-        return {'success': False, 'data': None, 'error': f'Auth error: {str(e)}'}
-    try:
-        resp = await nexus_call('GET', 'https://graph.microsoft.com/v1.0/me/chats', headers={'Authorization': f'Bearer {access_token}'}, params={'$top': max_results, '$expand': 'members'})
+        resp = await nexus_call('GET', 'https://graph.microsoft.com/v1.0/me/chats', params={'$top': max_results, '$expand': 'members'})
         if resp['status_code'] != 200:
             return {'success': False, 'data': None, 'error': f"Get chats failed: {resp['status_code']} {resp['body']}"}
         chats = resp['json'].get('value', [])

--- a/jarviscore/integrations/atoms/msgraph/msgraph_get_email.py
+++ b/jarviscore/integrations/atoms/msgraph/msgraph_get_email.py
@@ -1,11 +1,7 @@
 async def msgraph_get_email(message_id: str) -> dict:
     """Get email via the msgraph API."""
     try:
-        access_token = _get_nexus_token(None)
-    except Exception as e:
-        return {'success': False, 'data': None, 'error': f'Auth error: {str(e)}'}
-    try:
-        resp = await nexus_call('GET', f'https://graph.microsoft.com/v1.0/me/messages/{message_id}', headers={'Authorization': f'Bearer {access_token}'})
+        resp = await nexus_call('GET', f'https://graph.microsoft.com/v1.0/me/messages/{message_id}')
         if resp['status_code'] != 200:
             return {'success': False, 'data': None, 'error': f"Get email failed: {resp['status_code']} {resp['body']}"}
         return {'success': True, 'data': resp['json'], 'error': None}

--- a/jarviscore/integrations/atoms/msgraph/msgraph_get_emails.py
+++ b/jarviscore/integrations/atoms/msgraph/msgraph_get_emails.py
@@ -1,11 +1,7 @@
 async def msgraph_get_emails(max_results: int=20, folder: str='inbox') -> dict:
     """Get emails via the msgraph API."""
     try:
-        access_token = _get_nexus_token(None)
-    except Exception as e:
-        return {'success': False, 'data': None, 'error': f'Auth error: {str(e)}'}
-    try:
-        resp = await nexus_call('GET', f'https://graph.microsoft.com/v1.0/me/mailFolders/{folder}/messages', headers={'Authorization': f'Bearer {access_token}'}, params={'$top': max_results, '$orderby': 'receivedDateTime desc', '$select': 'id,subject,from,receivedDateTime,isRead,bodyPreview'})
+        resp = await nexus_call('GET', f'https://graph.microsoft.com/v1.0/me/mailFolders/{folder}/messages', headers={'$select': 'id,subject,from,receivedDateTime,isRead,bodyPreview'})
         if resp['status_code'] != 200:
             return {'success': False, 'data': None, 'error': f"Get emails failed: {resp['status_code']} {resp['body']}"}
         emails = resp['json'].get('value', [])

--- a/jarviscore/integrations/atoms/msgraph/msgraph_get_events.py
+++ b/jarviscore/integrations/atoms/msgraph/msgraph_get_events.py
@@ -1,14 +1,10 @@
 async def msgraph_get_events(max_results: int=20, start_datetime: str=None, end_datetime: str=None) -> dict:
     """Get events. GET https://graph.microsoft.com/v1.0/me/events"""
     try:
-        access_token = _get_nexus_token(None)
-    except Exception as e:
-        return {'success': False, 'data': None, 'error': f'Auth error: {str(e)}'}
-    try:
         params = {'$top': max_results, '$orderby': 'start/dateTime', '$select': 'id,subject,start,end,location,organizer,isOnlineMeeting'}
         if start_datetime and end_datetime:
             params['$filter'] = f"start/dateTime ge '{start_datetime}' and end/dateTime le '{end_datetime}'"
-        resp = await nexus_call('GET', 'https://graph.microsoft.com/v1.0/me/events', headers={'Authorization': f'Bearer {access_token}', 'Prefer': 'outlook.timezone="UTC"'}, params=params)
+        resp = await nexus_call('GET', 'https://graph.microsoft.com/v1.0/me/events', headers={'Prefer': 'outlook.timezone="UTC"'}, params=params)
         if resp['status_code'] != 200:
             return {'success': False, 'data': None, 'error': f"Get events failed: {resp['status_code']} {resp['body']}"}
         events = resp['json'].get('value', [])

--- a/jarviscore/integrations/atoms/msgraph/msgraph_get_me.py
+++ b/jarviscore/integrations/atoms/msgraph/msgraph_get_me.py
@@ -1,11 +1,7 @@
 async def msgraph_get_me() -> dict:
     """Get me. GET https://graph.microsoft.com/v1.0/me"""
     try:
-        access_token = _get_nexus_token(None)
-    except Exception as e:
-        return {'success': False, 'data': None, 'error': f'Auth error: {str(e)}'}
-    try:
-        resp = await nexus_call('GET', 'https://graph.microsoft.com/v1.0/me', headers={'Authorization': f'Bearer {access_token}'})
+        resp = await nexus_call('GET', 'https://graph.microsoft.com/v1.0/me')
         if resp['status_code'] != 200:
             return {'success': False, 'data': None, 'error': f"Get me failed: {resp['status_code']} {resp['body']}"}
         return {'success': True, 'data': resp['json'], 'error': None}

--- a/jarviscore/integrations/atoms/msgraph/msgraph_get_meeting.py
+++ b/jarviscore/integrations/atoms/msgraph/msgraph_get_meeting.py
@@ -1,11 +1,7 @@
 async def msgraph_get_meeting(meeting_id: str) -> dict:
     """Get meeting via the msgraph API."""
     try:
-        access_token = _get_nexus_token(None)
-    except Exception as e:
-        return {'success': False, 'data': None, 'error': f'Auth error: {str(e)}'}
-    try:
-        resp = await nexus_call('GET', f'https://graph.microsoft.com/v1.0/me/onlineMeetings/{meeting_id}', headers={'Authorization': f'Bearer {access_token}'})
+        resp = await nexus_call('GET', f'https://graph.microsoft.com/v1.0/me/onlineMeetings/{meeting_id}')
         if resp['status_code'] != 200:
             return {'success': False, 'data': None, 'error': f"Get meeting failed: {resp['status_code']} {resp['body']}"}
         return {'success': True, 'data': resp['json'], 'error': None}

--- a/jarviscore/integrations/atoms/msgraph/msgraph_get_teams.py
+++ b/jarviscore/integrations/atoms/msgraph/msgraph_get_teams.py
@@ -1,11 +1,7 @@
 async def msgraph_get_teams() -> dict:
     """Get teams. GET https://graph.microsoft.com/v1.0/me/joinedTeams"""
     try:
-        access_token = _get_nexus_token(None)
-    except Exception as e:
-        return {'success': False, 'data': None, 'error': f'Auth error: {str(e)}'}
-    try:
-        resp = await nexus_call('GET', 'https://graph.microsoft.com/v1.0/me/joinedTeams', headers={'Authorization': f'Bearer {access_token}'})
+        resp = await nexus_call('GET', 'https://graph.microsoft.com/v1.0/me/joinedTeams')
         if resp['status_code'] != 200:
             return {'success': False, 'data': None, 'error': f"Get teams failed: {resp['status_code']} {resp['body']}"}
         teams = resp['json'].get('value', [])

--- a/jarviscore/integrations/atoms/msgraph/msgraph_send_chat_message.py
+++ b/jarviscore/integrations/atoms/msgraph/msgraph_send_chat_message.py
@@ -1,11 +1,7 @@
 async def msgraph_send_chat_message(chat_id: str, message: str) -> dict:
     """Send chat message via the msgraph API."""
     try:
-        access_token = _get_nexus_token(None)
-    except Exception as e:
-        return {'success': False, 'data': None, 'error': f'Auth error: {str(e)}'}
-    try:
-        resp = await nexus_call('POST', f'https://graph.microsoft.com/v1.0/me/chats/{chat_id}/messages', headers={'Authorization': f'Bearer {access_token}', 'Content-Type': 'application/json'}, json={'body': {'content': message}})
+        resp = await nexus_call('POST', f'https://graph.microsoft.com/v1.0/me/chats/{chat_id}/messages', headers={'Content-Type': 'application/json'}, json={'body': {'content': message}})
         if resp['status_code'] != 201:
             return {'success': False, 'data': None, 'error': f"Send chat message failed: {resp['status_code']} {resp['body']}"}
         return {'success': True, 'data': resp['json'], 'error': None}

--- a/jarviscore/integrations/atoms/msgraph/msgraph_send_email.py
+++ b/jarviscore/integrations/atoms/msgraph/msgraph_send_email.py
@@ -1,15 +1,11 @@
 async def msgraph_send_email(to: list, subject: str, body: str, body_type: str='Text', cc: list=None) -> dict:
     """Send email. POST https://graph.microsoft.com/v1.0/me/sendMail"""
     try:
-        access_token = _get_nexus_token(None)
-    except Exception as e:
-        return {'success': False, 'data': None, 'error': f'Auth error: {str(e)}'}
-    try:
         to_recipients = [{'emailAddress': {'address': addr}} for addr in to]
         payload = {'message': {'subject': subject, 'body': {'contentType': body_type, 'content': body}, 'toRecipients': to_recipients}}
         if cc:
             payload['message']['ccRecipients'] = [{'emailAddress': {'address': addr}} for addr in cc]
-        resp = await nexus_call('POST', 'https://graph.microsoft.com/v1.0/me/sendMail', headers={'Authorization': f'Bearer {access_token}', 'Content-Type': 'application/json'}, json=payload)
+        resp = await nexus_call('POST', 'https://graph.microsoft.com/v1.0/me/sendMail', headers={'Content-Type': 'application/json'}, json=payload)
         if resp['status_code'] != 202:
             return {'success': False, 'data': None, 'error': f"Send email failed: {resp['status_code']} {resp['body']}"}
         return {'success': True, 'data': {'sent': True, 'to': to, 'subject': subject}, 'error': None}

--- a/jarviscore/integrations/atoms/msgraph/msgraph_update_event.py
+++ b/jarviscore/integrations/atoms/msgraph/msgraph_update_event.py
@@ -1,10 +1,6 @@
 async def msgraph_update_event(event_id: str, subject: str=None, start_datetime: str=None, end_datetime: str=None, timezone: str='UTC', body: str=None, location: str=None) -> dict:
     """Update event via the msgraph API."""
     try:
-        access_token = _get_nexus_token(None)
-    except Exception as e:
-        return {'success': False, 'data': None, 'error': f'Auth error: {str(e)}'}
-    try:
         payload = {}
         if subject:
             payload['subject'] = subject
@@ -16,7 +12,7 @@ async def msgraph_update_event(event_id: str, subject: str=None, start_datetime:
             payload['body'] = {'contentType': 'Text', 'content': body}
         if location:
             payload['location'] = {'displayName': location}
-        resp = await nexus_call('PATCH', f'https://graph.microsoft.com/v1.0/me/events/{event_id}', headers={'Authorization': f'Bearer {access_token}', 'Content-Type': 'application/json'}, json=payload)
+        resp = await nexus_call('PATCH', f'https://graph.microsoft.com/v1.0/me/events/{event_id}', headers={'Content-Type': 'application/json'}, json=payload)
         if resp['status_code'] != 200:
             return {'success': False, 'data': None, 'error': f"Update event failed: {resp['status_code']} {resp['body']}"}
         return {'success': True, 'data': resp['json'], 'error': None}

--- a/jarviscore/integrations/atoms/notion/notion_append_blocks.py
+++ b/jarviscore/integrations/atoms/notion/notion_append_blocks.py
@@ -1,11 +1,7 @@
 async def notion_append_blocks(page_id: str, blocks: list) -> dict:
     """Append blocks via the notion API."""
     try:
-        access_token = _get_nexus_token(None)
-    except Exception as e:
-        return {'success': False, 'data': None, 'error': f'Auth error: {str(e)}'}
-    try:
-        resp = await nexus_call('PATCH', f'https://api.notion.com/v1/blocks/{page_id}/children', json={'children': blocks}, headers={'Authorization': f'Bearer {access_token}', 'Content-Type': 'application/json', 'Notion-Version': '2022-06-28'})
+        resp = await nexus_call('PATCH', f'https://api.notion.com/v1/blocks/{page_id}/children', json={'children': blocks}, headers={'Content-Type': 'application/json', 'Notion-Version': '2022-06-28'})
         if resp['status_code'] != 200:
             return {'success': False, 'data': None, 'error': f"Append blocks failed: {resp['status_code']} {resp['body']}"}
         return {'success': True, 'data': resp['json'], 'error': None}

--- a/jarviscore/integrations/atoms/notion/notion_create_page.py
+++ b/jarviscore/integrations/atoms/notion/notion_create_page.py
@@ -1,15 +1,11 @@
 async def notion_create_page(parent_id: str, title: str, parent_type: str='page') -> dict:
     """Create page. POST https://api.notion.com/v1/pages"""
     try:
-        access_token = _get_nexus_token(None)
-    except Exception as e:
-        return {'success': False, 'data': None, 'error': f'Auth error: {str(e)}'}
-    try:
         if parent_type == 'database':
             parent = {'database_id': parent_id}
         else:
             parent = {'page_id': parent_id}
-        resp = await nexus_call('POST', 'https://api.notion.com/v1/pages', json={'parent': parent, 'properties': {'title': {'title': [{'type': 'text', 'text': {'content': title}}]}}}, headers={'Authorization': f'Bearer {access_token}', 'Content-Type': 'application/json', 'Notion-Version': '2022-06-28'})
+        resp = await nexus_call('POST', 'https://api.notion.com/v1/pages', json={'parent': parent, 'properties': {'title': {'title': [{'type': 'text', 'text': {'content': title}}]}}}, headers={'Content-Type': 'application/json', 'Notion-Version': '2022-06-28'})
         if resp['status_code'] not in (200, 201):
             return {'success': False, 'data': None, 'error': f"Create page failed: {resp['status_code']} {resp['body']}"}
         return {'success': True, 'data': resp['json'], 'error': None}

--- a/jarviscore/integrations/atoms/notion/notion_get_blocks.py
+++ b/jarviscore/integrations/atoms/notion/notion_get_blocks.py
@@ -1,13 +1,9 @@
 async def notion_get_blocks(page_id: str) -> dict:
     """Get blocks via the notion API."""
     try:
-        access_token = _get_nexus_token(None)
-    except Exception as e:
-        return {'success': False, 'data': None, 'error': f'Auth error: {str(e)}'}
-    try:
         blocks = []
         url = f'https://api.notion.com/v1/blocks/{page_id}/children'
-        headers = {'Authorization': f'Bearer {access_token}', 'Notion-Version': '2022-06-28'}
+        headers = {'Notion-Version': '2022-06-28'}
         while url:
             resp = await nexus_call('GET', url, headers=headers)
             if resp['status_code'] != 200:

--- a/jarviscore/integrations/atoms/notion/notion_get_page.py
+++ b/jarviscore/integrations/atoms/notion/notion_get_page.py
@@ -1,11 +1,7 @@
 async def notion_get_page(page_id: str) -> dict:
     """Get page via the notion API."""
     try:
-        access_token = _get_nexus_token(None)
-    except Exception as e:
-        return {'success': False, 'data': None, 'error': f'Auth error: {str(e)}'}
-    try:
-        resp = await nexus_call('GET', f'https://api.notion.com/v1/pages/{page_id}', headers={'Authorization': f'Bearer {access_token}', 'Notion-Version': '2022-06-28'})
+        resp = await nexus_call('GET', f'https://api.notion.com/v1/pages/{page_id}', headers={'Notion-Version': '2022-06-28'})
         if resp['status_code'] != 200:
             return {'success': False, 'data': None, 'error': f"Get page failed: {resp['status_code']} {resp['body']}"}
         return {'success': True, 'data': resp['json'], 'error': None}

--- a/jarviscore/integrations/atoms/notion/notion_search.py
+++ b/jarviscore/integrations/atoms/notion/notion_search.py
@@ -1,14 +1,10 @@
 async def notion_search(query: str, filter_type: str=None) -> dict:
     """Search. POST https://api.notion.com/v1/search"""
     try:
-        access_token = _get_nexus_token(None)
-    except Exception as e:
-        return {'success': False, 'data': None, 'error': f'Auth error: {str(e)}'}
-    try:
         payload = {'query': query}
         if filter_type in ('page', 'database'):
             payload['filter'] = {'value': filter_type, 'property': 'object'}
-        resp = await nexus_call('POST', 'https://api.notion.com/v1/search', json=payload, headers={'Authorization': f'Bearer {access_token}', 'Content-Type': 'application/json', 'Notion-Version': '2022-06-28'})
+        resp = await nexus_call('POST', 'https://api.notion.com/v1/search', json=payload, headers={'Content-Type': 'application/json', 'Notion-Version': '2022-06-28'})
         if resp['status_code'] != 200:
             return {'success': False, 'data': None, 'error': f"Search failed: {resp['status_code']} {resp['body']}"}
         results = resp['json'].get('results', [])

--- a/jarviscore/integrations/atoms/notion/notion_update_page.py
+++ b/jarviscore/integrations/atoms/notion/notion_update_page.py
@@ -1,16 +1,12 @@
 async def notion_update_page(page_id: str, title: str=None, archived: bool=None) -> dict:
     """Update page via the notion API."""
     try:
-        access_token = _get_nexus_token(None)
-    except Exception as e:
-        return {'success': False, 'data': None, 'error': f'Auth error: {str(e)}'}
-    try:
         payload = {}
         if title is not None:
             payload['properties'] = {'title': {'title': [{'type': 'text', 'text': {'content': title}}]}}
         if archived is not None:
             payload['archived'] = archived
-        resp = await nexus_call('PATCH', f'https://api.notion.com/v1/pages/{page_id}', json=payload, headers={'Authorization': f'Bearer {access_token}', 'Content-Type': 'application/json', 'Notion-Version': '2022-06-28'})
+        resp = await nexus_call('PATCH', f'https://api.notion.com/v1/pages/{page_id}', json=payload, headers={'Content-Type': 'application/json', 'Notion-Version': '2022-06-28'})
         if resp['status_code'] != 200:
             return {'success': False, 'data': None, 'error': f"Update page failed: {resp['status_code']} {resp['body']}"}
         return {'success': True, 'data': resp['json'], 'error': None}

--- a/jarviscore/integrations/atoms/reddit/reddit_get_me.py
+++ b/jarviscore/integrations/atoms/reddit/reddit_get_me.py
@@ -1,11 +1,7 @@
 async def reddit_get_me() -> dict:
     """Get me. GET https://oauth.reddit.com/api/v1/me"""
     try:
-        access_token = _get_nexus_token(None)
-    except Exception as e:
-        return {'success': False, 'data': None, 'error': f'Auth error: {str(e)}'}
-    try:
-        resp = await nexus_call('GET', 'https://oauth.reddit.com/api/v1/me', headers={'Authorization': f'Bearer {access_token}', 'User-Agent': 'jarviscore/1.0'})
+        resp = await nexus_call('GET', 'https://oauth.reddit.com/api/v1/me', headers={'User-Agent': 'jarviscore/1.0'})
         if resp['status_code'] != 200:
             return {'success': False, 'data': None, 'error': f"Get me failed: {resp['status_code']} {resp['body']}"}
         data = resp['json']

--- a/jarviscore/integrations/atoms/reddit/reddit_get_post.py
+++ b/jarviscore/integrations/atoms/reddit/reddit_get_post.py
@@ -1,12 +1,8 @@
 async def reddit_get_post(post_id: str) -> dict:
     """Get post via the reddit API."""
     try:
-        access_token = _get_nexus_token(None)
-    except Exception as e:
-        return {'success': False, 'data': None, 'error': f'Auth error: {str(e)}'}
-    try:
         clean_id = post_id.replace('t3_', '')
-        resp = await nexus_call('GET', f'https://oauth.reddit.com/api/info', params={'id': f't3_{clean_id}'}, headers={'Authorization': f'Bearer {access_token}', 'User-Agent': 'jarviscore/1.0'})
+        resp = await nexus_call('GET', f'https://oauth.reddit.com/api/info', params={'id': f't3_{clean_id}'}, headers={'User-Agent': 'jarviscore/1.0'})
         if resp['status_code'] != 200:
             return {'success': False, 'data': None, 'error': f"Get post failed: {resp['status_code']} {resp['body']}"}
         children = resp['json'].get('data', {}).get('children', [])

--- a/jarviscore/integrations/atoms/reddit/reddit_get_subreddit.py
+++ b/jarviscore/integrations/atoms/reddit/reddit_get_subreddit.py
@@ -1,11 +1,7 @@
 async def reddit_get_subreddit(subreddit: str, limit: int=10) -> dict:
     """Get subreddit via the reddit API."""
     try:
-        access_token = _get_nexus_token(None)
-    except Exception as e:
-        return {'success': False, 'data': None, 'error': f'Auth error: {str(e)}'}
-    try:
-        headers = {'Authorization': f'Bearer {access_token}', 'User-Agent': 'jarviscore/1.0'}
+        headers = {'User-Agent': 'jarviscore/1.0'}
         about_resp = await nexus_call('GET', f'https://oauth.reddit.com/r/{subreddit}/about', headers=headers)
         if about_resp['status_code'] != 200:
             return {'success': False, 'data': None, 'error': f"Get subreddit failed: {about_resp['status_code']} {about_resp['body']}"}

--- a/jarviscore/integrations/atoms/reddit/reddit_submit_comment.py
+++ b/jarviscore/integrations/atoms/reddit/reddit_submit_comment.py
@@ -1,11 +1,7 @@
 async def reddit_submit_comment(parent_id: str, text: str) -> dict:
     """Submit comment. POST https://oauth.reddit.com/api/comment"""
     try:
-        access_token = _get_nexus_token(None)
-    except Exception as e:
-        return {'success': False, 'data': None, 'error': f'Auth error: {str(e)}'}
-    try:
-        resp = await nexus_call('POST', 'https://oauth.reddit.com/api/comment', data={'parent': parent_id, 'text': text}, headers={'Authorization': f'Bearer {access_token}', 'User-Agent': 'jarviscore/1.0'})
+        resp = await nexus_call('POST', 'https://oauth.reddit.com/api/comment', data={'parent': parent_id, 'text': text}, headers={'User-Agent': 'jarviscore/1.0'})
         if resp['status_code'] != 200:
             return {'success': False, 'data': None, 'error': f"Submit comment failed: {resp['status_code']} {resp['body']}"}
         data = resp['json']

--- a/jarviscore/integrations/atoms/reddit/reddit_submit_post.py
+++ b/jarviscore/integrations/atoms/reddit/reddit_submit_post.py
@@ -1,10 +1,6 @@
 async def reddit_submit_post(subreddit: str, title: str, text: str=None, url: str=None) -> dict:
     """Submit post. POST https://oauth.reddit.com/api/submit"""
     try:
-        access_token = _get_nexus_token(None)
-    except Exception as e:
-        return {'success': False, 'data': None, 'error': f'Auth error: {str(e)}'}
-    try:
         if url:
             kind = 'link'
         else:
@@ -14,7 +10,7 @@ async def reddit_submit_post(subreddit: str, title: str, text: str=None, url: st
             payload['text'] = text
         if url:
             payload['url'] = url
-        resp = await nexus_call('POST', 'https://oauth.reddit.com/api/submit', data=payload, headers={'Authorization': f'Bearer {access_token}', 'User-Agent': 'jarviscore/1.0'})
+        resp = await nexus_call('POST', 'https://oauth.reddit.com/api/submit', data=payload, headers={'User-Agent': 'jarviscore/1.0'})
         if resp['status_code'] != 200:
             return {'success': False, 'data': None, 'error': f"Submit post failed: {resp['status_code']} {resp['body']}"}
         data = resp['json']

--- a/jarviscore/integrations/atoms/reddit/reddit_vote.py
+++ b/jarviscore/integrations/atoms/reddit/reddit_vote.py
@@ -1,11 +1,7 @@
 async def reddit_vote(fullname: str, direction: int) -> dict:
     """Vote. POST https://oauth.reddit.com/api/vote"""
     try:
-        access_token = _get_nexus_token(None)
-    except Exception as e:
-        return {'success': False, 'data': None, 'error': f'Auth error: {str(e)}'}
-    try:
-        resp = await nexus_call('POST', 'https://oauth.reddit.com/api/vote', data={'id': fullname, 'dir': direction}, headers={'Authorization': f'Bearer {access_token}', 'User-Agent': 'jarviscore/1.0'})
+        resp = await nexus_call('POST', 'https://oauth.reddit.com/api/vote', data={'id': fullname, 'dir': direction}, headers={'User-Agent': 'jarviscore/1.0'})
         if resp['status_code'] != 200:
             return {'success': False, 'data': None, 'error': f"Vote failed: {resp['status_code']} {resp['body']}"}
         return {'success': True, 'data': {'fullname': fullname, 'direction': direction}, 'error': None}

--- a/jarviscore/integrations/atoms/slack/slack_send_message.py
+++ b/jarviscore/integrations/atoms/slack/slack_send_message.py
@@ -1,3 +1,11 @@
+ATOM_POLICY = {
+    "effect": "notify",
+    "approval": "never",
+    "idempotency_fields": ["channel", "text"],
+    "consequence": "Posts one message to the selected Slack channel.",
+}
+
+
 async def slack_send_message(channel: str, text: str, thread_ts: str=None) -> dict:
     """Send message via the slack API."""
     _base = 'https://slack.com/api'

--- a/jarviscore/integrations/atoms/todoist/todoist_close_task.py
+++ b/jarviscore/integrations/atoms/todoist/todoist_close_task.py
@@ -1,11 +1,7 @@
 async def todoist_close_task(task_id: str) -> dict:
     """Close task via the todoist API."""
     try:
-        access_token = _get_nexus_token(None)
-    except Exception as e:
-        return {'success': False, 'data': None, 'error': f'Auth error: {str(e)}'}
-    try:
-        resp = await nexus_call('POST', f'https://api.todoist.com/api/v1/tasks/{task_id}/close', headers={'Authorization': f'Bearer {access_token}'})
+        resp = await nexus_call('POST', f'https://api.todoist.com/api/v1/tasks/{task_id}/close')
         if resp['status_code'] != 204:
             return {'success': False, 'data': None, 'error': f"Close task failed: {resp['status_code']} {resp['body']}"}
         return {'success': True, 'data': {'task_id': task_id, 'closed': True}, 'error': None}

--- a/jarviscore/integrations/atoms/todoist/todoist_create_project.py
+++ b/jarviscore/integrations/atoms/todoist/todoist_create_project.py
@@ -1,14 +1,10 @@
 async def todoist_create_project(name: str, color: str=None, is_favorite: bool=False) -> dict:
     """Create project. POST https://api.todoist.com/api/v1/projects"""
     try:
-        access_token = _get_nexus_token(None)
-    except Exception as e:
-        return {'success': False, 'data': None, 'error': f'Auth error: {str(e)}'}
-    try:
         payload = {'name': name, 'is_favorite': is_favorite}
         if color:
             payload['color'] = color
-        resp = await nexus_call('POST', 'https://api.todoist.com/api/v1/projects', json=payload, headers={'Authorization': f'Bearer {access_token}', 'Content-Type': 'application/json'})
+        resp = await nexus_call('POST', 'https://api.todoist.com/api/v1/projects', json=payload, headers={'Content-Type': 'application/json'})
         if resp['status_code'] not in (200, 201):
             return {'success': False, 'data': None, 'error': f"Create project failed: {resp['status_code']} {resp['body']}"}
         data = resp['json']

--- a/jarviscore/integrations/atoms/todoist/todoist_create_task.py
+++ b/jarviscore/integrations/atoms/todoist/todoist_create_task.py
@@ -1,16 +1,12 @@
 async def todoist_create_task(content: str, project_id: str=None, due_string: str=None, priority: int=1) -> dict:
     """Create task. POST https://api.todoist.com/api/v1/tasks"""
     try:
-        access_token = _get_nexus_token(None)
-    except Exception as e:
-        return {'success': False, 'data': None, 'error': f'Auth error: {str(e)}'}
-    try:
         payload = {'content': content, 'priority': priority}
         if project_id:
             payload['project_id'] = project_id
         if due_string:
             payload['due_string'] = due_string
-        resp = await nexus_call('POST', 'https://api.todoist.com/api/v1/tasks', json=payload, headers={'Authorization': f'Bearer {access_token}', 'Content-Type': 'application/json'})
+        resp = await nexus_call('POST', 'https://api.todoist.com/api/v1/tasks', json=payload, headers={'Content-Type': 'application/json'})
         if resp['status_code'] not in (200, 201):
             return {'success': False, 'data': None, 'error': f"Create task failed: {resp['status_code']} {resp['body']}"}
         return {'success': True, 'data': resp['json'].get('results', resp['json']), 'error': None}

--- a/jarviscore/integrations/atoms/todoist/todoist_get_projects.py
+++ b/jarviscore/integrations/atoms/todoist/todoist_get_projects.py
@@ -1,11 +1,7 @@
 async def todoist_get_projects() -> dict:
     """Get projects. GET https://api.todoist.com/api/v1/projects"""
     try:
-        access_token = _get_nexus_token(None)
-    except Exception as e:
-        return {'success': False, 'data': None, 'error': f'Auth error: {str(e)}'}
-    try:
-        resp = await nexus_call('GET', 'https://api.todoist.com/api/v1/projects', headers={'Authorization': f'Bearer {access_token}'})
+        resp = await nexus_call('GET', 'https://api.todoist.com/api/v1/projects')
         if resp['status_code'] != 200:
             return {'success': False, 'data': None, 'error': f"Get projects failed: {resp['status_code']} {resp['body']}"}
         projects = resp['json'].get('results', [])

--- a/jarviscore/integrations/atoms/todoist/todoist_get_task.py
+++ b/jarviscore/integrations/atoms/todoist/todoist_get_task.py
@@ -1,11 +1,7 @@
 async def todoist_get_task(task_id: str) -> dict:
     """Get task via the todoist API."""
     try:
-        access_token = _get_nexus_token(None)
-    except Exception as e:
-        return {'success': False, 'data': None, 'error': f'Auth error: {str(e)}'}
-    try:
-        resp = await nexus_call('GET', f'https://api.todoist.com/api/v1/tasks/{task_id}', headers={'Authorization': f'Bearer {access_token}'})
+        resp = await nexus_call('GET', f'https://api.todoist.com/api/v1/tasks/{task_id}')
         if resp['status_code'] != 200:
             return {'success': False, 'data': None, 'error': f"Get task failed: {resp['status_code']} {resp['body']}"}
         data = resp['json']

--- a/jarviscore/integrations/atoms/todoist/todoist_update_task.py
+++ b/jarviscore/integrations/atoms/todoist/todoist_update_task.py
@@ -1,10 +1,6 @@
 async def todoist_update_task(task_id: str, content: str=None, due_string: str=None, priority: int=None) -> dict:
     """Update task via the todoist API."""
     try:
-        access_token = _get_nexus_token(None)
-    except Exception as e:
-        return {'success': False, 'data': None, 'error': f'Auth error: {str(e)}'}
-    try:
         payload = {}
         if content:
             payload['content'] = content
@@ -12,7 +8,7 @@ async def todoist_update_task(task_id: str, content: str=None, due_string: str=N
             payload['due_string'] = due_string
         if priority:
             payload['priority'] = priority
-        resp = await nexus_call('POST', f'https://api.todoist.com/api/v1/tasks/{task_id}', json=payload, headers={'Authorization': f'Bearer {access_token}', 'Content-Type': 'application/json'})
+        resp = await nexus_call('POST', f'https://api.todoist.com/api/v1/tasks/{task_id}', json=payload, headers={'Content-Type': 'application/json'})
         if resp['status_code'] != 200:
             return {'success': False, 'data': None, 'error': f"Update task failed: {resp['status_code']} {resp['body']}"}
         data = resp['json']

--- a/jarviscore/integrations/atoms/twitter/twitter_like_tweet.py
+++ b/jarviscore/integrations/atoms/twitter/twitter_like_tweet.py
@@ -1,5 +1,5 @@
-async def _get_twitter_user_id(access_token: str) -> str:
-    resp = await nexus_call('GET', 'https://api.twitter.com/2/users/me', headers={'Authorization': f'Bearer {access_token}'})
+async def _get_twitter_user_id() -> str:
+    resp = await nexus_call('GET', 'https://api.twitter.com/2/users/me')
     if not resp['ok']:
         raise RuntimeError(resp['body'])
     return resp['json']['data']['id']
@@ -7,12 +7,11 @@ async def _get_twitter_user_id(access_token: str) -> str:
 async def twitter_like_tweet(tweet_id: str) -> dict:
     """Like tweet via the twitter API."""
     try:
-        access_token = _get_nexus_token(None)
-        twitter_user_id = await _get_twitter_user_id(access_token)
+        twitter_user_id = await _get_twitter_user_id()
     except Exception as e:
         return {'success': False, 'data': None, 'error': f'Auth error: {str(e)}'}
     try:
-        resp = await nexus_call('POST', f'https://api.twitter.com/2/users/{twitter_user_id}/likes', json={'tweet_id': tweet_id}, headers={'Authorization': f'Bearer {access_token}', 'Content-Type': 'application/json'})
+        resp = await nexus_call('POST', f'https://api.twitter.com/2/users/{twitter_user_id}/likes', json={'tweet_id': tweet_id}, headers={'Content-Type': 'application/json'})
         if resp['status_code'] not in (200, 201):
             return {'success': False, 'data': None, 'error': f"Like tweet failed: {resp['status_code']} {resp['body']}"}
         return {'success': True, 'data': resp['json'].get('data'), 'error': None}

--- a/jarviscore/integrations/atoms/twitter/twitter_post_tweet.py
+++ b/jarviscore/integrations/atoms/twitter/twitter_post_tweet.py
@@ -1,11 +1,7 @@
 async def twitter_post_tweet(text: str) -> dict:
     """Post tweet. POST https://api.twitter.com/2/tweets"""
     try:
-        access_token = _get_nexus_token(None)
-    except Exception as e:
-        return {'success': False, 'data': None, 'error': f'Auth error: {str(e)}'}
-    try:
-        resp = await nexus_call('POST', 'https://api.twitter.com/2/tweets', json={'text': text}, headers={'Authorization': f'Bearer {access_token}', 'Content-Type': 'application/json'})
+        resp = await nexus_call('POST', 'https://api.twitter.com/2/tweets', json={'text': text}, headers={'Content-Type': 'application/json'})
         if resp['status_code'] not in (200, 201):
             return {'success': False, 'data': None, 'error': f"Post tweet failed: {resp['status_code']} {resp['body']}"}
         return {'success': True, 'data': resp['json'].get('data'), 'error': None}

--- a/jarviscore/integrations/atoms/twitter/twitter_reply_tweet.py
+++ b/jarviscore/integrations/atoms/twitter/twitter_reply_tweet.py
@@ -1,11 +1,7 @@
 async def twitter_reply_tweet(text: str, reply_to_tweet_id: str) -> dict:
     """Reply tweet. POST https://api.twitter.com/2/tweets"""
     try:
-        access_token = _get_nexus_token(None)
-    except Exception as e:
-        return {'success': False, 'data': None, 'error': f'Auth error: {str(e)}'}
-    try:
-        resp = await nexus_call('POST', 'https://api.twitter.com/2/tweets', json={'text': text, 'reply': {'in_reply_to_tweet_id': reply_to_tweet_id}}, headers={'Authorization': f'Bearer {access_token}', 'Content-Type': 'application/json'})
+        resp = await nexus_call('POST', 'https://api.twitter.com/2/tweets', json={'text': text, 'reply': {'in_reply_to_tweet_id': reply_to_tweet_id}}, headers={'Content-Type': 'application/json'})
         if resp['status_code'] not in (200, 201):
             return {'success': False, 'data': None, 'error': f"Reply tweet failed: {resp['status_code']} {resp['body']}"}
         return {'success': True, 'data': resp['json'].get('data'), 'error': None}

--- a/jarviscore/integrations/atoms/webex/webex_get_me.py
+++ b/jarviscore/integrations/atoms/webex/webex_get_me.py
@@ -1,11 +1,7 @@
 async def webex_get_me() -> dict:
     """Get me. GET https://webexapis.com/v1/people/me"""
     try:
-        access_token = _get_nexus_token(None)
-    except Exception as e:
-        return {'success': False, 'data': None, 'error': f'Auth error: {str(e)}'}
-    try:
-        resp = await nexus_call('GET', 'https://webexapis.com/v1/people/me', headers={'Authorization': f'Bearer {access_token}'})
+        resp = await nexus_call('GET', 'https://webexapis.com/v1/people/me')
         if resp['status_code'] != 200:
             return {'success': False, 'data': None, 'error': f"Get me failed: {resp['status_code']} {resp['body']}"}
         return {'success': True, 'data': resp['json'], 'error': None}

--- a/jarviscore/integrations/atoms/webex/webex_get_message.py
+++ b/jarviscore/integrations/atoms/webex/webex_get_message.py
@@ -1,11 +1,7 @@
 async def webex_get_message(message_id: str) -> dict:
     """Get message via the webex API."""
     try:
-        access_token = _get_nexus_token(None)
-    except Exception as e:
-        return {'success': False, 'data': None, 'error': f'Auth error: {str(e)}'}
-    try:
-        resp = await nexus_call('GET', f'https://webexapis.com/v1/messages/{message_id}', headers={'Authorization': f'Bearer {access_token}'})
+        resp = await nexus_call('GET', f'https://webexapis.com/v1/messages/{message_id}')
         if resp['status_code'] != 200:
             return {'success': False, 'data': None, 'error': f"Get message failed: {resp['status_code']} {resp['body']}"}
         return {'success': True, 'data': resp['json'], 'error': None}

--- a/jarviscore/integrations/atoms/webex/webex_get_messages.py
+++ b/jarviscore/integrations/atoms/webex/webex_get_messages.py
@@ -1,11 +1,7 @@
 async def webex_get_messages(room_id: str, max_results: int=50) -> dict:
     """Get messages. GET https://webexapis.com/v1/messages"""
     try:
-        access_token = _get_nexus_token(None)
-    except Exception as e:
-        return {'success': False, 'data': None, 'error': f'Auth error: {str(e)}'}
-    try:
-        resp = await nexus_call('GET', 'https://webexapis.com/v1/messages', headers={'Authorization': f'Bearer {access_token}'}, params={'roomId': room_id, 'max': max_results})
+        resp = await nexus_call('GET', 'https://webexapis.com/v1/messages', params={'roomId': room_id, 'max': max_results})
         if resp['status_code'] != 200:
             return {'success': False, 'data': None, 'error': f"Get messages failed: {resp['status_code']} {resp['body']}"}
         messages = resp['json'].get('items', [])

--- a/jarviscore/integrations/atoms/webex/webex_get_room.py
+++ b/jarviscore/integrations/atoms/webex/webex_get_room.py
@@ -1,11 +1,7 @@
 async def webex_get_room(room_id: str) -> dict:
     """Get room via the webex API."""
     try:
-        access_token = _get_nexus_token(None)
-    except Exception as e:
-        return {'success': False, 'data': None, 'error': f'Auth error: {str(e)}'}
-    try:
-        resp = await nexus_call('GET', f'https://webexapis.com/v1/rooms/{room_id}', headers={'Authorization': f'Bearer {access_token}'})
+        resp = await nexus_call('GET', f'https://webexapis.com/v1/rooms/{room_id}')
         if resp['status_code'] != 200:
             return {'success': False, 'data': None, 'error': f"Get room failed: {resp['status_code']} {resp['body']}"}
         return {'success': True, 'data': resp['json'], 'error': None}

--- a/jarviscore/integrations/atoms/webex/webex_get_rooms.py
+++ b/jarviscore/integrations/atoms/webex/webex_get_rooms.py
@@ -1,11 +1,7 @@
 async def webex_get_rooms(max_results: int=50) -> dict:
     """Get rooms. GET https://webexapis.com/v1/rooms"""
     try:
-        access_token = _get_nexus_token(None)
-    except Exception as e:
-        return {'success': False, 'data': None, 'error': f'Auth error: {str(e)}'}
-    try:
-        resp = await nexus_call('GET', 'https://webexapis.com/v1/rooms', headers={'Authorization': f'Bearer {access_token}'}, params={'max': max_results})
+        resp = await nexus_call('GET', 'https://webexapis.com/v1/rooms', params={'max': max_results})
         if resp['status_code'] != 200:
             return {'success': False, 'data': None, 'error': f"Get rooms failed: {resp['status_code']} {resp['body']}"}
         rooms = resp['json'].get('items', [])

--- a/jarviscore/integrations/atoms/webex/webex_search_people.py
+++ b/jarviscore/integrations/atoms/webex/webex_search_people.py
@@ -1,9 +1,5 @@
 async def webex_search_people(email: str=None, display_name: str=None, max_results: int=10) -> dict:
     """Search people. GET https://webexapis.com/v1/people"""
-    try:
-        access_token = _get_nexus_token(None)
-    except Exception as e:
-        return {'success': False, 'data': None, 'error': f'Auth error: {str(e)}'}
     if not email and (not display_name):
         return {'success': False, 'data': None, 'error': 'Either email or display_name must be provided'}
     try:
@@ -12,7 +8,7 @@ async def webex_search_people(email: str=None, display_name: str=None, max_resul
             params['email'] = email
         if display_name:
             params['displayName'] = display_name
-        resp = await nexus_call('GET', 'https://webexapis.com/v1/people', headers={'Authorization': f'Bearer {access_token}'}, params=params)
+        resp = await nexus_call('GET', 'https://webexapis.com/v1/people', params=params)
         if resp['status_code'] != 200:
             return {'success': False, 'data': None, 'error': f"Search people failed: {resp['status_code']} {resp['body']}"}
         people = resp['json'].get('items', [])

--- a/jarviscore/integrations/atoms/zoho_books/zoho_books_create_contact.py
+++ b/jarviscore/integrations/atoms/zoho_books/zoho_books_create_contact.py
@@ -1,16 +1,12 @@
 async def zoho_books_create_contact(org_id: str, contact_name: str, contact_type: str='customer', email: str=None, phone: str=None) -> dict:
     """Books create contact. POST https://www.zohoapis.com/books/v3/contacts"""
     try:
-        access_token = _get_nexus_token(None)
-    except Exception as e:
-        return {'success': False, 'data': None, 'error': f'Auth error: {str(e)}'}
-    try:
         payload = {'contact_name': contact_name, 'contact_type': contact_type}
         if email:
             payload['email'] = email
         if phone:
             payload['phone'] = phone
-        resp = await nexus_call('POST', 'https://www.zohoapis.com/books/v3/contacts', headers={'Authorization': f'Zoho-oauthtoken {access_token}', 'Content-Type': 'application/json'}, params={'organization_id': org_id}, json=payload)
+        resp = await nexus_call('POST', 'https://www.zohoapis.com/books/v3/contacts', headers={'Content-Type': 'application/json'}, params={'organization_id': org_id}, json=payload)
         if resp['status_code'] not in (200, 201):
             return {'success': False, 'data': None, 'error': f"Create contact failed: {resp['status_code']} {resp['body']}"}
         data = resp['json']

--- a/jarviscore/integrations/atoms/zoho_books/zoho_books_create_expense.py
+++ b/jarviscore/integrations/atoms/zoho_books/zoho_books_create_expense.py
@@ -1,16 +1,12 @@
 async def zoho_books_create_expense(org_id: str, account_id: str, amount: float, date: str, paid_through_account_id: str, description: str=None, customer_id: str=None) -> dict:
     """Books create expense. POST https://www.zohoapis.com/books/v3/expenses"""
     try:
-        access_token = _get_nexus_token(None)
-    except Exception as e:
-        return {'success': False, 'data': None, 'error': f'Auth error: {str(e)}'}
-    try:
         payload = {'account_id': account_id, 'amount': amount, 'date': date, 'paid_through_account_id': paid_through_account_id}
         if description:
             payload['description'] = description
         if customer_id:
             payload['customer_id'] = customer_id
-        resp = await nexus_call('POST', 'https://www.zohoapis.com/books/v3/expenses', headers={'Authorization': f'Zoho-oauthtoken {access_token}', 'Content-Type': 'application/json'}, params={'organization_id': org_id}, json=payload)
+        resp = await nexus_call('POST', 'https://www.zohoapis.com/books/v3/expenses', headers={'Content-Type': 'application/json'}, params={'organization_id': org_id}, json=payload)
         if resp['status_code'] not in (200, 201):
             return {'success': False, 'data': None, 'error': f"Create expense failed: {resp['status_code']} {resp['body']}"}
         data = resp['json']

--- a/jarviscore/integrations/atoms/zoho_books/zoho_books_create_invoice.py
+++ b/jarviscore/integrations/atoms/zoho_books/zoho_books_create_invoice.py
@@ -1,16 +1,12 @@
 async def zoho_books_create_invoice(org_id: str, customer_id: str, line_items: list, date: str=None, notes: str=None) -> dict:
     """Books create invoice. POST https://www.zohoapis.com/books/v3/invoices"""
     try:
-        access_token = _get_nexus_token(None)
-    except Exception as e:
-        return {'success': False, 'data': None, 'error': f'Auth error: {str(e)}'}
-    try:
         payload = {'customer_id': customer_id, 'line_items': line_items}
         if date:
             payload['date'] = date
         if notes:
             payload['notes'] = notes
-        resp = await nexus_call('POST', 'https://www.zohoapis.com/books/v3/invoices', headers={'Authorization': f'Zoho-oauthtoken {access_token}', 'Content-Type': 'application/json'}, params={'organization_id': org_id}, json=payload)
+        resp = await nexus_call('POST', 'https://www.zohoapis.com/books/v3/invoices', headers={'Content-Type': 'application/json'}, params={'organization_id': org_id}, json=payload)
         if resp['status_code'] not in (200, 201):
             return {'success': False, 'data': None, 'error': f"Create invoice failed: {resp['status_code']} {resp['body']}"}
         data = resp['json']

--- a/jarviscore/integrations/atoms/zoho_books/zoho_books_get_contact.py
+++ b/jarviscore/integrations/atoms/zoho_books/zoho_books_get_contact.py
@@ -1,11 +1,7 @@
 async def zoho_books_get_contact(org_id: str, contact_id: str) -> dict:
     """Books get contact via the zoho_books API."""
     try:
-        access_token = _get_nexus_token(None)
-    except Exception as e:
-        return {'success': False, 'data': None, 'error': f'Auth error: {str(e)}'}
-    try:
-        resp = await nexus_call('GET', f'https://www.zohoapis.com/books/v3/contacts/{contact_id}', headers={'Authorization': f'Zoho-oauthtoken {access_token}'}, params={'organization_id': org_id})
+        resp = await nexus_call('GET', f'https://www.zohoapis.com/books/v3/contacts/{contact_id}', params={'organization_id': org_id})
         if resp['status_code'] != 200:
             return {'success': False, 'data': None, 'error': f"Get contact failed: {resp['status_code']} {resp['body']}"}
         data = resp['json']

--- a/jarviscore/integrations/atoms/zoho_books/zoho_books_get_contacts.py
+++ b/jarviscore/integrations/atoms/zoho_books/zoho_books_get_contacts.py
@@ -1,14 +1,10 @@
 async def zoho_books_get_contacts(org_id: str, contact_type: str=None) -> dict:
     """Books get contacts. GET https://www.zohoapis.com/books/v3/contacts"""
     try:
-        access_token = _get_nexus_token(None)
-    except Exception as e:
-        return {'success': False, 'data': None, 'error': f'Auth error: {str(e)}'}
-    try:
         params = {'organization_id': org_id}
         if contact_type:
             params['contact_type'] = contact_type
-        resp = await nexus_call('GET', 'https://www.zohoapis.com/books/v3/contacts', headers={'Authorization': f'Zoho-oauthtoken {access_token}'}, params=params)
+        resp = await nexus_call('GET', 'https://www.zohoapis.com/books/v3/contacts', params=params)
         if resp['status_code'] != 200:
             return {'success': False, 'data': None, 'error': f"Get contacts failed: {resp['status_code']} {resp['body']}"}
         data = resp['json']

--- a/jarviscore/integrations/atoms/zoho_books/zoho_books_get_expenses.py
+++ b/jarviscore/integrations/atoms/zoho_books/zoho_books_get_expenses.py
@@ -1,14 +1,10 @@
 async def zoho_books_get_expenses(org_id: str, status: str=None) -> dict:
     """Books get expenses. GET https://www.zohoapis.com/books/v3/expenses"""
     try:
-        access_token = _get_nexus_token(None)
-    except Exception as e:
-        return {'success': False, 'data': None, 'error': f'Auth error: {str(e)}'}
-    try:
         params = {'organization_id': org_id}
         if status:
             params['filter_by'] = f'Status.{status.capitalize()}'
-        resp = await nexus_call('GET', 'https://www.zohoapis.com/books/v3/expenses', headers={'Authorization': f'Zoho-oauthtoken {access_token}'}, params=params)
+        resp = await nexus_call('GET', 'https://www.zohoapis.com/books/v3/expenses', params=params)
         if resp['status_code'] != 200:
             return {'success': False, 'data': None, 'error': f"Get expenses failed: {resp['status_code']} {resp['body']}"}
         data = resp['json']

--- a/jarviscore/integrations/atoms/zoho_books/zoho_books_get_invoice.py
+++ b/jarviscore/integrations/atoms/zoho_books/zoho_books_get_invoice.py
@@ -1,11 +1,7 @@
 async def zoho_books_get_invoice(org_id: str, invoice_id: str) -> dict:
     """Books get invoice via the zoho_books API."""
     try:
-        access_token = _get_nexus_token(None)
-    except Exception as e:
-        return {'success': False, 'data': None, 'error': f'Auth error: {str(e)}'}
-    try:
-        resp = await nexus_call('GET', f'https://www.zohoapis.com/books/v3/invoices/{invoice_id}', headers={'Authorization': f'Zoho-oauthtoken {access_token}'}, params={'organization_id': org_id})
+        resp = await nexus_call('GET', f'https://www.zohoapis.com/books/v3/invoices/{invoice_id}', params={'organization_id': org_id})
         if resp['status_code'] != 200:
             return {'success': False, 'data': None, 'error': f"Get invoice failed: {resp['status_code']} {resp['body']}"}
         data = resp['json']

--- a/jarviscore/integrations/atoms/zoho_books/zoho_books_get_invoices.py
+++ b/jarviscore/integrations/atoms/zoho_books/zoho_books_get_invoices.py
@@ -1,14 +1,10 @@
 async def zoho_books_get_invoices(org_id: str, status: str=None) -> dict:
     """Books get invoices. GET https://www.zohoapis.com/books/v3/invoices"""
     try:
-        access_token = _get_nexus_token(None)
-    except Exception as e:
-        return {'success': False, 'data': None, 'error': f'Auth error: {str(e)}'}
-    try:
         params = {'organization_id': org_id}
         if status:
             params['status'] = status
-        resp = await nexus_call('GET', 'https://www.zohoapis.com/books/v3/invoices', headers={'Authorization': f'Zoho-oauthtoken {access_token}'}, params=params)
+        resp = await nexus_call('GET', 'https://www.zohoapis.com/books/v3/invoices', params=params)
         if resp['status_code'] != 200:
             return {'success': False, 'data': None, 'error': f"Get invoices failed: {resp['status_code']} {resp['body']}"}
         data = resp['json']

--- a/jarviscore/integrations/atoms/zoho_shifts/zoho_shifts_create_shift.py
+++ b/jarviscore/integrations/atoms/zoho_shifts/zoho_shifts_create_shift.py
@@ -1,10 +1,6 @@
 async def zoho_shifts_create_shift(org_id: str, schedule_id: str, start_time: str, end_time: str, employee_id: str=None, position_id: str=None, notes: str=None) -> dict:
     """Shifts create shift via the zoho_shifts API."""
     try:
-        access_token = _get_nexus_token(None)
-    except Exception as e:
-        return {'success': False, 'data': None, 'error': f'Auth error: {str(e)}'}
-    try:
         payload = {'schedule_id': schedule_id, 'start_time': start_time, 'end_time': end_time}
         if employee_id:
             payload['employee_id'] = employee_id
@@ -12,7 +8,7 @@ async def zoho_shifts_create_shift(org_id: str, schedule_id: str, start_time: st
             payload['position_id'] = position_id
         if notes:
             payload['notes'] = notes
-        resp = await nexus_call('POST', f'https://shifts.zoho.com/api/v1/{org_id}/shifts', headers={'Authorization': f'Zoho-oauthtoken {access_token}', 'Content-Type': 'application/json'}, json=payload)
+        resp = await nexus_call('POST', f'https://shifts.zoho.com/api/v1/{org_id}/shifts', headers={'Content-Type': 'application/json'}, json=payload)
         if resp['status_code'] != 200:
             return {'success': False, 'data': None, 'error': f"Create shift failed: {resp['status_code']} {resp['body']}"}
         return {'success': True, 'data': resp['json'], 'error': None}

--- a/jarviscore/integrations/atoms/zoho_shifts/zoho_shifts_delete_shift.py
+++ b/jarviscore/integrations/atoms/zoho_shifts/zoho_shifts_delete_shift.py
@@ -3,11 +3,7 @@ ATOM_POLICY = {"effect": "destructive", "approval": "required", "idempotency_fie
 async def zoho_shifts_delete_shift(org_id: str, shift_id: str) -> dict:
     """Shifts delete shift via the zoho_shifts API."""
     try:
-        access_token = _get_nexus_token(None)
-    except Exception as e:
-        return {'success': False, 'data': None, 'error': f'Auth error: {str(e)}'}
-    try:
-        resp = await nexus_call('DELETE', f'https://shifts.zoho.com/api/v1/{org_id}/shifts/{shift_id}', headers={'Authorization': f'Zoho-oauthtoken {access_token}'})
+        resp = await nexus_call('DELETE', f'https://shifts.zoho.com/api/v1/{org_id}/shifts/{shift_id}')
         if resp['status_code'] != 200:
             return {'success': False, 'data': None, 'error': f"Delete shift failed: {resp['status_code']} {resp['body']}"}
         return {'success': True, 'data': {'shift_id': shift_id, 'deleted': True}, 'error': None}

--- a/jarviscore/integrations/atoms/zoho_shifts/zoho_shifts_get_shifts.py
+++ b/jarviscore/integrations/atoms/zoho_shifts/zoho_shifts_get_shifts.py
@@ -1,11 +1,7 @@
 async def zoho_shifts_get_shifts(org_id: str, start_date: str, end_date: str) -> dict:
     """Shifts get shifts via the zoho_shifts API."""
     try:
-        access_token = _get_nexus_token(None)
-    except Exception as e:
-        return {'success': False, 'data': None, 'error': f'Auth error: {str(e)}'}
-    try:
-        resp = await nexus_call('GET', f'https://shifts.zoho.com/api/v1/{org_id}/shifts', headers={'Authorization': f'Zoho-oauthtoken {access_token}'}, params={'start_date': start_date, 'end_date': end_date})
+        resp = await nexus_call('GET', f'https://shifts.zoho.com/api/v1/{org_id}/shifts', params={'start_date': start_date, 'end_date': end_date})
         if resp['status_code'] != 200:
             return {'success': False, 'data': None, 'error': f"Get shifts failed: {resp['status_code']} {resp['body']}"}
         shifts = resp['json'].get('shifts', [])

--- a/jarviscore/integrations/atoms/zoho_shifts/zoho_shifts_update_shift.py
+++ b/jarviscore/integrations/atoms/zoho_shifts/zoho_shifts_update_shift.py
@@ -1,10 +1,6 @@
 async def zoho_shifts_update_shift(org_id: str, shift_id: str, start_time: str=None, end_time: str=None, employee_id: str=None, notes: str=None) -> dict:
     """Shifts update shift via the zoho_shifts API."""
     try:
-        access_token = _get_nexus_token(None)
-    except Exception as e:
-        return {'success': False, 'data': None, 'error': f'Auth error: {str(e)}'}
-    try:
         payload = {}
         if start_time:
             payload['start_time'] = start_time
@@ -14,7 +10,7 @@ async def zoho_shifts_update_shift(org_id: str, shift_id: str, start_time: str=N
             payload['employee_id'] = employee_id
         if notes is not None:
             payload['notes'] = notes
-        resp = await nexus_call('PUT', f'https://shifts.zoho.com/api/v1/{org_id}/shifts/{shift_id}', headers={'Authorization': f'Zoho-oauthtoken {access_token}', 'Content-Type': 'application/json'}, json=payload)
+        resp = await nexus_call('PUT', f'https://shifts.zoho.com/api/v1/{org_id}/shifts/{shift_id}', headers={'Content-Type': 'application/json'}, json=payload)
         if resp['status_code'] != 200:
             return {'success': False, 'data': None, 'error': f"Update shift failed: {resp['status_code']} {resp['body']}"}
         return {'success': True, 'data': resp['json'], 'error': None}

--- a/jarviscore/integrations/seed_registry.py
+++ b/jarviscore/integrations/seed_registry.py
@@ -23,6 +23,7 @@ Sources:
 from __future__ import annotations
 
 import ast
+import hashlib
 import json
 import logging
 import os
@@ -955,6 +956,7 @@ def seed_registry(
     registry,
     systems: Optional[List[str]] = None,
     overwrite_verified: bool = False,
+    missing_only: bool = False,
 ) -> Dict[str, Any]:
     """
     Bulk-register all atom functions into the FunctionRegistry.
@@ -963,6 +965,7 @@ def seed_registry(
         registry:           FunctionRegistry instance
         systems:            Optional list of system names to seed (default: all 18)
         overwrite_verified: If False (default), skip atoms already at verified/golden stage
+        missing_only:       Register only atom names absent from the registry
 
     Returns:
         Report dict with registered, skipped, failed counts and details
@@ -997,21 +1000,72 @@ def seed_registry(
         for atom_path in atom_files:
             function_name = atom_path.stem  # filename without .py
             report["total_atoms"] += 1
+            source = atom_path.read_text(encoding="utf-8")
+            existing_metadata = (
+                registry.get_function_metadata(function_name)
+                if registry.has_function(function_name) else None
+            )
 
-            # Skip if already at verified/golden and overwrite not requested
-            if not overwrite_verified and registry.has_function(function_name):
-                existing = registry.get_function_metadata(function_name)
-                if existing and existing.get("registry_stage") in ("verified", "golden"):
-                    logger.debug("[Seed] Skipping %s (already %s)", function_name, existing["registry_stage"])
+            if missing_only and existing_metadata:
+                from jarviscore.execution.atom_contract import read_contract
+
+                existing_source = registry.get_function_code(function_name) or ""
+                shipped_hash = hashlib.sha256(source.encode("utf-8")).hexdigest()
+                existing_hash = hashlib.sha256(
+                    existing_source.encode("utf-8")
+                ).hexdigest()
+                existing_contract = read_contract(
+                    existing_source, system=system, expected_name=function_name
+                )
+                shipped_contract = read_contract(
+                    source, system=system, expected_name=function_name
+                )
+                catalogue_managed = bool(
+                    existing_metadata.get("catalogue_managed")
+                    or (
+                        existing_metadata.get("agent_id") is None
+                        and existing_metadata.get("repair_of_version") is None
+                    )
+                )
+                current_catalogue_hash = existing_metadata.get(
+                    "catalogue_source_hash"
+                )
+                repaired_since_seed = bool(
+                    existing_metadata.get("repair_of_version")
+                    or (
+                        current_catalogue_hash
+                        and current_catalogue_hash != existing_hash
+                    )
+                )
+                converged = existing_hash == shipped_hash
+                if (
+                    not shipped_contract.ok
+                    or (existing_contract.ok and (
+                        converged or not catalogue_managed or repaired_since_seed
+                    ))
+                ):
                     report["skipped"].append({
                         "function": function_name,
                         "system": system,
-                        "reason": f"already {existing['registry_stage']}",
+                        "reason": "already registered",
+                    })
+                    continue
+
+            # Skip if already at verified/golden and overwrite not requested
+            if not overwrite_verified and existing_metadata and not missing_only:
+                if existing_metadata.get("registry_stage") in ("verified", "golden"):
+                    logger.debug(
+                        "[Seed] Skipping %s (already %s)",
+                        function_name, existing_metadata["registry_stage"],
+                    )
+                    report["skipped"].append({
+                        "function": function_name,
+                        "system": system,
+                        "reason": f"already {existing_metadata['registry_stage']}",
                     })
                     continue
 
             # Read and validate syntax
-            source = atom_path.read_text(encoding="utf-8")
             try:
                 ast.parse(source)
             except SyntaxError as e:
@@ -1033,6 +1087,10 @@ def seed_registry(
                 "tags": [system, meta["category"]],
                 "strategy": "sandbox",
                 "source": "external_import" if meta["status"] == "verified" else "framework_authored",
+                "catalogue_managed": True,
+                "catalogue_source_hash": hashlib.sha256(
+                    source.encode("utf-8")
+                ).hexdigest(),
             }
 
             try:
@@ -1043,7 +1101,7 @@ def seed_registry(
                 )
                 if success:
                     # External atoms start as verified, new ones as candidate
-                    if meta["status"] == "verified":
+                    if meta["status"] == "verified" and not existing_metadata:
                         registry.update_function_metadata(function_name, {
                             "registry_stage": "verified",
                             "success_count": 1,

--- a/jarviscore/kernel/cognition.py
+++ b/jarviscore/kernel/cognition.py
@@ -46,6 +46,9 @@ THINKING_TOOLS = frozenset({
     "get_context",
     "inspect_error",
     "scan_peers",
+    "list_peers",
+    "inspect_workflow",
+    "read_workflow_step",
     "read_mailbox",
     # Re-reading a retained tool result is recall, not action (issue #57).
     "read_turn_result",
@@ -58,6 +61,8 @@ ACTION_TOOLS = frozenset({
     "execute_code",
     "send_message",
     "send_mailbox",
+    "ask_peer",
+    "broadcast_update",
     "broadcast",
     "done",
 })

--- a/jarviscore/kernel/defaults/coder.py
+++ b/jarviscore/kernel/defaults/coder.py
@@ -415,6 +415,10 @@ atom.
             }
             for item in state.tool_history
         ]
+        dependency_artifacts = state.context.get("previous_step_results") or {}
+        dependency_interpretations = (
+            state.context.get("previous_step_interpretations") or {}
+        )
         prompt = (
             "Review one proposed external effect against source intent and gathered "
             "evidence. This is an agent reasoning decision, not provider routing. "
@@ -427,7 +431,12 @@ atom.
             '{"decision":"allow|redirect|already_satisfied","reason":"...",'
             '"missing_evidence":["..."],"supporting_evidence":["..."]}.\n\n'
             f"Source objective: {state.context.get('objective') or state.task}\n"
+            f"Scoped step task: {state.task}\n"
             f"Source context: {json.dumps(state.context.get('source_context', {}), default=str)}\n"
+            "Authoritative dependency artifacts: "
+            f"{json.dumps(dependency_artifacts, default=str)}\n"
+            "Authoritative dependency interpretations: "
+            f"{json.dumps(dependency_interpretations, default=str)}\n"
             f"Proposed effect: {atom.policy.effect}\n"
             f"Tool: {tool_name}\n"
             f"Parameters: {json.dumps(params, default=str)}\n"

--- a/jarviscore/kernel/defaults/coder.py
+++ b/jarviscore/kernel/defaults/coder.py
@@ -1,3 +1,4 @@
+from jarviscore.kernel.gate import GateEvidence
 """
 CoderSubAgent — Production-grade code generation and execution specialist.
 
@@ -16,12 +17,12 @@ Doctrine:
 """
 
 import ast
+import json
 import logging
 import time
 from typing import Any, Dict, List, Optional, Tuple
 
 from jarviscore.kernel.subagent import BaseSubAgent
-from jarviscore.kernel.gate import GateEvidence
 from jarviscore.kernel.state import KernelState
 
 logger = logging.getLogger(__name__)
@@ -171,13 +172,20 @@ Writing to it, after you succeed:
   enters as a candidate, becomes verified on its first success and golden after
   five, and from then on it is what the next agent finds instead of starting
   from a blank file.
-- Take `auth_info` as the first parameter and authenticate with it, the way the
-  catalogue does, so what you wrote can become a callable capability rather than
-  a snippet.
+- Use `nexus_call` and never accept or retrieve credentials in atom source.
 - Name it for what it does to what: `hubspot_list_contacts`, not `run_task` or
   `main`. The name is how it will be found.
 - Code that only reshapes local data is not worth keeping. An atom earns its
   place by reaching a system.
+
+When an offered atom fails, first decide what the evidence means. Authentication
+or consent, invalid task input, account permissions, rate limits, and a truthful
+provider refusal do not prove its implementation is wrong. If the source itself
+is wrong or stale, call `inspect_atom_for_repair`, correct that exact function,
+submit it with `repair_atom`, and register the successful candidate under the
+same name. The registry keeps the old version as history and makes the proven
+replacement the current version. Never create a parallel name to hide a broken
+atom.
 
 ## CRITICAL RULES (read all before acting)
 
@@ -306,6 +314,7 @@ Writing to it, after you succeed:
 
         # CandidateStore — versioned in-memory record of each code attempt
         self._candidates: List[Dict[str, Any]] = []
+        self._failed_atom_calls: Dict[str, Dict[str, Any]] = {}
 
         # Hard gate flag — delegate_research blocked until first write_code
         self._has_written_code: bool = False
@@ -332,62 +341,32 @@ Writing to it, after you succeed:
         return prompt
 
     def _build_user_prompt(self, state: KernelState, context_block: str) -> str:
-        """Add a coder-specific proof-of-work contract to the generic OODA prompt."""
+        """Keep provider work evidence-backed without forcing irrelevant execution."""
         prompt = super()._build_user_prompt(state, context_block)
-        offered = set(getattr(self, "_atom_tools", ()))
-        has_execution = any(
-            (tool_res.tool_name == "execute_code" or tool_res.tool_name in offered)
-            and tool_res.succeeded
-            for tool_res in state.tool_history
-        )
-        if has_execution:
-            return prompt
-
-        validated_candidates = [
-            tool_res.tool_output.get("candidate_id")
-            for tool_res in state.tool_history
-            if (
-                tool_res.tool_name == "write_code"
-                and tool_res.succeeded
-                and isinstance(tool_res.tool_output, dict)
-                and tool_res.tool_output.get("status") == "validated"
+        first_attempt = ""
+        if not state.tool_history:
+            offered_atoms = sorted(getattr(self, "_atom_tools", ()))
+            useful = offered_atoms + [
+                name for name in (
+                    "ask_capability", "ask_peer", "inspect_workflow", "write_code"
+                )
+                if name in self._tools
+            ]
+            first_attempt = (
+                "\n\nYou have not investigated this task yet. Your next response MUST "
+                "use one relevant tool before emitting DONE or a final artifact. "
+                f"Relevant available paths include: {', '.join(useful) or 'the registered tools above'}. "
+                "Choose from the current gap; do not call a tool merely to make the run pass."
             )
-        ]
-        if validated_candidates:
-            next_action = (
-                f"You already have validated candidate_id={validated_candidates[-1]}. "
-                "Your next response MUST call execute_code with that candidate_id."
-            )
-        elif offered:
-            # Mandating write_code here is what sent an agent to reimplement a
-            # capability it had already been given.
-            next_action = (
-                f"This system's proven capabilities are available to you: "
-                f"{', '.join(sorted(offered))}. Call one if it does what the task "
-                "needs. Otherwise your next response MUST call write_code with "
-                "executable Python code, then execute_code with the returned "
-                "candidate_id."
-            )
-        else:
-            next_action = (
-                "Your next response MUST call write_code with executable Python code. "
-                "After write_code validates it, call execute_code with the returned candidate_id."
-            )
-
         return (
             f"{prompt}\n\n"
-            "## CODER PROOF-OF-WORK GATE\n"
-            "DONE/RESULT is disabled until execute_code has returned status=success.\n"
-            f"{next_action}\n\n"
-            "Valid next response format:\n"
-            "THOUGHT: I need executable proof before completion.\n"
-            "TOOL: write_code\n"
-            "PARAMS: {\"code\": \"result = {'success': True, 'data': ...}\"}\n\n"
-            "If you already have a candidate_id:\n"
-            "THOUGHT: I have validated code and must execute it.\n"
-            "TOOL: execute_code\n"
-            "PARAMS: {\"candidate_id\": <id>}\n\n"
-            "Do not emit DONE. Do not emit RESULT. Do not answer in prose."
+            "## EXECUTION INTEGRITY\n"
+            "Use provider capabilities or executable code when a claim requires live "
+            "evidence. If a meaningful action fails, inspect the error, ask a capable "
+            "peer when useful, and try a relevant alternative. If no reasonable path "
+            "remains, finish with the honest blocker and the evidence gathered. Never "
+            "run unrelated code merely to demonstrate that execution works."
+            f"{first_attempt}"
         )
 
     # ─────────────────────────────────────────────────────────────
@@ -399,78 +378,111 @@ Writing to it, after you succeed:
         state: KernelState,
         parsed: Dict[str, Any],
     ) -> tuple:
-        """
-        Enforce the "Verify Before Done" proof-of-work contract.
-        """
-        # Exemption: If the agent successfully delegated to research, it is handing
-        # control back to the Kernel. It must be allowed to complete.
-        if state.tool_history:
-            last_tool = state.tool_history[-1]
-            if last_tool.tool_name == "delegate_research" and last_tool.succeeded:
-                return (True, "")
-
-        # Scan history for execution proof
-        has_executed = False
-        last_success_output = None
-        execute_calls = 0
-        write_calls = 0
-        atom_calls = 0
-        for tool_res in state.tool_history:
-            if tool_res.tool_name == "execute_code":
-                execute_calls += 1
-            elif tool_res.tool_name == "write_code":
-                write_calls += 1
-            elif tool_res.tool_name in getattr(self, "_atom_tools", ()):
-                # A capability call is a run against a live provider, which is
-                # the thing this gate exists to require. Demanding write_code as
-                # well would mean an agent that used the catalogue correctly gets
-                # told to go and reimplement it.
-                atom_calls += 1
-                if tool_res.succeeded:
-                    has_executed = True
-                    last_success_output = tool_res.tool_output
-            if tool_res.tool_name == "execute_code" and tool_res.succeeded:
-                has_executed = True
-                last_success_output = tool_res.tool_output
-            elif (
-                tool_res.tool_name == "write_code"
-                and tool_res.succeeded
-                and isinstance(tool_res.tool_output, dict)
-                and isinstance(tool_res.tool_output.get("execution_result"), dict)
-                and tool_res.tool_output["execution_result"].get("status") == "success"
-            ):
-                has_executed = True
-                last_success_output = tool_res.tool_output["execution_result"]
-
-        if not has_executed:
+        """Require investigation and one bounded peer review of blocked work."""
+        if not state.tool_history:
             return (
                 False,
                 GateEvidence(
-                    check="proof_of_work",
+                    check="meaningful_attempt",
                     requirement=(
-                        "one execute_code call that succeeded, one write_code call "
-                        "whose execution_result reports success, or one successful "
-                        "capability call against the declared system"
+                        "use a relevant provider, code, workflow, mailbox, or peer tool "
+                        "before claiming success or a blocker"
                     ),
-                    observed={
-                        "tool_calls": len(state.tool_history),
-                        "execute_code_calls": execute_calls,
-                        "write_code_calls": write_calls,
-                        "capability_calls": atom_calls,
-                        "successful_executions": 0,
-                    },
+                    observed={"tool_calls": 0},
                 ),
             )
+        return super()._can_complete(state, parsed)
 
-        # The gate checks that proof exists. It does not replace the answer with
-        # it: overwriting RESULT with the sandbox return value discarded the
-        # agent's conclusion at the one moment it had one, so a Drive listing
-        # reached the person as a dict of ids however well the agent had read it.
-        # The proof stays reachable as evidence for anyone who wants it.
-        if last_success_output is not None:
-            parsed["evidence"] = last_success_output.get("output", last_success_output)
+    async def _pre_execute_hook(
+        self,
+        tool_name: str,
+        params: Dict[str, Any],
+        state: KernelState,
+    ) -> Optional[Dict[str, Any]]:
+        atom = getattr(self, "_atoms", {}).get(tool_name)
+        if atom is None or atom.policy.effect not in {
+            "write", "notify", "destructive"
+        }:
+            return None
+        from jarviscore.orchestration.envelopes import EffectIntentDecision
 
-        return (True, "")
+        evidence = [
+            {
+                "tool": item.tool_name,
+                "input": item.tool_input,
+                "output": item.tool_output,
+                "error": item.error,
+            }
+            for item in state.tool_history
+        ]
+        prompt = (
+            "Review one proposed external effect against source intent and gathered "
+            "evidence. This is an agent reasoning decision, not provider routing. "
+            "Allow only when the proposed effect is requested and every conditional "
+            "precondition needed for it is supported by evidence. Do not infer absence "
+            "of one resource from absence of another. Return already_satisfied when "
+            "the gathered evidence establishes that the requested real-world outcome "
+            "already exists, so repeating the effect would be redundant. Redirect when "
+            "a relevant observation or verification is still missing. Return only JSON: "
+            '{"decision":"allow|redirect|already_satisfied","reason":"...",'
+            '"missing_evidence":["..."],"supporting_evidence":["..."]}.\n\n'
+            f"Source objective: {state.context.get('objective') or state.task}\n"
+            f"Source context: {json.dumps(state.context.get('source_context', {}), default=str)}\n"
+            f"Proposed effect: {atom.policy.effect}\n"
+            f"Tool: {tool_name}\n"
+            f"Parameters: {json.dumps(params, default=str)}\n"
+            f"Evidence so far: {json.dumps(evidence, default=str)}"
+        )
+        try:
+            call_kwargs = {
+                "messages": [{"role": "user", "content": prompt}],
+                "response_format": {"type": "json_object"},
+                **(
+                    {"model": self.llm_client.nano_model}
+                    if getattr(self.llm_client, "nano_model", None)
+                    else {}
+                ),
+            }
+            try:
+                response = await self.llm_client.generate(**call_kwargs)
+            except TypeError:
+                call_kwargs.pop("response_format", None)
+                response = await self.llm_client.generate(**call_kwargs)
+            content = (
+                response.get("content", "")
+                if isinstance(response, dict)
+                else str(response)
+            )
+            tokens = response.get("tokens", {}) if isinstance(response, dict) else {}
+            cognition = getattr(self, "_cognition", None)
+            if cognition is not None:
+                cognition.track_usage(
+                    "effect_intent_review",
+                    tokens=int(tokens.get("total", 0) or 0),
+                )
+            decision = EffectIntentDecision.from_response(content)
+        except Exception as exc:
+            return {
+                "status": "blocked",
+                "error": f"Effect intent review failed closed: {exc}",
+                "semantic_error": "EFFECT_INTENT_REVIEW_INVALID",
+            }
+        if decision.decision == "allow":
+            return None
+        if decision.decision == "already_satisfied":
+            return {
+                "status": "success",
+                "skipped": True,
+                "semantic_outcome": "EFFECT_ALREADY_SATISFIED",
+                "reason": decision.reason,
+                "supporting_evidence": list(decision.supporting_evidence),
+            }
+        return {
+            "status": "blocked",
+            "error": decision.reason,
+            "semantic_error": "EFFECT_INTENT_REDIRECT",
+            "missing_evidence": list(decision.missing_evidence),
+        }
 
     # ─────────────────────────────────────────────────────────────
     # Tool Registration
@@ -492,6 +504,27 @@ Writing to it, after you succeed:
             (
                 "Generate Python code for a task. Runs ValidationLayer automatically. "
                 "Params: {\"code\": \"<python code>\", \"system\": \"<optional provider name>\"}"
+            ),
+            phase="thinking",
+        )
+        self.register_tool(
+            "inspect_atom_for_repair",
+            self._tool_inspect_atom_for_repair,
+            (
+                "Read the exact registered source and failure evidence for an atom "
+                "that failed in this run. Params: {\"function_name\": \"<atom_name>\"}"
+            ),
+            phase="thinking",
+        )
+        self.register_tool(
+            "repair_atom",
+            self._tool_repair_atom,
+            (
+                "Submit corrected source for an atom that failed in this run. The "
+                "replacement must preserve its registered name and provider contract; "
+                "it is executed against the original invocation before it can replace "
+                "the registry version. Params: {\"function_name\": \"<atom_name>\", "
+                "\"code\": \"<corrected source>\"}"
             ),
             phase="thinking",
         )
@@ -565,7 +598,7 @@ Writing to it, after you succeed:
         """Execute tools, auto-running validated code when runtime proof is required."""
         result = await super()._execute_tool(tool_name, params)
         if (
-            tool_name != "write_code"
+            tool_name not in {"write_code", "repair_atom"}
             or not isinstance(result, dict)
             or result.get("status") != "validated"
             or not self.sandbox
@@ -602,6 +635,98 @@ Writing to it, after you succeed:
             merged["status"] = "error"
             merged["error"] = execution_result.get("error", "Code execution failed.")
         return merged
+
+    def _tool_inspect_atom_for_repair(
+        self,
+        function_name: str,
+        **kwargs,
+    ) -> Dict[str, Any]:
+        """Expose current source only after that exact atom failed in this run."""
+        failure = self._failed_atom_calls.get(function_name)
+        if failure is None or self.code_registry is None:
+            return {
+                "status": "error",
+                "error": f"No repairable failure for `{function_name}` was observed in this run.",
+                "semantic_error": "ATOM_REPAIR_NOT_OBSERVED",
+            }
+        source = self.code_registry.get_function_code(function_name)
+        metadata = self.code_registry.get_function_metadata(function_name) or {}
+        if not source:
+            return {
+                "status": "error",
+                "error": f"Registered source for `{function_name}` is unavailable.",
+                "semantic_error": "ATOM_SOURCE_UNAVAILABLE",
+            }
+        return {
+            "status": "success",
+            "function_name": function_name,
+            "system": metadata.get("system"),
+            "version": metadata.get("version"),
+            "source": source,
+            "failed_invocation": failure.get("params", {}),
+            "failure": failure.get("error"),
+        }
+
+    def _tool_repair_atom(
+        self,
+        function_name: str,
+        code: str,
+        **kwargs,
+    ) -> Dict[str, Any]:
+        """Validate a replacement tied to one observed atom failure/version."""
+        from jarviscore.execution.atom_contract import read_contract
+
+        failure = self._failed_atom_calls.get(function_name)
+        if failure is None or self.code_registry is None:
+            return {
+                "status": "error",
+                "error": f"No repairable failure for `{function_name}` was observed in this run.",
+                "semantic_error": "ATOM_REPAIR_NOT_OBSERVED",
+            }
+        metadata = self.code_registry.get_function_metadata(function_name) or {}
+        base_version = metadata.get("version")
+        if base_version != failure.get("version"):
+            return {
+                "status": "error",
+                "error": (
+                    f"`{function_name}` changed from version {failure.get('version')} "
+                    f"to {base_version}; inspect the current version before repairing it."
+                ),
+                "semantic_error": "ATOM_REPAIR_STALE",
+            }
+        contract = read_contract(
+            code,
+            system=str(metadata.get("system") or ""),
+            expected_name=function_name,
+        )
+        if not contract.ok or contract.atom is None or contract.atom.legacy:
+            return {
+                "status": "validation_failed",
+                "error": "; ".join(contract.errors) or "Replacement atom contract is invalid.",
+                "issues": list(contract.errors),
+            }
+        candidate_id = len(self._candidates) + 1
+        self._candidates.append({
+            "candidate_id": candidate_id,
+            "code": code,
+            "system": metadata.get("system"),
+            "status": "validated",
+            "function_name": function_name,
+            "repair_of": function_name,
+            "base_version": base_version,
+            "invocation_params": dict(failure.get("params") or {}),
+            "ts": time.time(),
+        })
+        return {
+            "candidate_id": candidate_id,
+            "status": "validated",
+            "function_name": function_name,
+            "base_version": base_version,
+            "message": (
+                f"Replacement for `{function_name}` v{base_version} is contract-valid. "
+                "It must execute successfully before registry replacement."
+            ),
+        }
 
     # ─────────────────────────────────────────────────────────────
     # Tool: check_registry
@@ -865,6 +990,28 @@ Writing to it, after you succeed:
                 }
             exec_code = candidate["code"]
 
+        if candidate and candidate.get("repair_of"):
+            from jarviscore.execution.atom_contract import invocation, read_contract
+
+            contract = read_contract(
+                exec_code or "",
+                system=str(candidate.get("system") or ""),
+                expected_name=str(candidate["repair_of"]),
+            )
+            if not contract.ok or contract.atom is None:
+                return {
+                    "status": "error",
+                    "error": "; ".join(contract.errors) or "Replacement atom contract is invalid.",
+                    "semantic_error": "ATOM_REPAIR_INVALID",
+                }
+            repair_atom = contract.atom
+            invocation_params = dict(candidate.get("invocation_params") or {})
+            exec_code = f"{exec_code}\n\n{invocation(repair_atom, invocation_params)}"
+            kwargs["_internal_atom"] = (
+                repair_atom,
+                self._atom_action_id(repair_atom, invocation_params),
+            )
+
         if not exec_code:
             return {"status": "error", "error": "No code provided to execute_code."}
 
@@ -891,6 +1038,29 @@ Writing to it, after you succeed:
             for k in SAFE_KEYS:
                 if k in self._run_context:
                     exec_context[k] = self._run_context[k]
+        internal_atom = kwargs.get("_internal_atom")
+        offered_atoms = getattr(self, "_atoms", {})
+        repair_authorized = bool(
+            candidate
+            and candidate.get("repair_of")
+            and isinstance(internal_atom, tuple)
+            and len(internal_atom) == 2
+            and internal_atom[0].name == candidate.get("repair_of")
+        )
+        if (
+            isinstance(internal_atom, tuple)
+            and len(internal_atom) == 2
+            and (
+                internal_atom[0] in offered_atoms.values()
+                or repair_authorized
+            )
+        ):
+            atom, action_id = internal_atom
+            exec_context["_mutation_authority"] = {
+                "atom": atom.name,
+                "action_id": str(action_id),
+                "effect": atom.policy.effect,
+            }
 
         start_ts = time.time()
         result = await self.sandbox.execute(exec_code, context=exec_context or None)
@@ -947,6 +1117,7 @@ Writing to it, after you succeed:
             self.code_registry
             and candidate
             and candidate.get("function_name")
+            and not candidate.get("repair_of")
             and result.get("status") in ("success", "failure")
             and not result.get("access_failure")
         ):
@@ -984,12 +1155,46 @@ Writing to it, after you succeed:
         if not self.code_registry:
             return {"status": "error", "error": "No code_registry configured."}
 
-        final_code = code
-        if candidate_id is not None:
-            candidate = self._get_candidate(candidate_id)
-            if candidate:
-                final_code = candidate.get("code", code)
-                system = system or candidate.get("system")
+        if candidate_id is None:
+            return {
+                "status": "error",
+                "error": "candidate_id is required; registry writes require successful execution evidence.",
+                "semantic_error": "REGISTRY_EXECUTION_PROOF_REQUIRED",
+            }
+        candidate = self._get_candidate(candidate_id)
+        if candidate is None:
+            return {"status": "error", "error": f"candidate_id={candidate_id} not found."}
+        if candidate.get("status") != "success":
+            return {
+                "status": "error",
+                "error": (
+                    f"candidate_id={candidate_id} has status={candidate.get('status')!r}; "
+                    "execute_code must succeed before registration."
+                ),
+                "semantic_error": "REGISTRY_EXECUTION_PROOF_REQUIRED",
+            }
+        final_code = candidate.get("code", code)
+        system = system or candidate.get("system")
+        repair_of = candidate.get("repair_of")
+        if repair_of:
+            if function_name != repair_of:
+                return {
+                    "status": "error",
+                    "error": f"A repair for `{repair_of}` cannot be registered as `{function_name}`.",
+                    "semantic_error": "ATOM_REPAIR_IDENTITY_MISMATCH",
+                }
+            current = self.code_registry.get_function_metadata(repair_of) or {}
+            if current.get("version") != candidate.get("base_version"):
+                return {
+                    "status": "error",
+                    "error": (
+                        f"`{repair_of}` changed after this repair began; inspect and repair "
+                        "the current registry version."
+                    ),
+                    "semantic_error": "ATOM_REPAIR_STALE",
+                }
+            description = description or str(current.get("description") or "")
+            capabilities = capabilities or list(current.get("capabilities") or [])
 
         if not final_code:
             return {"status": "error", "error": "No code to register."}
@@ -1019,6 +1224,11 @@ Writing to it, after you succeed:
             "agent_id": self.agent_id,
             "tags": [system] if system else [],
         }
+        if repair_of:
+            metadata["repair_of_version"] = candidate.get("base_version")
+            metadata["repair_failure"] = (
+                self._failed_atom_calls.get(str(repair_of), {}).get("error")
+            )
 
         success = self.code_registry.register_function(
             function_name=function_name,
@@ -1028,14 +1238,16 @@ Writing to it, after you succeed:
         self._registered_this_run = bool(success)
 
         if success:
+            self.code_registry.update_execution_stats(
+                function_name,
+                success=True,
+                execution_time=float(candidate.get("execution_time") or 0.0),
+            )
             # Registry identity for the result envelope (issue #88): the
             # promoted function's name IS its registry id.
             getattr(self, "_dispatch_metadata", {})["function_id"] = function_name
-            if candidate_id is not None:
-                candidate = self._get_candidate(candidate_id)
-                if candidate:
-                    candidate["function_name"] = function_name
-                    candidate["status"] = "registered"
+            candidate["function_name"] = function_name
+            candidate["status"] = "registered"
 
             return {
                 "status": "registered",
@@ -1299,7 +1511,14 @@ Writing to it, after you succeed:
         self._current_task = str(task)
         self._run_context = context or {}
         await self._sync_connections()
-        self._prepare_access(self._resolved_system())
+        declared_systems = [
+            str(value) for value in self._run_context.get("systems", [])
+            if str(value)
+        ]
+        if len(declared_systems) > 1:
+            self._prepare_access_for_systems(declared_systems)
+        else:
+            self._prepare_access(self._resolved_system())
         try:
             return await super().run(task, context, max_turns, model, **kwargs)
         finally:
@@ -1329,6 +1548,15 @@ Writing to it, after you succeed:
         atoms: Dict[str, Any] = {}
         if not system or not self.code_registry:
             return atoms
+        requested_effect = str(self._run_context.get("effect") or "").strip()
+        allowed_effects = {
+            "read": {"read"},
+            "propose": {"read"},
+            "write": {"read", "write"},
+            "notify": {"read", "notify"},
+            "destructive": {"read", "destructive"},
+            "final_response": {"read"},
+        }.get(requested_effect)
         for entry in self.code_registry.get_functions_by_system(system):
             name = entry.get("function_name")
             code = self.code_registry.get_function_code(name) if name else None
@@ -1338,6 +1566,8 @@ Writing to it, after you succeed:
             atom = contract.atom
             # Only the current shape is offered; a legacy atom cannot be called.
             if not contract.ok or atom is None or atom.legacy:
+                continue
+            if allowed_effects is not None and atom.policy.effect not in allowed_effects:
                 continue
             atoms[name] = atom
         return atoms
@@ -1349,18 +1579,22 @@ Writing to it, after you succeed:
         sometimes skip, and it did. These arrive the way every other tool does,
         so using them is the default path rather than a decision.
         """
+        self._offer_system_capabilities_for([system] if system else [])
+
+    def _offer_system_capabilities_for(self, systems: List[str]) -> None:
+        """Offer current-effect atoms from every connected authorized provider."""
         for name in getattr(self, "_atom_tools", ()):
             self._tools.pop(name, None)
         self._atom_tools = []
-        self._atoms = self._valid_atoms(system)
-        if not system:
-            return
+        self._atoms = {}
+        for system in systems:
+            self._atoms.update(self._valid_atoms(system))
 
         for name, atom in self._atoms.items():
             self.register_tool(
                 name,
                 self._atom_tool(name),
-                f"{atom.describe()} Runs against {system} with "
+                f"{atom.describe()} Runs against {atom.system} with "
                 "credentials resolved outside the sandbox; you never handle them.",
                 phase="action",
             )
@@ -1368,8 +1602,8 @@ Writing to it, after you succeed:
 
         if self._atom_tools:
             self._log.info(
-                "Offering %d %s capability(ies): %s",
-                len(self._atom_tools), system, ", ".join(self._atom_tools),
+                "Offering %d capability(ies) across %s: %s",
+                len(self._atom_tools), ", ".join(systems), ", ".join(self._atom_tools),
             )
 
     async def _sync_connections(self) -> None:
@@ -1414,7 +1648,7 @@ Writing to it, after you succeed:
 
     def _connection_handle(self, system: str) -> str:
         """What the sandbox should call through for this system."""
-        manager = self.auth_manager
+        manager = getattr(self, "auth_manager", None)
         found = manager.connection_handle(system) if manager is not None and hasattr(manager, "connection_handle") else None
         # Local-vault mode: the handle is the provider name.
         return found if isinstance(found, str) and found else system
@@ -1437,6 +1671,21 @@ Writing to it, after you succeed:
             if self._run_context.get("_nexus_provider") != system:
                 self._run_context["_nexus_connection_id"] = self._connection_handle(system)
                 self._run_context["_nexus_provider"] = system
+
+    def _prepare_access_for_systems(self, systems: List[str]) -> None:
+        """Expose read-capable connected systems without choosing one for the agent."""
+        from jarviscore.nexus.store import ConnectionState
+
+        unique = list(dict.fromkeys(systems))
+        connected = [
+            system for system in unique
+            if self._connection_state(system) is ConnectionState.CONNECTED
+        ]
+        self._offered_system = ",".join(unique)
+        self._offer_system_capabilities_for(connected)
+        self._offer_access_request()
+        self._run_context.pop("_nexus_connection_id", None)
+        self._run_context.pop("_nexus_provider", None)
 
     def _refresh_offerings_for(self, system: Optional[str]) -> Optional[str]:
         """Re-offer for a system named after the run began; note what changed."""
@@ -1625,14 +1874,22 @@ Writing to it, after you succeed:
             prior = self._idempotent_result(action_id)
             if prior is not None:
                 return prior
+            self._run_context["_nexus_connection_id"] = self._connection_handle(
+                atom.system
+            )
+            self._run_context["_nexus_provider"] = atom.system
             # Runs where any other sandbox code runs: nexus_call attaches the
             # credential there, so proving an atom is just running it.
             result = await self._tool_execute_code(
                 code=f"{code}\n\n{invocation(atom, params)}",
                 description=f"{name} via {atom.system}",
+                _internal_atom=(atom, action_id),
             )
-            self._record_atom_outcome(name, result)
-            if atom.policy.effect == "destructive" and result.get("status") == "success":
+            self._record_atom_outcome(name, result, params=params)
+            if (
+                atom.policy.effect in {"write", "notify", "destructive"}
+                and result.get("status") == "success"
+            ):
                 self._save_idempotent_result(action_id, result)
             return result
         call.__name__ = name
@@ -1662,7 +1919,13 @@ Writing to it, after you succeed:
         if store is not None and hasattr(store, "save_atom_execution"):
             store.save_atom_execution(action_id, result)
 
-    def _record_atom_outcome(self, name: str, result: Dict[str, Any]) -> None:
+    def _record_atom_outcome(
+        self,
+        name: str,
+        result: Dict[str, Any],
+        *,
+        params: Optional[Dict[str, Any]] = None,
+    ) -> None:
         """An atom called as a tool is the evidence its stage is built on.
 
         This is the path agents use once a provider is connected, so leaving it
@@ -1681,5 +1944,18 @@ Writing to it, after you succeed:
                 execution_time=float(result.get("execution_time") or 0.0),
                 error_type=result.get("error_type"),
             )
+            if status == "failure":
+                metadata = self.code_registry.get_function_metadata(name) or {}
+                self._failed_atom_calls[name] = {
+                    "version": metadata.get("version"),
+                    "params": dict(params or {}),
+                    "error": result.get("error"),
+                }
+                result["atom_repair"] = {
+                    "available": True,
+                    "function_name": name,
+                    "version": metadata.get("version"),
+                    "next_tool": "inspect_atom_for_repair",
+                }
         except Exception as exc:
             logger.warning("Failed to record outcome for atom %s: %s", name, exc)

--- a/jarviscore/kernel/defaults/communicator.py
+++ b/jarviscore/kernel/defaults/communicator.py
@@ -80,6 +80,7 @@ Your job: transform raw data into clear, actionable output for your audience.
         blob_storage=None,
     ):
         self.mailbox = mailbox
+        self.peers = None
         self._drafts: List[Dict[str, Any]] = []
         super().__init__(
             agent_id=agent_id,
@@ -231,6 +232,17 @@ Your job: transform raw data into clear, actionable output for your audience.
         if not message:
             return {"status": "error", "error": "Missing message — specify what to send"}
 
+        if self.peers is not None:
+            sent = await self.peers.notify(
+                peer_role,
+                {"message": message, "priority": priority},
+            )
+            return {
+                "status": "sent" if sent else "error",
+                "peer": peer_role,
+                "priority": priority,
+                **({} if sent else {"error": "Peer was not found or unavailable"}),
+            }
         if not self.mailbox:
             return {"status": "error", "error": "No mailbox configured"}
 

--- a/jarviscore/kernel/hitl.py
+++ b/jarviscore/kernel/hitl.py
@@ -42,10 +42,8 @@ class AdaptiveHITLPolicy:
     """
     Decides when the kernel should pause for human input.
 
-    Triggers (any match → escalate):
-      - reason_code in reason_codes
-      - confidence < max_confidence   (agent not confident enough)
-      - risk_score > min_risk_score   (action too risky to auto-proceed)
+        HITL is admissible only for one of the canonical human-only categories.
+        Confidence, token spend, and routine execution failure never qualify.
 
     Default: disabled — agents never escalate unless you turn this on.
 
@@ -72,6 +70,8 @@ class AdaptiveHITLPolicy:
         reason_code: Optional[str] = None,
         confidence: Optional[float] = None,
         risk_score: Optional[float] = None,
+        autonomous_paths_exhausted: bool = False,
+        human_exclusive: bool = False,
     ) -> Tuple[bool, str]:
         """
         Evaluate whether to escalate to a human.
@@ -82,19 +82,18 @@ class AdaptiveHITLPolicy:
         if not self.enabled:
             return False, ""
 
-        # Reason code match
-        if reason_code and self.reason_codes and reason_code in self.reason_codes:
-            return True, f"reason_code:{reason_code}"
+        allowed = {"auth_required", "data_required", "critical_action"}
+        category = str(reason_code or "")
+        if category not in allowed:
+            return False, ""
+        if self.reason_codes and category not in self.reason_codes:
+            return False, ""
+        if category == "data_required" and not (
+            autonomous_paths_exhausted and human_exclusive
+        ):
+            return False, ""
+        return True, f"category:{category}"
 
-        # Low confidence
-        if confidence is not None and confidence < self.max_confidence:
-            return True, f"low_confidence:{confidence:.2f}<{self.max_confidence:.2f}"
-
-        # High risk
-        if risk_score is not None and risk_score > self.min_risk_score:
-            return True, f"high_risk:{risk_score:.2f}>{self.min_risk_score:.2f}"
-
-        return False, ""
 
 
 __all__ = [

--- a/jarviscore/kernel/kernel.py
+++ b/jarviscore/kernel/kernel.py
@@ -28,6 +28,7 @@ from jarviscore.context.truth import AgentOutput
 from jarviscore.context.context_manager import ContextManager, BudgetConfig
 from jarviscore.execution.llm import LLMProvider
 from jarviscore.kernel.lease import ExecutionLease, ROLE_LEASE_PROFILES
+from jarviscore.orchestration.envelopes import ExecutionBudget, neutral_context
 from jarviscore.kernel.cognition import AgentCognitionManager
 from jarviscore.context.fidelity import Record, select_whole
 from jarviscore.kernel.state import KernelState
@@ -276,6 +277,8 @@ class Kernel:
         self.blob_storage = blob_storage
         self.config = config or {}
         self.hitl_policy = hitl_policy
+        self.peer_tool: Any = None
+        self.peers: Any = None
 
         # Auth manager — Mesh-injected via requires_auth=True on agent class.
         # AutoAgent forwards it lazily at execute_task() time (because Mesh
@@ -313,6 +316,123 @@ class Kernel:
             min_confidence=float(self.config.get("kernel_router_min_confidence", 0.55)),
             valid_roles=sorted(self._role_lease_profiles),
             role_catalog=self._role_catalog,
+        )
+
+    def attach_mesh_capabilities(self, peers=None, mailbox=None) -> None:
+        """Attach capabilities injected by Mesh after Kernel construction."""
+        self.mailbox = mailbox
+        self.peers = peers
+        self.peer_tool = peers.as_tool() if peers is not None else None
+        for subagent in self._subagent_cache.values():
+            self._attach_mesh_tools(subagent)
+
+    def _attach_mesh_tools(self, subagent) -> None:
+        if hasattr(subagent, "mailbox"):
+            subagent.mailbox = self.mailbox
+        if hasattr(subagent, "peers"):
+            subagent.peers = self.peers
+        if self.mailbox is not None:
+            def read_mailbox(limit: int = 10) -> Dict[str, Any]:
+                bounded = max(1, min(int(limit), 50))
+                messages = self.mailbox.peek(limit=bounded)
+                return {
+                    "status": "success",
+                    "messages": messages,
+                    "count": len(messages),
+                }
+
+            subagent.register_tool(
+                "read_mailbox",
+                read_mailbox,
+                "Read durable unread peer notifications for this agent. Params: {\"limit\": 10}",
+                phase="thinking",
+            )
+        if self.peer_tool is not None:
+            definitions = {item["name"]: item for item in self.peer_tool.schema}
+            for name in self.peer_tool.tool_names:
+                definition = definitions[name]
+
+                async def execute_peer_tool(_name=name, **kwargs):
+                    state = getattr(subagent, "_current_state", None)
+                    source_context = dict(getattr(state, "context", {}) or {})
+                    peer_context = neutral_context(source_context)
+                    workflow_id = str(getattr(state, "workflow_id", "") or "")
+                    step_id = str(getattr(state, "step_id", "") or "")
+                    if workflow_id and workflow_id != "unknown":
+                        peer_context["workflow_id"] = workflow_id
+                    if step_id and step_id != "unknown":
+                        peer_context["peer_requester_step_id"] = step_id
+                    peer_context["peer_requester_role"] = subagent.role
+                    execution_budget = source_context.get("execution_budget")
+                    if hasattr(execution_budget, "to_record"):
+                        execution_budget = execution_budget.to_record()
+                    peer_timeout = (
+                        execution_budget.get("peer_timeout_seconds")
+                        if isinstance(execution_budget, dict)
+                        else None
+                    )
+                    execute_result = getattr(self.peer_tool, "execute_result", None)
+                    if callable(execute_result):
+                        return await execute_result(
+                            _name,
+                            kwargs,
+                            context=peer_context,
+                            timeout_seconds=peer_timeout,
+                        )
+                    legacy_output = await self.peer_tool.execute(
+                        _name, kwargs, context=peer_context
+                    )
+                    return {"status": "success", "output": legacy_output}
+
+                phase = "thinking" if name == "list_peers" else "action"
+                subagent.register_tool(
+                    name, execute_peer_tool, definition["description"], phase=phase
+                )
+        if self.redis_store is None:
+            return
+
+        def current_workflow_id() -> str:
+            state = getattr(subagent, "_current_state", None)
+            return str(getattr(state, "workflow_id", "") or "")
+
+        def inspect_workflow() -> Dict[str, Any]:
+            workflow_id = current_workflow_id()
+            if not workflow_id or workflow_id == "unknown":
+                return {"status": "error", "error": "This dispatch has no workflow identity."}
+            definition = self.redis_store.get_workflow_definition(workflow_id)
+            if definition is None:
+                return {"status": "error", "error": f"Workflow {workflow_id!r} was not found."}
+            live_steps = []
+            for planned in definition.get("steps", []):
+                step_id = str(planned.get("id") or planned.get("step_id") or "")
+                live_steps.append(self.redis_store.get_step_definition(workflow_id, step_id) or planned)
+            return {"status": "success", **definition, "steps": live_steps}
+
+        def read_workflow_step(step_id: str) -> Dict[str, Any]:
+            workflow_id = current_workflow_id()
+            if not workflow_id or workflow_id == "unknown":
+                return {"status": "error", "error": "This dispatch has no workflow identity."}
+            definition = self.redis_store.get_step_definition(workflow_id, step_id)
+            if definition is None:
+                return {"status": "error", "error": f"Step {step_id!r} was not found."}
+            saved = self.redis_store.get_step_output(workflow_id, step_id)
+            return {
+                "status": "success",
+                "step": definition,
+                "output": saved.get("output") if saved else None,
+            }
+
+        subagent.register_tool(
+            "inspect_workflow",
+            inspect_workflow,
+            "Inspect this workflow's source goal, obligations, steps, dependencies, owners, and live statuses. Params: {}",
+            phase="thinking",
+        )
+        subagent.register_tool(
+            "read_workflow_step",
+            read_workflow_step,
+            "Read one step definition and its durable output from this workflow. Params: {\"step_id\": \"<step id>\"}",
+            phase="thinking",
         )
 
     def _get_model_for_tier(self, tier: str, complexity: Optional[str] = None) -> Optional[str]:
@@ -434,6 +554,24 @@ class Kernel:
         if agent_default_role and not use_default_role_as_fallback:
             explicit_role = agent_default_role
 
+        system_name = (context or {}).get("system")
+        system_names = [
+            str(value) for value in (context or {}).get("systems", [])
+            if str(value)
+        ]
+        effect = str((context or {}).get("effect") or "").strip()
+        if system_name and effect in {"write", "notify", "destructive"}:
+            return RoutingDecision(
+                role="coder",
+                confidence=1.0,
+                reason="Provider mutation requires the credentialed Coder harness.",
+            )
+        if system_names and effect in {"read", "propose", "write", "notify", "destructive"}:
+            return RoutingDecision(
+                role="coder",
+                confidence=1.0,
+                reason="Connected-system work requires the credentialed Coder harness.",
+            )
         if explicit_role:
             normalized_role = str(explicit_role).lower().strip()
             if normalized_role not in self._role_lease_profiles:
@@ -443,8 +581,6 @@ class Kernel:
                 confidence=1.0,
                 reason="Explicit planner/profile role.",
             )
-
-        system_name = (context or {}).get("system")
         routing_context = dict(context or {})
         credentialed = False
         if system_name:
@@ -505,7 +641,9 @@ class Kernel:
             logger.debug("[Kernel] Provider inventory unavailable: %s", exc)
             return {}
 
-    def _lease_for_role(self, role: str) -> ExecutionLease:
+    def _lease_for_role(
+        self, role: str, execution_budget: Optional[Dict[str, Any]] = None
+    ) -> ExecutionLease:
         """Create a lease from built-in or application-registered role profile."""
         profile = self._role_lease_profiles.get(role)
         if profile is None:
@@ -513,7 +651,19 @@ class Kernel:
                 f"No lease profile registered for kernel role {role!r}. "
                 "Add config['kernel_role_profiles'][role] or use a built-in role."
             )
-        return ExecutionLease(**profile)
+        lease = ExecutionLease(**profile)
+        if execution_budget is not None:
+            budget = ExecutionBudget.from_record(execution_budget)
+            original_total = max(1, lease.max_total_tokens)
+            capped_total = min(original_total, budget.max_tokens)
+            ratio = capped_total / original_total
+            lease.max_total_tokens = capped_total
+            lease.thinking_budget = max(1, int(lease.thinking_budget * ratio))
+            lease.action_budget = max(1, int(lease.action_budget * ratio))
+            lease.wall_clock_ms = min(
+                lease.wall_clock_ms, int(budget.max_seconds * 1000)
+            )
+        return lease
 
     def _get_or_create_subagent(self, role: str, agent_id: str, step_id: str):
         """Get a cached subagent or create a new one.
@@ -568,7 +718,7 @@ class Kernel:
         )
 
         if role == "coder":
-            return CoderSubAgent(
+            subagent = CoderSubAgent(
                 agent_id=agent_id,
                 llm_client=self.llm_client,
                 sandbox=self.sandbox,
@@ -579,7 +729,7 @@ class Kernel:
                 blob_storage=self.blob_storage,
             )
         elif role == "researcher":
-            return ResearcherSubAgent(
+            subagent = ResearcherSubAgent(
                 agent_id=agent_id,
                 llm_client=self.llm_client,
                 search_client=self.search_client,
@@ -588,7 +738,7 @@ class Kernel:
                 blob_storage=self.blob_storage,
             )
         elif role == "communicator":
-            return CommunicatorSubAgent(
+            subagent = CommunicatorSubAgent(
                 agent_id=agent_id,
                 llm_client=self.llm_client,
                 mailbox=self.mailbox,
@@ -596,7 +746,7 @@ class Kernel:
                 blob_storage=self.blob_storage,
             )
         elif role == "browser":
-            return BrowserSubAgent(
+            subagent = BrowserSubAgent(
                 agent_id=agent_id,
                 llm_client=self.llm_client,
                 headless=self.config.get("browser_headless", True),
@@ -606,6 +756,8 @@ class Kernel:
             )
         else:
             raise ValueError(f"Unknown subagent role: {role}")
+        self._attach_mesh_tools(subagent)
+        return subagent
 
     def _create_memory(self, workflow_id: str, step_id: str, agent_id: str):
         """Create a UnifiedMemory instance for the current step.
@@ -836,7 +988,9 @@ class Kernel:
             )
 
             # 2. DECIDE: create lease, cognition, memory, context manager
-            lease = self._lease_for_role(role)
+            lease = self._lease_for_role(
+                role, enriched_context.get("execution_budget")
+            )
             cognition = AgentCognitionManager(
                 lease=lease,
                 agent_id=agent_id,
@@ -926,47 +1080,37 @@ class Kernel:
                             system_name,
                         )
                     else:
-                        # Deterministic: the task named a provider and neither the
-                        # gateway nor the vault has it. Ask for access instead of
-                        # spending a dispatch on code that cannot authenticate.
                         pending_consent = self._awaiting_consent(str(system_name))
-                        if pending_consent:
-                            summary = (
-                                f"{system_name} is set up, but no account has been "
-                                "connected to it yet, so nothing can be signed. "
-                                "Approving access once unblocks this task."
-                            )
-                            reason = "consent_required"
-                            outcome = "YIELD_CONSENT_REQUIRED"
+                        if pending_consent and self.auth_manager is not None:
+                            # Coder owns the real resumable consent path. It exposes
+                            # request_access with a provider URL and connection ID.
+                            enriched_context["_consent_required_system"] = system_name
                         else:
                             summary = (
                                 f"This task needs {system_name}, which is not "
                                 "connected here. Someone has to grant access to it "
                                 "before the task can run."
                             )
-                            reason = "auth_required"
-                            outcome = "YIELD_AUTH_REQUIRED"
-                        logger.warning(
-                            "[Kernel] %s (system=%s) — register with "
-                            "'jarviscore nexus register %s' or set NEXUS_GATEWAY_URL",
-                            summary, system_name, system_name,
-                        )
-                        await self._cleanup_step(step_id)
-                        return AgentOutput(
-                            status="yield",
-                            summary=summary,
-                            trajectory=[],
-                            metadata={
-                                "tokens": total_tokens,
-                                "cost_usd": total_cost,
-                                "dispatches": dispatches,
-                                "yield_pending": True,
-                                "escalation_reason": reason,
-                                "system": system_name,
-                                "hitl_type": "auth",
-                                "typed_outcome": outcome,
-                            },
-                        )
+                            logger.warning(
+                                "[Kernel] %s (system=%s) — no consent channel is available",
+                                summary, system_name,
+                            )
+                            await self._cleanup_step(step_id)
+                            return AgentOutput(
+                                status="yield",
+                                summary=summary,
+                                trajectory=[],
+                                metadata={
+                                    "tokens": total_tokens,
+                                    "cost_usd": total_cost,
+                                    "dispatches": dispatches,
+                                    "yield_pending": True,
+                                    "escalation_reason": "auth_required",
+                                    "system": system_name,
+                                    "hitl_type": "auth",
+                                    "typed_outcome": "YIELD_AUTH_REQUIRED",
+                                },
+                            )
 
 
             # ── Dispatch subagent with full infrastructure ──
@@ -1032,6 +1176,21 @@ class Kernel:
                         "dispatches": dispatches,
                         "elapsed_ms": (time.time() - start_time) * 1000,
                         "distilled_facts": output.metadata.get("distilled_facts", {}),
+                    },
+                )
+
+            if output.status == "epoch_exhausted":
+                return AgentOutput(
+                    status="epoch_exhausted",
+                    payload=output.payload,
+                    summary=output.summary,
+                    trajectory=output.trajectory,
+                    metadata={
+                        "tokens": total_tokens,
+                        "cost_usd": total_cost,
+                        "dispatches": dispatches,
+                        "typed_outcome": "CONTINUE_NEW_EXECUTION_EPOCH",
+                        "checkpointed": meta.get("checkpointed", False),
                     },
                 )
 
@@ -1129,42 +1288,6 @@ class Kernel:
                         "typed_outcome": "YIELD_AUTH_REQUIRED",
                     },
                 )
-
-            # Check HITL policy for escalation — only on the FINAL dispatch.
-            # Intermediate failures should be retried (possibly with research
-            # findings), not dumped to human review.  Goal-oriented agents get
-            # their recovery from the Planner's replan loop; premature HITL
-            # escalation short-circuits that and floods the review queue.
-            is_final_dispatch = (dispatch_num == max_dispatches - 1)
-            if self.hitl_policy and is_final_dispatch:
-                # Gentler confidence decay: 0.15 per dispatch instead of 0.25.
-                # dispatch 0 → 0.85, dispatch 1 → 0.70, dispatch 2 → 0.55.
-                # This gives the retry loop room to succeed before the
-                # confidence drops below the escalation threshold.
-                dispatch_confidence = max(0.1, 1.0 - (dispatch_num * 0.15))
-                tokens_spent = total_tokens.get("total", 0)
-                risk_from_spend = min(0.9, tokens_spent / 200_000)
-
-                should_escalate, reason = self.hitl_policy.should_escalate(
-                    reason_code="execution_failure",
-                    confidence=dispatch_confidence,
-                    risk_score=risk_from_spend,
-                )
-                if should_escalate:
-                    await self._cleanup_step(step_id)
-                    return AgentOutput(
-                        status="yield",
-                        summary=f"Escalated to human: {reason}",
-                        trajectory=output.trajectory,
-                        metadata={
-                            "tokens": total_tokens,
-                            "cost_usd": total_cost,
-                            "dispatches": dispatches,
-                            "yield_pending": True,
-                            "escalation_reason": reason,
-                            "typed_outcome": "YIELD_HITL_POLICY",
-                        },
-                    )
 
         # All dispatches exhausted
         elapsed = (time.time() - start_time) * 1000

--- a/jarviscore/kernel/subagent.py
+++ b/jarviscore/kernel/subagent.py
@@ -89,6 +89,9 @@ _TOOL_PATTERN = re.compile(r"^TOOL:\s*(.+)$", re.MULTILINE)
 _PARAMS_PATTERN = re.compile(r"^PARAMS:\s*(.+)$", re.MULTILINE | re.DOTALL)
 _DONE_PATTERN = re.compile(r"^DONE:\s*(.+?)(?=\nRESULT:|\Z)", re.MULTILINE | re.DOTALL)
 _RESULT_PATTERN = re.compile(r"^RESULT:\s*(.+)$", re.MULTILINE | re.DOTALL)
+_COMBINED_DONE_RESULT_PATTERN = re.compile(
+    r"^DONE/RESULT\s*:?\s*\n(.+)$", re.MULTILINE | re.DOTALL
+)
 _THOUGHT_PATTERN = re.compile(r"^THOUGHT:\s*(.+?)(?=\n(?:TOOL|DONE|RESULT|THOUGHT):|\Z)", re.MULTILINE | re.DOTALL)
 
 # ── Observation channel integrity (issue #57) ─────────────────────────────
@@ -558,7 +561,7 @@ class BaseSubAgent(ABC):
             total_tokens["input"] += tokens.get("input", 0)
             total_tokens["output"] += tokens.get("output", 0)
             total_tokens["total"] += tokens.get("total", 0)
-            parsed = self._parse_response(content)
+            parsed = self._parse_response_for_contract(content, state.context)
             if parsed.get("type") != "done":
                 return None
             state.status = "completed"
@@ -597,6 +600,15 @@ class BaseSubAgent(ABC):
             "4. **EXIT CHECK:** Do I have enough to produce a useful result? If yes, call DONE.\n\n"
             "Then emit your TOOL/PARAMS or DONE/RESULT."
         )
+        if "ask_peer" in self._tools:
+            parts.append(
+                "**PEER RESOLUTION:** Before concluding blocked, incomplete, or DONE "
+                "with a material gap, ask whether an available peer can resolve it. "
+                "Use `ask_capability` for the exact missing fact when you know the "
+                "needed capability, or `ask_peer` when a specific role is already clear. "
+                "Include known identifiers, then treat the response as new context and "
+                "re-evaluate. Do not delegate work you can complete with your own tools."
+            )
         return "\n\n".join(parts)
 
     # ──────────────────────────────────────────────────────────────────────
@@ -672,6 +684,17 @@ class BaseSubAgent(ABC):
                     self._cognition.lease.action_used = state.action_tokens_used
                     self._cognition.lease.turns_used = state.turn
                     self._restore_subagent_state(state)
+                    if context.get("_new_execution_epoch"):
+                        state.turn = 0
+                        state.retry_count = 0
+                        state.last_error = None
+                        state.thinking_tokens_used = 0
+                        state.action_tokens_used = 0
+                        state.tokens_used = 0
+                        state.total_cost_usd = 0.0
+                        self._cognition.lease.thinking_used = 0
+                        self._cognition.lease.action_used = 0
+                        self._cognition.lease.turns_used = 0
 
         # Restore cross-task memory (no-op unless memory_enabled=True)
         await self._restore_memory(state)
@@ -783,6 +806,36 @@ class BaseSubAgent(ABC):
                     messages=messages, **kwargs
                 )
             except Exception as e:
+                from jarviscore.orchestration.budget import WorkflowBudgetExceeded
+
+                if isinstance(e, WorkflowBudgetExceeded):
+                    state.status = "active"
+                    state.last_error = str(e)
+                    state.thinking_tokens_used = self._cognition.lease.thinking_used
+                    state.action_tokens_used = self._cognition.lease.action_used
+                    state.tokens_used = total_tokens["total"]
+                    state.total_cost_usd = total_cost
+                    if memory is not None:
+                        await memory.save_checkpoint(state.model_dump_json())
+                    _trace.log_step_complete(
+                        False,
+                        "Active execution epoch exhausted; checkpointed for continuation.",
+                    )
+                    return AgentOutput(
+                        status="epoch_exhausted",
+                        payload=state.output,
+                        summary=(
+                            "Active execution epoch exhausted; durable state was "
+                            "checkpointed for continuation."
+                        ),
+                        trajectory=trajectory,
+                        metadata={
+                            "tokens": total_tokens,
+                            "cost_usd": total_cost,
+                            "typed_outcome": "CONTINUE_NEW_EXECUTION_EPOCH",
+                            "checkpointed": memory is not None,
+                        },
+                    )
                 self._log.error("LLM call failed: %s", e)
                 state.retry_count += 1
                 if state.retry_count > state.max_retries:
@@ -812,7 +865,7 @@ class BaseSubAgent(ABC):
             state.tokens_used = total_tokens["total"]
 
             # Parse response
-            parsed = self._parse_response(content)
+            parsed = self._parse_response_for_contract(content, context)
 
             # ── Auto-summarize if context is getting large ──
             try:
@@ -990,23 +1043,18 @@ class BaseSubAgent(ABC):
                     tool_name, tool_params, state
                 )
                 if hook_result is not None:
-                    self._log.info("Pre-execute hook blocked '%s': %s", tool_name, str(hook_result)[:200])
-                    state.add_tool_result(
-                        tool_name, tool_params, hook_result,
-                        error=hook_result.get("error") if isinstance(hook_result, dict) else None,
+                    hook_succeeded = (
+                        isinstance(hook_result, dict)
+                        and hook_result.get("status") == "success"
                     )
-                    trajectory.append({
-                        "turn": turn, "type": "pre_execute_block",
-                        "tool": tool_name,
-                        "reason": hook_result.get("error", "blocked by pre-execute hook"),
-                    })
-                    conversation_history.append({
-                        "assistant": content,
-                        "observation": (
-                            f"[Turn {turn}] Tool '{tool_name}' blocked by pre-execute hook: "
-                            f"{str(hook_result)[:500]}"
-                        ),
-                    })
+                    hook_event = (
+                        "pre_execute_resolution" if hook_succeeded
+                        else "pre_execute_block"
+                    )
+                    self._record_pre_execute_result(
+                        state, trajectory, conversation_history, content,
+                        turn, tool_name, tool_params, hook_result, hook_event,
+                    )
                     continue
 
                 # Execute tool
@@ -1353,13 +1401,109 @@ class BaseSubAgent(ABC):
         Do not advise here. Naming the missing fact is this method's whole job;
         deciding what to do about it is the agent's.
 
-        Default: always allow.
+        The generic boundary requires one real peer-resolution attempt when a
+        top-level result explicitly declares unresolved work and peer tools are
+        available. Incoming peer responders are already the resolution attempt,
+        so they may return their bounded finding without recursive delegation.
         """
+        result = parsed.get("result")
+        result_status = (
+            str(result.get("status", "")).lower()
+            if isinstance(result, dict)
+            else ""
+        )
+        unresolved = result.get("unresolved") if isinstance(result, dict) else None
+        materially_incomplete = (
+            result_status in {"blocked", "incomplete", "partial"}
+            or bool(unresolved)
+        )
+        peer_tools = {"ask_capability", "ask_peer"}
+        available_peer_tools = peer_tools & set(getattr(self, "_tools", {}))
+        peer_attempted = any(
+            item.tool_name in peer_tools
+            and (
+                item.succeeded
+                or (
+                    isinstance(item.tool_output, dict)
+                    and item.tool_output.get("peer_request_attempted") is True
+                )
+            )
+            for item in state.tool_history
+        )
+        fulfilling_peer_request = bool(
+            state.context.get("peer_requester_agent_id")
+        )
+        if (
+            materially_incomplete
+            and available_peer_tools
+            and not peer_attempted
+            and not fulfilling_peer_request
+        ):
+            return (
+                False,
+                GateEvidence(
+                    check="peer_resolution_review",
+                    requirement=(
+                        "one actual attempt using an available peer capability "
+                        "before accepting a blocked or incomplete result"
+                    ),
+                    observed={
+                        "peer_tool_calls": 0,
+                        "unresolved_facts": (
+                            len(unresolved) if isinstance(unresolved, list) else 0
+                        ),
+                        "available_peer_tools": sorted(available_peer_tools),
+                    },
+                ),
+            )
         return (True, "")
 
     # ──────────────────────────────────────────────────────────────────────
     # Tool Execution
     # ──────────────────────────────────────────────────────────────────────
+
+    def _record_pre_execute_result(
+        self,
+        state: KernelState,
+        trajectory: list,
+        conversation_history: list,
+        content: str,
+        turn: int,
+        tool_name: str,
+        tool_params: Dict[str, Any],
+        hook_result: Dict[str, Any],
+        hook_event: str,
+    ) -> None:
+        hook_succeeded = hook_result.get("status") == "success"
+        disposition = "resolved" if hook_succeeded else "blocked"
+        self._log.info(
+            "Pre-execute hook %s '%s': %s",
+            disposition,
+            tool_name,
+            str(hook_result)[:200],
+        )
+        state.add_tool_result(
+            tool_name,
+            tool_params,
+            hook_result,
+            error=hook_result.get("error"),
+        )
+        trajectory.append({
+            "turn": turn,
+            "type": hook_event,
+            "tool": tool_name,
+            "reason": hook_result.get(
+                "reason",
+                hook_result.get("error", "blocked by pre-execute hook"),
+            ),
+        })
+        conversation_history.append({
+            "assistant": content,
+            "observation": (
+                f"[Turn {turn}] Tool '{tool_name}' {disposition} by "
+                f"pre-execute review: {str(hook_result)[:500]}"
+            ),
+        })
 
     async def _execute_tool(self, tool_name: str, params: Dict) -> Dict[str, Any]:
         """Execute a registered tool."""
@@ -1428,9 +1572,20 @@ class BaseSubAgent(ABC):
         thought_match = _THOUGHT_PATTERN.search(content)
         thought = thought_match.group(1).strip() if thought_match else ""
 
+        combined_match = _COMBINED_DONE_RESULT_PATTERN.search(content)
         done_match = _DONE_PATTERN.search(content)
         result_match = _RESULT_PATTERN.search(content)
         tool_match = _TOOL_PATTERN.search(content)
+
+        if combined_match and not tool_match:
+            result = _extract_json_object(combined_match.group(1).strip())
+            if result is not None:
+                return {
+                    "type": "done",
+                    "thought": thought,
+                    "summary": "Completed via DONE/RESULT block",
+                    "result": result,
+                }
 
         # RESULT alone (no DONE, no TOOL) only completes when it carries a
         # structured JSON object. "RESULT: pending" prose mid-thought must not
@@ -1517,3 +1672,24 @@ class BaseSubAgent(ABC):
 
         # Unparseable
         return {"type": "raw", "content": content}
+
+    @classmethod
+    def _parse_response_for_contract(
+        cls, content: str, context: Optional[Dict[str, Any]]
+    ) -> Dict[str, Any]:
+        parsed = cls._parse_response(content)
+        contract = (context or {}).get("execution_contract")
+        if (
+            parsed.get("type") == "raw"
+            and isinstance(contract, dict)
+            and contract.get("execution_shape") == "single_artifact"
+        ):
+            artifact = _extract_json_object(content)
+            if artifact is not None:
+                return {
+                    "type": "done",
+                    "thought": "",
+                    "summary": "Structured artifact completed.",
+                    "result": artifact,
+                }
+        return parsed

--- a/jarviscore/mailbox/mailbox.py
+++ b/jarviscore/mailbox/mailbox.py
@@ -118,6 +118,29 @@ class MailboxManager:
             return True
         return self.redis.send_mailbox_message(target_agent_id, envelope)
 
+    def deliver(
+        self,
+        sender: str,
+        message: dict,
+        *,
+        workflow_id: str = None,
+        step_id: str = None,
+        context: dict = None,
+    ) -> bool:
+        """Persist an inbound peer envelope under this mailbox owner."""
+        envelope = {"sender": sender, "message": message}
+        if workflow_id is not None:
+            envelope["workflow_id"] = workflow_id
+        if step_id is not None:
+            envelope["step_id"] = step_id
+        if context is not None:
+            envelope["context"] = context
+        if self.redis is None:
+            envelope["timestamp"] = time.time()
+            _LOCAL_QUEUES.setdefault(self.agent_id, []).append(envelope)
+            return True
+        return self.redis.send_mailbox_message(self.agent_id, envelope)
+
     def send_by_capability(
         self,
         capability: str,

--- a/jarviscore/nexus/_data/provider_hosts.json
+++ b/jarviscore/nexus/_data/provider_hosts.json
@@ -167,6 +167,7 @@
     "developers.google.com"
   ],
   "google_drive": [
+    "docs.googleapis.com",
     "www.googleapis.com"
   ],
   "google_maps": [

--- a/jarviscore/orchestration/__init__.py
+++ b/jarviscore/orchestration/__init__.py
@@ -12,6 +12,17 @@ from .dependency import DependencyManager
 from .status import StatusManager, StepStatus
 from .state import WorkflowState
 from .workflow_builder import WorkflowBuilder, Workflow, WorkflowStep
+from .envelopes import (
+    CapabilityMandate,
+    ClaimRecord,
+    DependencyAuthorization,
+    ExecutionBudget,
+    EffectIntentDecision,
+    FulfillmentRecord,
+    WorkflowEnvelope,
+    WorkflowEvidence,
+    neutral_context,
+)
 
 __all__ = [
     'WorkflowEngine',
@@ -24,4 +35,13 @@ __all__ = [
     'WorkflowBuilder',
     'Workflow',
     'WorkflowStep',
+    'CapabilityMandate',
+    'ClaimRecord',
+    'DependencyAuthorization',
+    'ExecutionBudget',
+    'EffectIntentDecision',
+    'FulfillmentRecord',
+    'WorkflowEnvelope',
+    'WorkflowEvidence',
+    'neutral_context',
 ]

--- a/jarviscore/orchestration/budget.py
+++ b/jarviscore/orchestration/budget.py
@@ -1,0 +1,83 @@
+"""Workflow-global execution budget scope for every LLM call."""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from contextvars import ContextVar
+from dataclasses import dataclass
+from typing import Any, Iterator, Optional
+from uuid import uuid4
+
+
+class WorkflowBudgetExceeded(RuntimeError):
+    """Raised before an LLM call when its workflow cannot reserve capacity."""
+
+
+@dataclass(frozen=True)
+class WorkflowBudgetAccount:
+    store: Any
+    workflow_id: str
+    epoch_id: str
+
+    def reserve(self, tokens: int) -> str:
+        reservation_id = uuid4().hex
+        if not self.store.reserve_workflow_tokens(
+            self.workflow_id,
+            self.epoch_id,
+            reservation_id,
+            max(1, int(tokens)),
+        ):
+            usage = self.store.get_workflow_budget_usage(self.workflow_id) or {}
+            raise WorkflowBudgetExceeded(
+                f"Workflow {self.workflow_id!r} cannot reserve {tokens} tokens; "
+                f"epoch={self.epoch_id!r}, "
+                f"epoch_used={usage.get('epoch_used_tokens', 0)}, "
+                f"epoch_reserved={usage.get('epoch_reserved_tokens', 0)}, "
+                f"epoch_limit={usage.get('max_tokens_per_epoch', 0)}."
+            )
+        return reservation_id
+
+    def settle(self, reservation_id: str, tokens: int, cost_usd: float) -> None:
+        self.store.settle_workflow_tokens(
+            self.workflow_id,
+            self.epoch_id,
+            reservation_id,
+            max(0, int(tokens)),
+            max(0.0, float(cost_usd)),
+        )
+
+    def release(self, reservation_id: str) -> None:
+        self.store.release_workflow_token_reservation(
+            self.workflow_id,
+            self.epoch_id,
+            reservation_id,
+        )
+
+
+_CURRENT_WORKFLOW_BUDGET: ContextVar[Optional[WorkflowBudgetAccount]] = ContextVar(
+    "jarviscore_workflow_budget",
+    default=None,
+)
+
+
+def current_workflow_budget() -> Optional[WorkflowBudgetAccount]:
+    return _CURRENT_WORKFLOW_BUDGET.get()
+
+
+@contextmanager
+def workflow_budget_scope(
+    store: Any,
+    workflow_id: str,
+    epoch_id: str = "default",
+) -> Iterator[None]:
+    token = _CURRENT_WORKFLOW_BUDGET.set(
+        WorkflowBudgetAccount(
+            store=store,
+            workflow_id=workflow_id,
+            epoch_id=epoch_id,
+        )
+    )
+    try:
+        yield
+    finally:
+        _CURRENT_WORKFLOW_BUDGET.reset(token)

--- a/jarviscore/orchestration/envelopes.py
+++ b/jarviscore/orchestration/envelopes.py
@@ -108,12 +108,14 @@ class WorkflowEvidence:
     artifacts: Dict[str, Any] = field(default_factory=dict)
     interpretations: Dict[str, Dict[str, Any]] = field(default_factory=dict)
     states: Dict[str, str] = field(default_factory=dict)
+    obligations: Dict[str, Dict[str, Any]] = field(default_factory=dict)
 
     def to_record(self) -> Dict[str, Any]:
         return {
             "artifacts": deepcopy(self.artifacts),
             "interpretations": deepcopy(self.interpretations),
             "states": dict(self.states),
+            "obligations": deepcopy(self.obligations),
         }
 
 

--- a/jarviscore/orchestration/envelopes.py
+++ b/jarviscore/orchestration/envelopes.py
@@ -1,0 +1,382 @@
+"""Canonical durable envelopes for distributed Mesh execution."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from dataclasses import dataclass, field, replace
+from typing import Any, Dict, Literal, Optional, cast
+import json
+
+
+AUTHORITY_KEYS = frozenset({
+    "system",
+    "systems",
+    "effect",
+    "capability",
+    "step_id",
+    "execution_contract",
+    "execution_budget",
+    "output_schema",
+    "mesh_workflow_id",
+})
+
+
+def neutral_context(context: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+    """Copy caller context while removing execution authority and private state."""
+    return deepcopy({
+        key: value
+        for key, value in dict(context or {}).items()
+        if key not in AUTHORITY_KEYS and not str(key).startswith("_")
+    })
+
+
+@dataclass(frozen=True)
+class ExecutionBudget:
+    max_seconds: float = 900.0
+    max_steps: int = 30
+    max_replans: int = 8
+    max_tokens: int = 240_000
+    max_peer_depth: int = 2
+    peer_timeout_seconds: float = 300.0
+
+    @classmethod
+    def from_record(cls, record: Optional[Dict[str, Any]] = None):
+        values = dict(record or {})
+        return cls(
+            max_seconds=max(1.0, float(values.get("max_seconds", 900.0))),
+            max_steps=max(1, int(values.get("max_steps", 30))),
+            max_replans=max(0, int(values.get("max_replans", 8))),
+            max_tokens=max(1, int(values.get("max_tokens", 240_000))),
+            max_peer_depth=max(1, int(values.get("max_peer_depth", 2))),
+            peer_timeout_seconds=max(
+                1.0, float(values.get("peer_timeout_seconds", 300.0))
+            ),
+        )
+
+    def to_record(self) -> Dict[str, Any]:
+        return {
+            "max_seconds": self.max_seconds,
+            "max_steps": self.max_steps,
+            "max_replans": self.max_replans,
+            "max_tokens": self.max_tokens,
+            "max_peer_depth": self.max_peer_depth,
+            "peer_timeout_seconds": self.peer_timeout_seconds,
+        }
+
+
+@dataclass(frozen=True)
+class WorkflowEnvelope:
+    workflow_id: str
+    goal: str
+    context: Dict[str, Any] = field(default_factory=dict)
+    obligations: list[Dict[str, Any]] = field(default_factory=list)
+    steps: list[Dict[str, Any]] = field(default_factory=list)
+    budget: ExecutionBudget = field(default_factory=ExecutionBudget)
+    revision: int = 1
+    published_at: Optional[float] = None
+
+    def to_record(self) -> Dict[str, Any]:
+        record = {
+            "workflow_id": self.workflow_id,
+            "goal": self.goal,
+            "context": neutral_context(self.context),
+            "obligations": deepcopy(self.obligations),
+            "steps": deepcopy(self.steps),
+            "budget": self.budget.to_record(),
+            "revision": self.revision,
+        }
+        if self.published_at is not None:
+            record["published_at"] = self.published_at
+        return record
+
+    @classmethod
+    def from_record(cls, record: Dict[str, Any]) -> "WorkflowEnvelope":
+        return cls(
+            workflow_id=str(record.get("workflow_id") or ""),
+            goal=str(record.get("goal") or ""),
+            context=neutral_context(record.get("context") or {}),
+            obligations=deepcopy(record.get("obligations") or []),
+            steps=deepcopy(record.get("steps") or []),
+            budget=ExecutionBudget.from_record(record.get("budget")),
+            revision=int(record.get("revision") or 0),
+            published_at=record.get("published_at"),
+        )
+
+
+@dataclass(frozen=True)
+class WorkflowEvidence:
+    artifacts: Dict[str, Any] = field(default_factory=dict)
+    interpretations: Dict[str, Dict[str, Any]] = field(default_factory=dict)
+    states: Dict[str, str] = field(default_factory=dict)
+
+    def to_record(self) -> Dict[str, Any]:
+        return {
+            "artifacts": deepcopy(self.artifacts),
+            "interpretations": deepcopy(self.interpretations),
+            "states": dict(self.states),
+        }
+
+
+MandateStatus = Literal[
+    "open", "claimed", "fulfilled", "failed", "cancelled"
+]
+
+
+def terminal_step_status(
+    result_status: Any,
+) -> Literal["completed", "waiting", "blocked", "failed"]:
+    """Normalize agent envelopes at the durable step boundary."""
+    status = str(result_status or "").lower()
+    if status in {"success", "completed", "complete"}:
+        return "completed"
+    if status in {"waiting", "yield", "hitl"}:
+        return "waiting"
+    if status == "blocked":
+        return "blocked"
+    return "failed"
+
+
+@dataclass(frozen=True)
+class EffectIntentDecision:
+    decision: Literal["allow", "redirect", "already_satisfied"]
+    reason: str
+    missing_evidence: tuple[str, ...] = ()
+    supporting_evidence: tuple[str, ...] = ()
+
+    @classmethod
+    def from_response(cls, content: str):
+        text = str(content or "").strip()
+        if text.startswith("```"):
+            text = "\n".join(
+                line for line in text.splitlines()
+                if not line.strip().startswith("```")
+            ).strip()
+        try:
+            data = json.loads(text)
+        except json.JSONDecodeError as exc:
+            raise ValueError("Effect intent review must be valid JSON") from exc
+        decision = str(data.get("decision") or "").lower()
+        if decision not in {"allow", "redirect", "already_satisfied"}:
+            raise ValueError(
+                "Effect intent decision must be allow, redirect, or already_satisfied"
+            )
+        reason = str(data.get("reason") or "").strip()
+        if not reason:
+            raise ValueError("Effect intent decision requires a reason")
+        missing = data.get("missing_evidence") or []
+        if not isinstance(missing, list):
+            raise ValueError("missing_evidence must be a list")
+        supporting = data.get("supporting_evidence") or []
+        if not isinstance(supporting, list):
+            raise ValueError("supporting_evidence must be a list")
+        if decision == "already_satisfied" and not supporting:
+            raise ValueError("already_satisfied requires supporting_evidence")
+        return cls(
+            decision=cast(
+                Literal["allow", "redirect", "already_satisfied"], decision
+            ),
+            reason=reason,
+            missing_evidence=tuple(str(item) for item in missing if str(item)),
+            supporting_evidence=tuple(
+                str(item) for item in supporting if str(item)
+            ),
+        )
+
+
+@dataclass(frozen=True)
+class DependencyAuthorization:
+    decision: Literal["allow", "block"]
+    reason: str
+
+    @classmethod
+    def from_response(cls, content: str):
+        text = str(content or "").strip()
+        if text.startswith("```"):
+            text = "\n".join(
+                line for line in text.splitlines()
+                if not line.strip().startswith("```")
+            ).strip()
+        try:
+            data = json.loads(text)
+        except json.JSONDecodeError as exc:
+            raise ValueError("Dependency authorization must be valid JSON") from exc
+        decision = str(data.get("decision") or "").lower()
+        if decision not in {"allow", "block"}:
+            raise ValueError("Dependency authorization must be allow or block")
+        reason = str(data.get("reason") or "").strip()
+        if not reason:
+            raise ValueError("Dependency authorization requires a reason")
+        return cls(cast(Literal["allow", "block"], decision), reason)
+
+
+@dataclass(frozen=True)
+class ClaimRecord:
+    claim_id: str
+    agent_id: str
+    expires_at: float
+
+
+@dataclass(frozen=True)
+class FulfillmentRecord:
+    agent_id: str
+    result: Dict[str, Any]
+
+
+@dataclass(frozen=True)
+class CapabilityMandate:
+    mandate_id: str
+    workflow_id: str
+    requester_agent_id: str
+    requester_step_id: str
+    capability: str
+    question: str
+    context: Dict[str, Any]
+    status: MandateStatus
+    created_at: float
+    updated_at: float
+    claim: Optional[ClaimRecord] = None
+    fulfillment: Optional[FulfillmentRecord] = None
+    error: Optional[str] = None
+
+    def claimed(self, claim_id: str, agent_id: str, expires_at: float, now: float):
+        if self.status != "open":
+            raise ValueError("Only an open capability mandate can be claimed")
+        return replace(
+            self,
+            status="claimed",
+            updated_at=now,
+            claim=ClaimRecord(claim_id, agent_id, expires_at),
+        )
+
+    def renewed(self, expires_at: float, now: float):
+        if self.status != "claimed" or self.claim is None:
+            raise ValueError("Only a claimed capability mandate can be renewed")
+        return replace(
+            self,
+            updated_at=now,
+            claim=replace(self.claim, expires_at=expires_at),
+        )
+
+    def fulfilled(self, agent_id: str, result: Dict[str, Any], now: float):
+        if self.status != "claimed":
+            raise ValueError("Only a claimed capability mandate can be fulfilled")
+        return replace(
+            self,
+            status="fulfilled",
+            updated_at=now,
+            claim=None,
+            fulfillment=FulfillmentRecord(agent_id, deepcopy(result)),
+        )
+
+    def failed(self, reason: str, now: float):
+        if self.status not in {"open", "claimed"}:
+            raise ValueError("Only an active capability mandate can fail")
+        return replace(
+            self,
+            status="failed",
+            updated_at=now,
+            claim=None,
+            error=reason,
+        )
+
+    def reopened(self, now: float):
+        if self.status != "claimed":
+            raise ValueError("Only a claimed capability mandate can be reopened")
+        return replace(self, status="open", updated_at=now, claim=None)
+
+    def cancelled(self, reason: str, now: float):
+        if self.status not in {"open", "claimed"}:
+            return self
+        return replace(
+            self,
+            status="cancelled",
+            updated_at=now,
+            claim=None,
+            error=reason,
+        )
+
+    @classmethod
+    def open(
+        cls,
+        *,
+        mandate_id: str,
+        workflow_id: str,
+        requester_agent_id: str,
+        requester_step_id: str,
+        capability: str,
+        question: str,
+        context: Optional[Dict[str, Any]],
+        now: float,
+    ) -> "CapabilityMandate":
+        return cls(
+            mandate_id=mandate_id,
+            workflow_id=workflow_id,
+            requester_agent_id=requester_agent_id,
+            requester_step_id=requester_step_id,
+            capability=capability,
+            question=question,
+            context=neutral_context(context),
+            status="open",
+            created_at=now,
+            updated_at=now,
+        )
+
+    def to_record(self) -> Dict[str, Any]:
+        """Serialize to the existing Redis shape for rolling compatibility."""
+        record: Dict[str, Any] = {
+            "id": self.mandate_id,
+            "workflow_id": self.workflow_id,
+            "requester_agent_id": self.requester_agent_id,
+            "requester_step_id": self.requester_step_id,
+            "capability": self.capability,
+            "question": self.question,
+            "context": neutral_context(self.context),
+            "status": self.status,
+            "created_at": self.created_at,
+            "updated_at": self.updated_at,
+        }
+        if self.claim is not None:
+            record.update({
+                "claimed_by": self.claim.agent_id,
+                "claim_id": self.claim.claim_id,
+                "claim_expires_at": self.claim.expires_at,
+            })
+        if self.fulfillment is not None:
+            record.update({
+                "fulfilled_by": self.fulfillment.agent_id,
+                "result": deepcopy(self.fulfillment.result),
+            })
+        if self.error:
+            record["error"] = self.error
+        return record
+
+    @classmethod
+    def from_record(cls, record: Dict[str, Any]) -> "CapabilityMandate":
+        claim = None
+        if record.get("claim_id"):
+            claim = ClaimRecord(
+                claim_id=str(record["claim_id"]),
+                agent_id=str(record.get("claimed_by") or ""),
+                expires_at=float(record.get("claim_expires_at") or 0),
+            )
+        fulfillment = None
+        if "result" in record:
+            fulfillment = FulfillmentRecord(
+                agent_id=str(record.get("fulfilled_by") or ""),
+                result=deepcopy(record.get("result") or {}),
+            )
+        return cls(
+            mandate_id=str(record.get("id") or ""),
+            workflow_id=str(record.get("workflow_id") or ""),
+            requester_agent_id=str(record.get("requester_agent_id") or ""),
+            requester_step_id=str(record.get("requester_step_id") or ""),
+            capability=str(record.get("capability") or ""),
+            question=str(record.get("question") or ""),
+            context=neutral_context(record.get("context") or {}),
+            status=cast(MandateStatus, str(record.get("status") or "open")),
+            created_at=float(record.get("created_at") or 0),
+            updated_at=float(record.get("updated_at") or 0),
+            claim=claim,
+            fulfillment=fulfillment,
+            error=str(record.get("error")) if record.get("error") else None,
+        )

--- a/jarviscore/p2p/coordinator.py
+++ b/jarviscore/p2p/coordinator.py
@@ -245,6 +245,9 @@ class P2PCoordinator:
                 'agent_id': agent.agent_id,
                 'role': agent.role,
                 'capabilities': list(agent.capabilities),
+                'capability_descriptions': dict(
+                    getattr(agent, 'capability_descriptions', {}) or {}
+                ),
                 'description': getattr(agent, 'description', ''),
                 'node_id': self._get_node_id()
             }

--- a/jarviscore/p2p/peer_client.py
+++ b/jarviscore/p2p/peer_client.py
@@ -707,7 +707,11 @@ class PeerClient:
 
         except asyncio.TimeoutError:
             self._logger.debug(f"Request to '{target}' timed out after {timeout}s")
-            return None
+            return {
+                "error": f"Peer '{target}' did not respond within {timeout:g} seconds.",
+                "semantic_error": "PEER_RESPONSE_TIMEOUT",
+                "peer_request_attempted": True,
+            }
 
         finally:
             # Cleanup pending request

--- a/jarviscore/p2p/peer_client.py
+++ b/jarviscore/p2p/peer_client.py
@@ -23,13 +23,17 @@ import asyncio
 import logging
 import random
 import time
-from typing import List, Dict, Any, Optional, TYPE_CHECKING
+from collections.abc import Awaitable, Callable
+from typing import TYPE_CHECKING, Any, Dict, List, Optional
 from uuid import uuid4
 
-from .messages import PeerInfo, IncomingMessage, OutgoingMessage, MessageType
+from jarviscore.orchestration.envelopes import ExecutionBudget, neutral_context
+
+from .messages import IncomingMessage, MessageType, OutgoingMessage, PeerInfo
 
 if TYPE_CHECKING:
     from .coordinator import P2PCoordinator
+    from .peer_tool import PeerTool
 
 logger = logging.getLogger(__name__)
 
@@ -73,7 +77,8 @@ class PeerClient:
         agent_id: str,
         agent_role: str,
         agent_registry: Dict[str, List],
-        node_id: str = ""
+        node_id: str = "",
+        redis_store=None,
     ):
         """
         Initialize PeerClient.
@@ -90,12 +95,20 @@ class PeerClient:
         self._agent_role = agent_role
         self._agent_registry = agent_registry
         self._node_id = node_id
+        self._redis_store = redis_store
 
         # Message queue for incoming messages
         self._message_queue: asyncio.Queue[IncomingMessage] = asyncio.Queue()
 
         # Pending requests waiting for responses (correlation_id -> Future)
         self._pending_requests: Dict[str, asyncio.Future] = {}
+        self._request_handler: Optional[
+            Callable[[IncomingMessage], Awaitable[Optional[Dict[str, Any]]]]
+        ] = None
+        self._notification_handler: Optional[
+            Callable[[IncomingMessage], Awaitable[None]]
+        ] = None
+        self._handler_tasks: set[asyncio.Task] = set()
 
         # Async request inbox (correlation_id -> response data or None)
         self._async_inbox: Dict[str, Optional[Dict[str, Any]]] = {}
@@ -108,6 +121,31 @@ class PeerClient:
         self._peer_last_used: Dict[str, float] = {}   # agent_id -> timestamp
 
         self._logger = logging.getLogger(f"jarviscore.peer_client.{agent_id}")
+
+    def set_request_handler(
+        self,
+        handler: Callable[[IncomingMessage], Awaitable[Optional[Dict[str, Any]]]],
+    ) -> None:
+        """Handle requests directly for task-driven agents without run loops."""
+        self._request_handler = handler
+
+    def set_notification_handler(
+        self, handler: Callable[[IncomingMessage], Awaitable[None]]
+    ) -> None:
+        self._notification_handler = handler
+
+    async def close(self) -> None:
+        """Cancel in-flight handlers and pending requests owned by this client."""
+        tasks = list(self._handler_tasks)
+        for task in tasks:
+            task.cancel()
+        if tasks:
+            await asyncio.gather(*tasks, return_exceptions=True)
+        self._handler_tasks.clear()
+        for future in self._pending_requests.values():
+            if not future.done():
+                future.cancel()
+        self._pending_requests.clear()
 
     # ─────────────────────────────────────────────────────────────────
     # DISCOVERY
@@ -419,6 +457,9 @@ class PeerClient:
                         "role": agent.role,
                         "agent_id": agent.agent_id,
                         "capabilities": list(agent.capabilities),
+                        "capability_descriptions": dict(
+                            getattr(agent, "capability_descriptions", {}) or {}
+                        ),
                         "description": getattr(agent, 'description', ''),
                         "status": "online",
                         "location": "local"
@@ -434,6 +475,9 @@ class PeerClient:
                         "role": remote.get('role', 'unknown'),
                         "agent_id": agent_id,
                         "capabilities": remote.get('capabilities', []),
+                        "capability_descriptions": remote.get(
+                            'capability_descriptions', {}
+                        ),
                         "description": remote.get('description', ''),
                         "status": "online",
                         "location": "remote",
@@ -441,6 +485,122 @@ class PeerClient:
                     })
 
         return peers
+
+    async def request_capability(
+        self,
+        capability: str,
+        question: str,
+        *,
+        context: Optional[Dict[str, Any]] = None,
+        timeout: float = 7200.0,
+    ) -> Dict[str, Any]:
+        """Resolve one scoped capability mandate through durable or direct P2P."""
+        peer_context = neutral_context(context)
+        workflow_id = str(peer_context.get("workflow_id") or "").strip()
+        workflow = (
+            self._redis_store.get_workflow_definition(workflow_id)
+            if workflow_id and self._redis_store is not None
+            else None
+        ) or {}
+        budget = ExecutionBudget.from_record(workflow.get("budget"))
+        lineage = {
+            str(agent_id)
+            for agent_id in peer_context.get("peer_request_lineage", [])
+            if agent_id
+        }
+        lineage.add(self.my_id)
+        if len(lineage) > budget.max_peer_depth:
+            return {
+                "status": "error",
+                "error": (
+                    f"Capability request exceeds max_peer_depth="
+                    f"{budget.max_peer_depth}."
+                ),
+            }
+        matches = [
+            peer
+            for peer in self.discover(capability=capability, strategy="least_recent")
+            if peer.agent_id not in lineage
+        ]
+        if not matches:
+            return {
+                "status": "error",
+                "error": (
+                    f"no non-cyclic peer owns capability {capability!r}; "
+                    "active request ancestors cannot be asked back."
+                ),
+            }
+        peer_context["peer_request_lineage"] = sorted(lineage)
+        timeout = min(float(timeout), budget.peer_timeout_seconds)
+        store = self._redis_store
+        if workflow_id and store is not None and getattr(store, "enabled", False):
+            mandate_id = store.publish_capability_need(
+                workflow_id,
+                requester_agent_id=self.my_id,
+                requester_step_id=str(
+                    peer_context.get("peer_requester_step_id") or ""
+                ),
+                capability=capability,
+                question=question,
+                context=peer_context,
+            )
+            deadline = time.monotonic() + timeout
+            while time.monotonic() < deadline:
+                mandate = store.get_capability_need(workflow_id, mandate_id)
+                if mandate and mandate.get("status") == "fulfilled":
+                    return {
+                        "status": "success",
+                        "capability": capability,
+                        "mandate_id": mandate_id,
+                        "result": mandate.get("result"),
+                    }
+                if mandate and mandate.get("status") in {"failed", "cancelled"}:
+                    return {
+                        "status": "error",
+                        "capability": capability,
+                        "mandate_id": mandate_id,
+                        "error": mandate.get("error") or mandate["status"],
+                    }
+                await asyncio.sleep(0.1)
+            store.fail_capability_need(
+                workflow_id,
+                mandate_id,
+                self.my_id,
+                "Capability mandate timed out.",
+            )
+            return {
+                "status": "error",
+                "capability": capability,
+                "mandate_id": mandate_id,
+                "error": "Capability mandate timed out.",
+            }
+
+        target = matches[0]
+        response = await self.request(
+            target.agent_id,
+            {"query": question, "from": self.my_role, "capability": capability},
+            timeout=timeout,
+            context=peer_context,
+        )
+        if response is None:
+            return {
+                "status": "error",
+                "capability": capability,
+                "error": f"Peer {target.role!r} did not respond.",
+            }
+        if isinstance(response, dict) and response.get("error"):
+            return {
+                "status": "error",
+                "capability": capability,
+                "error": response["error"],
+            }
+        return {
+            "status": "success",
+            "capability": capability,
+            "peer_id": target.agent_id,
+            "peer_role": target.role,
+            "result": response,
+        }
 
     # ─────────────────────────────────────────────────────────────────
     # MESSAGING - SEND
@@ -1090,13 +1250,17 @@ class PeerClient:
         """
         # 1. Try local registry first (by role)
         agents = self._agent_registry.get(target, [])
-        if agents:
-            return agents[0]
+        peer = next(
+            (agent for agent in agents if agent.agent_id != self._agent_id),
+            None,
+        )
+        if peer is not None:
+            return peer
 
         # 2. Try local agent_id match
         for role_name, agents in self._agent_registry.items():
             for agent in agents:
-                if agent.agent_id == target:
+                if agent.agent_id == target and agent.agent_id != self._agent_id:
                     return agent
 
         # 3. Try remote agents via coordinator
@@ -1219,8 +1383,38 @@ class PeerClient:
                 )
                 return
 
+        if message.type == MessageType.REQUEST and self._request_handler is not None:
+            task = asyncio.create_task(
+                self._handle_request(message),
+                name=f"peer-request-{self._agent_id}-{message.correlation_id or 'uncorrelated'}",
+            )
+            self._handler_tasks.add(task)
+            task.add_done_callback(self._handler_tasks.discard)
+            return
+
+        if message.type == MessageType.NOTIFY and self._notification_handler is not None:
+            task = asyncio.create_task(
+                self._notification_handler(message),
+                name=f"peer-notify-{self._agent_id}-{message.sender}",
+            )
+            self._handler_tasks.add(task)
+            task.add_done_callback(self._handler_tasks.discard)
+            await task
+            return
+
         # Otherwise queue for receive()
         await self._message_queue.put(message)
         self._logger.debug(
             f"Queued {message.type.value} from {message.sender}"
         )
+
+    async def _handle_request(self, message: IncomingMessage) -> None:
+        try:
+            response = await self._request_handler(message)
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            self._logger.exception("Peer request handler failed")
+            response = {"status": "failure", "error": f"{type(exc).__name__}: {exc}"}
+        if response is not None:
+            await self.respond(message, response)

--- a/jarviscore/p2p/peer_tool.py
+++ b/jarviscore/p2p/peer_tool.py
@@ -24,7 +24,9 @@ Example:
 """
 import asyncio
 import logging
-from typing import List, Dict, Any, TYPE_CHECKING
+from typing import List, Dict, Any, Optional, TYPE_CHECKING
+
+from jarviscore.orchestration.envelopes import neutral_context
 
 if TYPE_CHECKING:
     from .peer_client import PeerClient
@@ -43,7 +45,7 @@ class PeerTool:
     """
 
     # Tool names this adapter handles
-    tool_names = ["ask_peer", "broadcast_update", "list_peers"]
+    tool_names = ["ask_peer", "ask_capability", "broadcast_update", "list_peers"]
 
     def __init__(self, peer_client: 'PeerClient'):
         """
@@ -82,6 +84,24 @@ class PeerTool:
         # Get live peer info
         active_roles = self._peers.list_roles()
         peers_info = self._peers.list_peers()
+        active_capabilities = sorted({
+            capability
+            for peer in peers_info
+            for capability in peer.get("capabilities", [])
+        })
+        capability_descriptions = {
+            capability: description
+            for peer in peers_info
+            for capability, description in (
+                peer.get("capability_descriptions", {}) or {}
+            ).items()
+            if description
+        }
+        capability_details = "; ".join(
+            f"{capability}: {capability_descriptions[capability]}"
+            for capability in active_capabilities
+            if capability in capability_descriptions
+        )
 
         # Format for LLM context
         if active_roles:
@@ -120,6 +140,31 @@ class PeerTool:
                 }
             },
             {
+                "name": "ask_capability",
+                "description": (
+                    "Ask any available peer that owns a specific capability to resolve "
+                    "a missing fact or perform specialist analysis. The requesting peer "
+                    "selects the capability; the recipient controls its own tools and authority. "
+                    f"CURRENT CAPABILITIES: [{', '.join(active_capabilities) or 'none online'}]. "
+                    f"CAPABILITY MEANINGS: [{capability_details or 'not supplied'}]."
+                ),
+                "input_schema": {
+                    "type": "object",
+                    "properties": {
+                        "capability": {
+                            "type": "string",
+                            "enum": active_capabilities,
+                            "description": "Capability needed to resolve the current gap",
+                        },
+                        "question": {
+                            "type": "string",
+                            "description": "Exact missing fact or specialist request",
+                        },
+                    },
+                    "required": ["capability", "question"],
+                },
+            },
+            {
                 "name": "broadcast_update",
                 "description": (
                     "Send a notification to ALL peers in the mesh. "
@@ -151,7 +196,13 @@ class PeerTool:
             }
         ]
 
-    async def execute(self, tool_name: str, args: Dict[str, Any]) -> str:
+    async def execute(
+        self,
+        tool_name: str,
+        args: Dict[str, Any],
+        context: Optional[Dict[str, Any]] = None,
+        timeout_seconds: Optional[float] = None,
+    ) -> str:
         """
         Execute a peer tool call.
 
@@ -162,22 +213,154 @@ class PeerTool:
         Returns:
             String result to feed back to LLM
         """
+        result = await self.execute_result(
+            tool_name,
+            args,
+            context=context,
+            timeout_seconds=timeout_seconds,
+        )
+        if result.get("status") == "success":
+            return str(result.get("output") or "")
+        return f"Error: {result.get('error', 'peer request failed')}"
+
+    async def execute_result(
+        self,
+        tool_name: str,
+        args: Dict[str, Any],
+        context: Optional[Dict[str, Any]] = None,
+        timeout_seconds: Optional[float] = None,
+    ) -> Dict[str, Any]:
+        """Execute a peer tool and preserve transport/schema failure semantics."""
         self._logger.debug(f"Executing {tool_name} with args: {args}")
 
         try:
             if tool_name == "ask_peer":
-                return await self._ask_peer(args)
+                return await self._ask_peer_result(
+                    args,
+                    context=context,
+                    timeout_seconds=timeout_seconds,
+                )
+            elif tool_name == "ask_capability":
+                return await self._ask_capability_result(
+                    args,
+                    context=context,
+                    timeout_seconds=timeout_seconds,
+                )
             elif tool_name == "broadcast_update":
-                return await self._broadcast_update(args)
+                return {"status": "success", "output": await self._broadcast_update(args)}
             elif tool_name == "list_peers":
-                return self._list_peers()
+                return {"status": "success", "output": self._list_peers()}
             else:
-                return f"Error: Unknown tool '{tool_name}'"
+                return {
+                    "status": "error",
+                    "error": f"Unknown peer tool '{tool_name}'",
+                    "semantic_error": "UNKNOWN_PEER_TOOL",
+                    "peer_request_attempted": False,
+                }
         except Exception as e:
             self._logger.error(f"Tool execution error: {e}")
-            return f"Error: {str(e)}"
+            return {
+                "status": "error",
+                "error": str(e),
+                "semantic_error": "PEER_TOOL_EXECUTION_ERROR",
+                "peer_request_attempted": True,
+            }
 
-    async def _ask_peer(self, args: Dict[str, Any]) -> str:
+    async def _ask_peer_result(
+        self,
+        args: Dict[str, Any],
+        context: Optional[Dict[str, Any]] = None,
+        timeout_seconds: Optional[float] = None,
+    ) -> Dict[str, Any]:
+        role = str(args.get("role") or "").strip()
+        question = str(args.get("question") or "").strip()
+        missing = [
+            field for field, value in (("role", role), ("question", question))
+            if not value
+        ]
+        if missing:
+            return {
+                "status": "error",
+                "error": f"Missing required peer arguments: {', '.join(missing)}",
+                "semantic_error": "INVALID_PEER_TOOL_ARGUMENTS",
+                "missing_fields": missing,
+                "peer_request_attempted": False,
+            }
+        response = await self._peers.request(
+            role,
+            {"query": question, "from": self._peers.my_role},
+            timeout=max(1.0, float(timeout_seconds or 300.0)),
+            context=neutral_context(context),
+        )
+        if response is None:
+            available_roles = [p["role"] for p in self._peers.list_peers()]
+            return {
+                "status": "error",
+                "error": f"'{role}' not found or did not respond",
+                "semantic_error": "PEER_UNAVAILABLE",
+                "available_roles": available_roles,
+                "peer_request_attempted": True,
+            }
+        if isinstance(response, dict) and response.get("error"):
+            return {
+                "status": "error",
+                "error": str(response["error"]),
+                "semantic_error": "PEER_RESPONSE_ERROR",
+                "peer_request_attempted": True,
+            }
+        payload = response.get("response", response) if isinstance(response, dict) else response
+        return {
+            "status": "success",
+            "output": f"{role}: {payload}",
+            "peer_request_attempted": True,
+        }
+
+    async def _ask_capability_result(
+        self,
+        args: Dict[str, Any],
+        context: Optional[Dict[str, Any]] = None,
+        timeout_seconds: Optional[float] = None,
+    ) -> Dict[str, Any]:
+        capability = str(args.get("capability") or "").strip()
+        question = str(args.get("question") or "").strip()
+        missing = [
+            field
+            for field, value in (("capability", capability), ("question", question))
+            if not value
+        ]
+        if missing:
+            return {
+                "status": "error",
+                "error": f"Missing required capability arguments: {', '.join(missing)}",
+                "semantic_error": "INVALID_PEER_TOOL_ARGUMENTS",
+                "missing_fields": missing,
+                "peer_request_attempted": False,
+            }
+        response = await self._peers.request_capability(
+            capability,
+            question,
+            context=context,
+            timeout=max(1.0, float(timeout_seconds or 300.0)),
+        )
+        if response.get("status") != "success":
+            return {
+                "status": "error",
+                "error": str(response.get("error") or "request failed"),
+                "semantic_error": "CAPABILITY_REQUEST_FAILED",
+                "peer_request_attempted": True,
+            }
+        peer = response.get("peer_role") or capability
+        return {
+            "status": "success",
+            "output": f"{peer} ({capability}): {response.get('result')}",
+            "peer_request_attempted": True,
+        }
+
+    async def _ask_peer(
+        self,
+        args: Dict[str, Any],
+        context: Optional[Dict[str, Any]] = None,
+    ) -> str:
         """Execute ask_peer tool."""
         role = args.get("role")
         question = args.get("question")
@@ -192,7 +375,8 @@ class PeerTool:
         response = await self._peers.request(
             role,
             {"query": question, "from": self._peers.my_role},
-            timeout=7200.0
+            timeout=7200.0,
+            context=neutral_context(context),
         )
         
         self._logger.info(f"ask_peer: Got response: {response}")
@@ -219,6 +403,26 @@ class PeerTool:
             else:
                 return f"{role}: {response}"
         return f"{role}: {response}"
+
+    async def _ask_capability(
+        self,
+        args: Dict[str, Any],
+        context: Optional[Dict[str, Any]] = None,
+    ) -> str:
+        capability = str(args.get("capability") or "").strip()
+        question = str(args.get("question") or "").strip()
+        if not capability or not question:
+            return "Error: 'capability' and 'question' are required"
+        response = await self._peers.request_capability(
+            capability,
+            question,
+            context=context,
+            timeout=float(args.get("timeout") or 7200.0),
+        )
+        if response.get("status") != "success":
+            return f"Error from {capability}: {response.get('error', 'request failed')}"
+        peer = response.get("peer_role") or capability
+        return f"{peer} ({capability}): {response.get('result')}"
 
     async def _broadcast_update(self, args: Dict[str, Any]) -> str:
         """Execute broadcast_update tool."""

--- a/jarviscore/planning/evaluator.py
+++ b/jarviscore/planning/evaluator.py
@@ -34,7 +34,12 @@ Return ONLY a JSON object with exactly these fields:
   "evaluator_note"      : "<concise explanation of verdict — 1-2 sentences>",
   "additional_findings" : {
     "<snake_case_key>" : "<value extracted from the output that future steps should know>"
-  }
+    },
+    "goal_decision"      : "<continue|complete|replan>",
+    "goal_note"          : "<why the remaining plan is still needed, obsolete, or must change>",
+    "hitl_category"      : "<auth_required|data_required|critical_action|null>",
+    "autonomous_paths_exhausted": <true|false>,
+    "human_exclusive"    : <true|false>
 }
 
 Verdict guide:
@@ -57,6 +62,20 @@ additional_findings:
   Keys must be short snake_case (e.g. "api_base_url", "record_count").
   Return an empty object {} if there is nothing new to add.
   Do NOT duplicate facts already listed in accumulated_goal_facts.
+
+goal_decision:
+    "continue" — remaining steps are still necessary under current evidence.
+    "complete" — the overall goal is already satisfied; remaining steps are obsolete.
+    "replan"   — new evidence invalidated the remaining plan, but the goal is not complete.
+    Respect conditional intent. If an observation proves a conditional branch is false,
+    do not execute, compensate for, or replace that branch merely because it was planned.
+
+HITL admissibility:
+    Low confidence, token spend, failed analysis, or incomplete routine work NEVER justify HITL.
+    auth_required: a person must grant account access or credentials.
+    critical_action: a consequential action requires explicit human approval.
+    data_required: allowed only when autonomous_paths_exhausted=true AND human_exclusive=true.
+    Otherwise use fail/partial and replan autonomously.
 
 Withheld facts:
   The accumulated goal facts may end with a note saying some records are not
@@ -110,6 +129,7 @@ class StepEvaluator:
         step: PlannedStep,
         output: Any,                # AgentOutput
         goal_execution: GoalExecution,
+        remaining_steps: Optional[list[PlannedStep]] = None,
     ) -> StepEvaluation:
         """
         Evaluate a completed step against its success criterion.
@@ -171,6 +191,13 @@ class StepEvaluator:
                     additional_findings={},
                 )
             # Genuine HITL: convergence stall or unknown yield reason
+            hitl_type = str(meta.get("hitl_type") or "").lower()
+            category = {
+                "auth": "auth_required",
+                "approval": "critical_action",
+                "data": "data_required",
+                "input": "data_required",
+            }.get(hitl_type)
             return StepEvaluation(
                 verdict="hitl",
                 confidence=0.98,
@@ -179,10 +206,17 @@ class StepEvaluator:
                     f"{getattr(output, 'summary', 'yield triggered')}"
                 ),
                 additional_findings={},
+                hitl_category=category,
+                autonomous_paths_exhausted=bool(
+                    meta.get("autonomous_paths_exhausted")
+                ),
+                human_exclusive=bool(meta.get("human_exclusive")),
             )
 
         # ── LLM evaluation for "success" outputs ──────────────────────────────
-        prompt = self._build_prompt(step, output, goal_execution)
+        prompt = self._build_prompt(
+            step, output, goal_execution, remaining_steps=remaining_steps
+        )
 
         # Evaluator is a fast 4-way classification task (pass/partial/fail/hitl).
         # Route to the nano/fast tier — cheaper, lower latency, no quality loss.
@@ -234,6 +268,7 @@ class StepEvaluator:
         step: PlannedStep,
         output: Any,
         goal_execution: GoalExecution,
+        remaining_steps: Optional[list[PlannedStep]] = None,
     ) -> str:
         output_repr = self._format_output(output)
         facts = goal_execution.truth.to_flat_dict()
@@ -245,6 +280,12 @@ class StepEvaluator:
         known = selection.render() or "None yet."
         if not selection.complete:
             known += f"\n  {selection.notice('the goal truth store')}"
+        if remaining_steps is None:
+            remaining_steps = goal_execution.remaining_plan
+        remaining = "\n".join(
+            f"  - {item.step_id}: {item.task}"
+            for item in (remaining_steps or [])
+        ) or "  None."
 
         return (
             f"Evaluate whether this agent step met its success criterion.\n\n"
@@ -254,6 +295,7 @@ class StepEvaluator:
             f"Expected findings: {step.expected_findings}\n\n"
             f"Step output:\n{output_repr}\n\n"
             f"Accumulated goal facts (do not re-extract these):\n{known}\n\n"
+            f"Remaining planned steps:\n{remaining}\n\n"
             f"{_EVAL_SCHEMA}"
         )
 
@@ -508,9 +550,36 @@ class StepEvaluator:
         if not isinstance(additional, dict):
             additional = {}
 
+        goal_decision = str(parsed.get("goal_decision") or "continue").lower().strip()
+        if goal_decision not in {"continue", "complete", "replan"}:
+            raise EvaluatorError(
+                f"Evaluator returned invalid goal_decision: {goal_decision!r}. "
+                "Must be one of: continue, complete, replan."
+            )
+
+        hitl_category = parsed.get("hitl_category")
+        if hitl_category is not None:
+            hitl_category = str(hitl_category).lower().strip()
+            if hitl_category in {"", "null", "none"}:
+                hitl_category = None
+        if hitl_category is not None:
+            if hitl_category not in {
+                "auth_required", "data_required", "critical_action"
+            }:
+                raise EvaluatorError(
+                    f"Evaluator returned invalid hitl_category: {hitl_category!r}."
+                )
+
         return StepEvaluation(
             verdict=verdict,
             confidence=confidence,
             evaluator_note=_honest_clip(str(parsed.get("evaluator_note", "")), 600),
             additional_findings=additional,
+            goal_decision=goal_decision,
+            goal_note=_honest_clip(str(parsed.get("goal_note", "")), 600),
+            hitl_category=hitl_category,
+            autonomous_paths_exhausted=bool(
+                parsed.get("autonomous_paths_exhausted", False)
+            ),
+            human_exclusive=bool(parsed.get("human_exclusive", False)),
         )

--- a/jarviscore/planning/goal_context.py
+++ b/jarviscore/planning/goal_context.py
@@ -118,6 +118,13 @@ class StepEvaluation:
     confidence: float
     evaluator_note: str
     additional_findings: Dict[str, Any] = field(default_factory=dict)
+    goal_decision: Literal["continue", "complete", "replan"] = "continue"
+    goal_note: str = ""
+    hitl_category: Optional[
+        Literal["auth_required", "data_required", "critical_action"]
+    ] = None
+    autonomous_paths_exhausted: bool = False
+    human_exclusive: bool = False
 
     @property
     def passed(self) -> bool:
@@ -125,11 +132,23 @@ class StepEvaluation:
 
     @property
     def needs_hitl(self) -> bool:
-        return self.verdict == "hitl"
+        if self.verdict != "hitl":
+            return False
+        if self.hitl_category in {"auth_required", "critical_action"}:
+            return True
+        return bool(
+            self.hitl_category == "data_required"
+            and self.autonomous_paths_exhausted
+            and self.human_exclusive
+        )
 
     @property
     def needs_replan(self) -> bool:
-        return self.verdict == "fail"
+        return (
+            self.verdict == "fail"
+            or self.goal_decision == "replan"
+            or (self.verdict == "hitl" and not self.needs_hitl)
+        )
 
 
 # ── Completed step record ─────────────────────────────────────────────────────
@@ -168,6 +187,11 @@ class _ResumedStep:
     step: PlannedStep
     verdict: str
     evaluator_note: str
+    goal_decision: str
+    goal_note: str
+    hitl_category: Optional[str]
+    autonomous_paths_exhausted: bool
+    human_exclusive: bool
     summary: str
     elapsed_ms: float = 0.0
 
@@ -178,6 +202,11 @@ class _ResumedStep:
             verdict=self.verdict,
             evaluator_note=self.evaluator_note,
             confidence=0.0,
+            goal_decision=self.goal_decision,
+            goal_note=self.goal_note,
+            hitl_category=self.hitl_category,
+            autonomous_paths_exhausted=self.autonomous_paths_exhausted,
+            human_exclusive=self.human_exclusive,
         )
 
     @property
@@ -203,6 +232,13 @@ class _ResumedStep:
             ),
             verdict=str(entry.get("verdict", "pass")),
             evaluator_note=str(entry.get("evaluator_note", "")),
+            goal_decision=str(entry.get("goal_decision", "continue")),
+            goal_note=str(entry.get("goal_note", "")),
+            hitl_category=entry.get("hitl_category"),
+            autonomous_paths_exhausted=bool(
+                entry.get("autonomous_paths_exhausted", False)
+            ),
+            human_exclusive=bool(entry.get("human_exclusive", False)),
             summary=str(entry.get("summary", "")),
             elapsed_ms=float(entry.get("elapsed_ms", 0.0) or 0.0),
         )
@@ -244,6 +280,7 @@ class GoalExecution:
 
     # Plan state
     plan: List[PlannedStep] = field(default_factory=list)
+    remaining_plan: List[PlannedStep] = field(default_factory=list)
     plan_revision: int = 0
     current_step_index: int = 0
 
@@ -418,6 +455,19 @@ class GoalExecution:
                     "task": cs.step.task,
                     "verdict": cs.evaluation.verdict,
                     "evaluator_note": cs.evaluation.evaluator_note,
+                    "goal_decision": getattr(
+                        cs.evaluation, "goal_decision", "continue"
+                    ),
+                    "goal_note": getattr(cs.evaluation, "goal_note", ""),
+                    "hitl_category": getattr(
+                        cs.evaluation, "hitl_category", None
+                    ),
+                    "autonomous_paths_exhausted": getattr(
+                        cs.evaluation, "autonomous_paths_exhausted", False
+                    ),
+                    "human_exclusive": getattr(
+                        cs.evaluation, "human_exclusive", False
+                    ),
                     "summary": str(getattr(cs.output, "summary", "") or "")[:300],
                     "elapsed_ms": round(cs.elapsed_ms, 1),
                 }

--- a/jarviscore/planning/mesh_planner.py
+++ b/jarviscore/planning/mesh_planner.py
@@ -148,9 +148,18 @@ class MeshPlanner:
             if audit.get("complete") is True and not audit.get("missing"):
                 return plan
             try:
-                repair_raw = await self._call_json(
-                    self._repair_prompt(plan, audit, context or {})
-                )
+                corrected_obligations = audit.get("obligations")
+                if corrected_obligations is not None:
+                    obligations = self._parse_obligations(
+                        {"obligations": corrected_obligations}, source
+                    )
+                    repair_raw = await self._call_json(
+                        self._step_prompt(source, obligations, context or {})
+                    )
+                else:
+                    repair_raw = await self._call_json(
+                        self._repair_prompt(plan, audit, context or {})
+                    )
                 repaired_steps = self._ensure_response_step(
                     self._parse_steps(repair_raw, obligations)
                 )
@@ -177,52 +186,177 @@ class MeshPlanner:
         goal: str,
         *,
         obligations: list[dict[str, Any]],
+        target_obligation_ids: set[str] | None = None,
         current_steps: list[dict[str, Any]],
         reason: str,
         revision: int,
         context: dict[str, Any] | None = None,
     ) -> MeshPlan:
-        """Replace unfinished work without changing the source obligation ledger."""
+        """Plan only new work against immutable workflow history."""
         source = (goal or "").strip()
         parsed_obligations = self._parse_obligations(
             {"obligations": obligations}, source
         )
+        obligation_ids = {item.id for item in parsed_obligations}
+        targets = (
+            obligation_ids
+            if target_obligation_ids is None
+            else set(target_obligation_ids)
+        )
+        if not targets or not targets <= obligation_ids:
+            raise MeshPlanError("Amendment targets must be known source obligations")
         step_raw = await self._call_json(
             self._amendment_prompt(
                 source,
                 parsed_obligations,
+                targets,
                 current_steps,
                 reason,
                 context or {},
             )
         )
-        steps = self._ensure_response_step(
-            self._parse_steps(step_raw, parsed_obligations)
-        )
+        current_ids = {
+            str(step.get("id") or step.get("step_id"))
+            for step in current_steps
+        }
+        try:
+            steps = self._ensure_response_step(
+                self._parse_steps(
+                    step_raw, parsed_obligations,
+                    allowed_dependency_ids=current_ids,
+                    forbidden_step_ids=current_ids,
+                    required_obligation_ids=targets,
+                    allowed_cover_ids=targets,
+                ),
+                reserved_ids=current_ids,
+            )
+        except MeshPlanError as first_error:
+            last_error = first_error
+            for repair_attempt in range(1, 3):
+                try:
+                    step_raw = await self._call_json(
+                        self._invalid_amendment_repair_prompt(
+                            source,
+                            parsed_obligations,
+                            current_steps=current_steps,
+                            rejected=step_raw,
+                            reason=reason,
+                            validation_error=str(last_error),
+                        )
+                    )
+                    steps = self._ensure_response_step(
+                        self._parse_steps(
+                            step_raw, parsed_obligations,
+                            allowed_dependency_ids=current_ids,
+                            forbidden_step_ids=current_ids,
+                            required_obligation_ids=targets,
+                            allowed_cover_ids=targets,
+                        ),
+                        reserved_ids=current_ids,
+                    )
+                    break
+                except Exception as exc:
+                    last_error = exc
+            else:
+                raise MeshPlanError(
+                    f"Mesh amendment draft is invalid: {first_error}; "
+                    f"repair failed: {last_error}"
+                ) from last_error
         plan = MeshPlan(
             goal=source,
             obligations=parsed_obligations,
             steps=steps,
             revision=revision + 1,
         )
-        audit = await self._call_json(self._audit_prompt(plan))
-        if audit.get("complete") is not True or audit.get("missing"):
+        audit = await self._call_json(self._amendment_audit_prompt(
+            plan, current_steps=current_steps, reason=reason,
+        ))
+        first_failure = audit.get("missing") or audit
+        for repair_attempt in range(1, 3):
+            if audit.get("complete") is True and not audit.get("missing"):
+                return plan
+            try:
+                repair_raw = await self._call_json(self._amendment_repair_prompt(
+                    plan,
+                    audit=audit,
+                    current_steps=current_steps,
+                    reason=reason,
+                ))
+                repaired_steps = self._ensure_response_step(
+                    self._parse_steps(
+                        repair_raw, parsed_obligations,
+                        allowed_dependency_ids=current_ids,
+                        forbidden_step_ids=current_ids,
+                        required_obligation_ids=targets,
+                        allowed_cover_ids=targets,
+                    ),
+                    reserved_ids=current_ids,
+                )
+                plan = MeshPlan(
+                    goal=source,
+                    obligations=parsed_obligations,
+                    steps=repaired_steps,
+                    revision=revision + 1,
+                )
+                audit = await self._call_json(self._amendment_audit_prompt(
+                    plan, current_steps=current_steps, reason=reason,
+                ))
+            except Exception as exc:
+                if repair_attempt == 2:
+                    raise MeshPlanError(
+                        f"Mesh amendment failed coverage audit: {first_failure}; "
+                        f"repair {repair_attempt} failed: {exc}"
+                    ) from exc
+                audit = {
+                    "complete": False,
+                    "missing": [f"Repair draft failed validation: {exc}"],
+                }
+        if audit.get("complete") is True and not audit.get("missing"):
+            return plan
+        raise MeshPlanError(
+            "Mesh amendment failed coverage audit after two repairs: "
+            f"{audit.get('missing') or audit}"
+        )
+
+    async def reconciliation_decision(
+        self,
+        goal: str,
+        *,
+        obligations: list[dict[str, Any]],
+        current_steps: list[dict[str, Any]],
+        revision: int,
+    ) -> dict[str, str]:
+        """Decide whether semantic gaps require another bounded DAG revision."""
+        raw = await self._call_json(self._reconciliation_prompt(
+            goal, obligations, current_steps, revision,
+        ))
+        unknown = set(raw) - {"decision", "reason"}
+        decision = str(raw.get("decision") or "").strip().lower()
+        reason = str(raw.get("reason") or "").strip()
+        if unknown or decision not in {"amend", "settle_blocked"} or not reason:
             raise MeshPlanError(
-                f"Mesh amendment failed coverage audit: {audit.get('missing') or audit}"
+            "Semantic reconciliation requires exactly "
+            "decision=amend|settle_blocked and reason"
             )
-        return plan
+        return {"decision": decision, "reason": reason}
 
     def _ensure_response_step(
-        self, steps: list[MeshPlannedStep]
+        self,
+        steps: list[MeshPlannedStep],
+        reserved_ids: set[str] | None = None,
     ) -> list[MeshPlannedStep]:
         capability = self.response_capability
-        if not capability or any(step.capability == capability for step in steps):
+        active_response = any(
+            step.capability == capability
+            for step in steps
+        )
+        if not capability or active_response:
             return steps
         depended_on = {
             dependency for step in steps for dependency in step.depends_on
         }
         sinks = [step.step_id for step in steps if step.step_id not in depended_on]
-        existing_ids = {step.step_id for step in steps}
+        existing_ids = {step.step_id for step in steps} | (reserved_ids or set())
         step_id = "final_response"
         suffix = 2
         while step_id in existing_ids:
@@ -289,7 +423,11 @@ id, description, source_quote.
 - source_quote is an exact non-empty quote from SOURCE GOAL.
 - capture every requested outcome, constraint, prohibition, approval boundary,
   fallback condition, scope limit and evidence requirement.
-- split independently verifiable obligations; do not add or execute work."""
+- split independently verifiable obligations; do not add or execute work.
+- a named workflow or playbook is context, not another obligation, when the source
+    immediately defines it through independently verifiable outcomes.
+- do not emit an umbrella obligation whose only success criterion is completion
+    of other obligations in the same ledger."""
 
     @staticmethod
     def _obligation_repair_prompt(
@@ -351,6 +489,9 @@ expected_findings, depends_on, covers.
 - reason about the information required to execute each effectful outcome. Every
     required fact must come from the source goal or an ancestor step whose task and
     success criterion resolve it. naming an entity does not supply its provider identifiers.
+- when downstream work needs an artifact's contents, the producing step must inspect
+    and return provider-readback evidence of usable content; a matching name, identifier,
+    link or MIME type proves resource identity, not content sufficiency.
 - declare only real data dependencies; independent work should run in parallel only
     when neither outcome needs information discovered by the other.
 - each task must include enough scope and constraints to execute independently.
@@ -417,11 +558,13 @@ Do not execute work or add requirements."""
         self,
         goal: str,
         obligations: list[GoalObligation],
+        target_obligation_ids: set[str],
         current_steps: list[dict[str, Any]],
         reason: str,
         context: dict[str, Any],
     ) -> str:
         catalog = self._render_capability_catalog()
+        ledger = self._amendment_ledger_view(current_steps)
         return f"""Amend the unfinished portion of one capability-addressed DAG.
 
 SOURCE GOAL (immutable):
@@ -430,8 +573,14 @@ SOURCE GOAL (immutable):
 OBLIGATION LEDGER (immutable):
 {json.dumps([item.to_dict() for item in obligations], ensure_ascii=False)}
 
-CURRENT STEP LEDGER:
-{json.dumps(current_steps, ensure_ascii=False, default=str)}
+UNRESOLVED OBLIGATION IDS (the only obligations this delta may cover):
+{json.dumps(sorted(target_obligation_ids), ensure_ascii=False)}
+
+CURRENT STEP DEFINITIONS (return using the normal step schema):
+{json.dumps(ledger["definitions"], ensure_ascii=False, default=str)}
+
+AUTHORITATIVE STEP OUTCOMES (reason from these; do not copy runtime fields):
+{json.dumps(ledger["outcomes"], ensure_ascii=False, default=str)}
 
 AMENDMENT REASON:
 {reason}
@@ -442,12 +591,16 @@ LIVE CAPABILITY CATALOG:
 PUBLIC CONTEXT:
 {json.dumps(context, ensure_ascii=False, default=str)}
 
-Return one valid json object with `steps`. Each step has exactly:
+Return one valid json object containing only NEW `steps`. Each step has exactly:
 step_id, capability, effect, systems, task, success_criterion,
 expected_findings, depends_on, covers.
-- reproduce every completed step exactly, including its id and definition.
-- replace only failed, blocked, waiting or pending work.
-- cover every immutable obligation and preserve dependencies on completed work.
+- do not reproduce, alter or remove any current step.
+- every step_id must be new; current step ids may only appear in depends_on.
+- semantic hold or rejection on a completed attempt may be remediated only by adding
+    concrete new work that depends on its durable artifact; never alter or rerun the attempt.
+- preserve completed effects as immutable facts and do not add work that repeats them.
+- cover every UNRESOLVED OBLIGATION ID exactly through new work and preserve
+    dependencies on completed work; `covers` must not contain any other obligation id.
 - capability must come from LIVE CAPABILITY CATALOG.
 - effect must be exactly one of: read, propose, write, notify, destructive, final_response.
 - systems lists every provider the step will call and must be authorized by the capability.
@@ -455,6 +608,198 @@ expected_findings, depends_on, covers.
 - use capabilities, never an agent ID or named instance.
 
 Do not assign peers, execute work, change completed work or add requirements."""
+
+    def _reconciliation_prompt(
+        self,
+        goal: str,
+        obligations: list[dict[str, Any]],
+        current_steps: list[dict[str, Any]],
+        revision: int,
+    ) -> str:
+        return f"""Reconcile one terminal mesh DAG against its source obligations.
+
+SOURCE GOAL (immutable):
+{goal}
+
+OBLIGATION LEDGER (immutable):
+{json.dumps(obligations, ensure_ascii=False, default=str)}
+
+TERMINAL STEP LEDGER (authoritative artifacts and semantic interpretations):
+{json.dumps(current_steps, ensure_ascii=False, default=str)}
+
+CURRENT REVISION: {revision}
+
+LIVE CAPABILITY CATALOG:
+{self._render_capability_catalog()}
+
+Return exactly one json object with `decision` and `reason`.
+- decision=`amend` only when an unmet or partially met source obligation can be
+  advanced by concrete new work authorized by the live capability catalog.
+- decision=`settle_blocked` only when the remaining gaps require unavailable
+    authority, missing human input, or facts no available capability can obtain.
+- this decision is invoked only while obligation gaps exist; never claim all source
+    obligations are satisfied here. Satisfaction is derived after those gaps close.
+- treat completed effects and provider identities as authoritative world state;
+  never propose repeating an already completed effect.
+- reason identifies the remaining obligation and why another DAG revision can or
+  cannot make progress.
+
+Do not choose tools, name atoms, execute work, alter completed artifacts, or add obligations."""
+
+    @staticmethod
+    def _amendment_audit_prompt(
+        plan: MeshPlan,
+        *,
+        current_steps: list[dict[str, Any]],
+        reason: str,
+    ) -> str:
+        completed = [step for step in current_steps if step.get("status") == "completed"]
+        ledger = MeshPlanner._amendment_ledger_view(completed)
+        return f"""Audit one reconciled mesh DAG against immutable completed history.
+
+SOURCE GOAL:
+{plan.goal}
+
+OBLIGATIONS:
+{json.dumps([item.to_dict() for item in plan.obligations], ensure_ascii=False)}
+
+COMPLETED ATTEMPT DEFINITIONS (immutable historical facts):
+{json.dumps(ledger["definitions"], ensure_ascii=False, default=str)}
+
+AUTHORITATIVE ATTEMPT OUTCOMES:
+{json.dumps(ledger["outcomes"], ensure_ascii=False, default=str)}
+
+RECONCILIATION REASON:
+{reason}
+
+PROPOSED NEW-STEP DELTA:
+{json.dumps([step.to_dict() for step in plan.steps], ensure_ascii=False)}
+
+Return exactly one json object: {{"complete": true, "missing": []}} only when:
+- every proposed step is new and completed history is left untouched;
+- new work can advance the reconciliation reason using available dependencies;
+- no new step repeats a provider effect whose authoritative outcome says it executed;
+- every immutable obligation remains covered by completed history or executable new work;
+- a fresh final response follows the new terminal work when one is configured.
+
+Durable step status `completed` means the attempt ended; it does not prove its provider
+effect executed. Use typed output `execution_state`, semantic decision and provider evidence
+to determine effect truth. A new effectful step may remediate a completed attempt whose
+authoritative outcome is blocked or `not_executed`, but must not repeat an already executed
+provider outcome. A capability-change amendment may advance only the blocked obligations named
+by its reconciliation reason; other obligations already represented by completed blocked
+attempts may remain unresolved history and do not require invented replacement work. Do not
+retroactively reject, reorder or demand prerequisites for an effect that actually executed.
+Audit only whether new work safely advances the named semantic gaps.
+Otherwise return complete=false with `missing` entries describing the amendment defect."""
+
+    @staticmethod
+    def _amendment_repair_prompt(
+        plan: MeshPlan,
+        *,
+        audit: dict[str, Any],
+        current_steps: list[dict[str, Any]],
+        reason: str,
+    ) -> str:
+        completed = [
+            step for step in current_steps if step.get("status") == "completed"
+        ]
+        ledger = MeshPlanner._amendment_ledger_view(completed)
+        return f"""Repair one rejected reconciliation amendment.
+
+SOURCE GOAL (immutable):
+{plan.goal}
+
+OBLIGATION LEDGER (immutable):
+{json.dumps([item.to_dict() for item in plan.obligations], ensure_ascii=False)}
+
+COMPLETED STEP DEFINITIONS (reproduce each exactly using the normal step schema):
+{json.dumps(ledger["definitions"], ensure_ascii=False, default=str)}
+
+COMPLETED OUTCOMES (reason from these; do not copy runtime fields):
+{json.dumps(ledger["outcomes"], ensure_ascii=False, default=str)}
+
+RECONCILIATION REASON:
+{reason}
+
+REJECTED NEW-STEP DELTA:
+{json.dumps([step.to_dict() for step in plan.steps], ensure_ascii=False)}
+
+AUDIT FINDINGS:
+{json.dumps(audit, ensure_ascii=False, default=str)}
+
+Return one valid json object containing only NEW `steps` using the normal step
+schema. Current step ids may appear only in depends_on. Add remediation work after
+completed history and a distinct final response after its sinks when configured.
+Never repeat a completed effect, alter source obligations, choose tools, or name atoms."""
+
+    def _invalid_amendment_repair_prompt(
+        self,
+        goal: str,
+        obligations: list[GoalObligation],
+        *,
+        current_steps: list[dict[str, Any]],
+        rejected: dict[str, Any],
+        reason: str,
+        validation_error: str,
+    ) -> str:
+        ledger = self._amendment_ledger_view(current_steps)
+        return f"""Repair one invalid reconciliation amendment before audit.
+
+SOURCE GOAL (immutable):
+{goal}
+
+OBLIGATION LEDGER (immutable):
+{json.dumps([item.to_dict() for item in obligations], ensure_ascii=False)}
+
+CURRENT STEP DEFINITIONS:
+{json.dumps(ledger["definitions"], ensure_ascii=False, default=str)}
+
+AUTHORITATIVE STEP OUTCOMES (reason from these; do not copy runtime fields):
+{json.dumps(ledger["outcomes"], ensure_ascii=False, default=str)}
+
+RECONCILIATION REASON:
+{reason}
+
+LIVE CAPABILITY CATALOG:
+{self._render_capability_catalog()}
+
+REJECTED AMENDMENT:
+{json.dumps(rejected, ensure_ascii=False, default=str)}
+
+VALIDATION ERROR:
+{validation_error}
+
+Return one valid json object containing only NEW `steps` using the normal step
+schema and capabilities in the live catalog. Current step ids may appear only in
+depends_on. Preserve completed effects and add a fresh final response after
+remediation when configured. Do not choose tools, name atoms, add capabilities,
+or copy runtime fields."""
+
+    @staticmethod
+    def _amendment_ledger_view(
+        current_steps: list[dict[str, Any]],
+    ) -> dict[str, list[dict[str, Any]]]:
+        definition_fields = (
+            "capability", "effect", "systems", "task", "success_criterion",
+            "expected_findings", "depends_on", "covers",
+        )
+        definitions = []
+        outcomes = []
+        for step in current_steps:
+            step_id = str(step.get("id") or step.get("step_id") or "")
+            definitions.append({
+                "step_id": step_id,
+                **{field: step.get(field) for field in definition_fields},
+            })
+            outcomes.append({
+                "step_id": step_id,
+                "status": step.get("status"),
+                "semantic_outcome": step.get("semantic_outcome"),
+                "semantic_decision": step.get("semantic_decision"),
+                "output": step.get("output"),
+            })
+        return {"definitions": definitions, "outcomes": outcomes}
 
     def _render_capability_catalog(self) -> str:
         lines = []
@@ -490,7 +835,18 @@ steps when one needs facts the other is expected to discover. A provider-owned
 inspect-or-create outcome is executable when its task explicitly discovers its own
 same-provider identifiers and its success criterion returns the concrete identifiers
 or links required downstream; do not demand atom-level steps for that discovery.
-Otherwise return complete=false and
+When a downstream outcome needs an artifact's content, require the producing step's
+task and success criterion to inspect and return provider-readback evidence of usable
+content. Resource existence, title, identifier, link or MIME type alone is insufficient.
+Every obligation must also have an independently verifiable success criterion. A named
+workflow or playbook is not an additional obligation when its meaning is fully defined
+by the atomic outcomes that follow it. Do not require a synthesis or inspection step
+merely to restate completion of those outcomes.
+
+For an invalid obligation ledger, return complete=false, `missing`, and a corrected
+`obligations` list using exactly id, description, source_quote. The corrected ledger may
+remove only redundant composite obligations and must preserve every independently
+verifiable source requirement. For an executable-step defect, omit `obligations` and
 list each missing item with description and an exact source_quote."""
 
     @staticmethod
@@ -523,6 +879,10 @@ list each missing item with description and an exact source_quote."""
         self,
         raw: dict[str, Any],
         obligations: list[GoalObligation],
+        allowed_dependency_ids: set[str] | None = None,
+        forbidden_step_ids: set[str] | None = None,
+        required_obligation_ids: set[str] | None = None,
+        allowed_cover_ids: set[str] | None = None,
     ) -> list[MeshPlannedStep]:
         raw_steps = raw.get("steps")
         if not isinstance(raw_steps, list) or not raw_steps:
@@ -534,13 +894,17 @@ list each missing item with description and an exact source_quote."""
             if not isinstance(item, dict):
                 raise MeshPlanError(f"Step {index} must be an object")
             allowed = {
-                "step_id", "capability", "effect", "systems", "task", "success_criterion",
+                "id", "step_id", "capability", "effect", "systems", "task", "success_criterion",
                 "expected_findings", "depends_on", "covers",
             }
             unknown = set(item) - allowed
             if unknown:
                 raise MeshPlanError(f"Step {index} has unsupported fields: {sorted(unknown)}")
-            step_id = str(item.get("step_id") or "").strip()
+            raw_id = str(item.get("id") or "").strip()
+            raw_step_id = str(item.get("step_id") or "").strip()
+            if raw_id and raw_step_id and raw_id != raw_step_id:
+                raise MeshPlanError(f"Step {index} has conflicting id and step_id")
+            step_id = raw_step_id or raw_id
             capability = str(item.get("capability") or "").strip()
             effect = str(item.get("effect") or "").strip()
             systems = [str(value).strip() for value in item.get("systems") or [] if str(value).strip()]
@@ -548,6 +912,8 @@ list each missing item with description and an exact source_quote."""
             criterion = str(item.get("success_criterion") or "").strip()
             if not step_id or step_id in step_ids:
                 raise MeshPlanError(f"Step {index} has a missing or duplicate step_id")
+            if step_id in (forbidden_step_ids or set()):
+                raise MeshPlanError(f"Step {step_id} already exists in immutable history")
             if capability not in self.capabilities:
                 raise MeshPlanError(f"Step {step_id} requests unknown capability {capability!r}")
             if effect not in {
@@ -591,26 +957,32 @@ list each missing item with description and an exact source_quote."""
             ))
 
         for step in steps:
-            missing_dependencies = set(step.depends_on) - step_ids
+            missing_dependencies = set(step.depends_on) - (
+                step_ids | (allowed_dependency_ids or set())
+            )
             if missing_dependencies or step.step_id in step.depends_on:
                 raise MeshPlanError(
                     f"Step {step.step_id} has invalid dependencies: "
                     f"{sorted(missing_dependencies | ({step.step_id} if step.step_id in step.depends_on else set()))}"
                 )
-            unknown_obligations = set(step.covers) - obligation_ids
+            valid_cover_ids = allowed_cover_ids or obligation_ids
+            unknown_obligations = set(step.covers) - valid_cover_ids
             if unknown_obligations:
                 raise MeshPlanError(
-                    f"Step {step.step_id} covers unknown obligations: {sorted(unknown_obligations)}"
+                    f"Step {step.step_id} covers obligations outside the amendment target: "
+                    f"{sorted(unknown_obligations)}"
                 )
         covered = {obligation for step in steps for obligation in step.covers}
-        uncovered = obligation_ids - covered
+        uncovered = (required_obligation_ids or obligation_ids) - covered
         if uncovered:
             raise MeshPlanError(f"Mesh plan has uncovered obligation(s): {sorted(uncovered)}")
-        self._reject_cycles(steps)
+        self._reject_cycles(steps, external_ids=allowed_dependency_ids or set())
         return steps
 
     @staticmethod
-    def _reject_cycles(steps: list[MeshPlannedStep]) -> None:
+    def _reject_cycles(
+        steps: list[MeshPlannedStep], external_ids: set[str] | None = None
+    ) -> None:
         dependencies = {step.step_id: set(step.depends_on) for step in steps}
         visiting = set()
         visited = set()
@@ -619,6 +991,9 @@ list each missing item with description and an exact source_quote."""
             if step_id in visiting:
                 raise MeshPlanError("Mesh plan contains a dependency cycle")
             if step_id in visited:
+                return
+            if step_id in (external_ids or set()):
+                visited.add(step_id)
                 return
             visiting.add(step_id)
             for dependency in dependencies[step_id]:

--- a/jarviscore/planning/mesh_planner.py
+++ b/jarviscore/planning/mesh_planner.py
@@ -1,0 +1,630 @@
+"""Compile a source goal into a validated capability-addressed mesh DAG."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from typing import Any
+
+
+class MeshPlanError(ValueError):
+    """The proposed plan cannot faithfully and safely enter the shared ledger."""
+
+
+@dataclass(frozen=True)
+class GoalObligation:
+    id: str
+    description: str
+    source_quote: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "description": self.description,
+            "source_quote": self.source_quote,
+        }
+
+
+@dataclass(frozen=True)
+class MeshPlannedStep:
+    step_id: str
+    capability: str
+    effect: str
+    systems: list[str]
+    task: str
+    success_criterion: str
+    expected_findings: list[str] = field(default_factory=list)
+    depends_on: list[str] = field(default_factory=list)
+    covers: list[str] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.step_id,
+            "capability": self.capability,
+            "effect": self.effect,
+            "systems": list(self.systems),
+            "task": self.task,
+            "success_criterion": self.success_criterion,
+            "expected_findings": list(self.expected_findings),
+            "depends_on": list(self.depends_on),
+            "covers": list(self.covers),
+        }
+
+
+@dataclass(frozen=True)
+class MeshPlan:
+    goal: str
+    obligations: list[GoalObligation]
+    steps: list[MeshPlannedStep]
+    revision: int = 1
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "goal": self.goal,
+            "obligations": [item.to_dict() for item in self.obligations],
+            "steps": [step.to_dict() for step in self.steps],
+            "revision": self.revision,
+        }
+
+
+class MeshPlanner:
+    """Produce work requirements; Redis claims decide which peer executes them."""
+
+    def __init__(
+        self,
+        llm_client,
+        capabilities: dict[str, Any],
+        response_capability: str | None = None,
+    ):
+        self.llm = llm_client
+        all_effects = {
+            "read", "propose", "write", "notify", "destructive", "final_response"
+        }
+        self.capability_contracts = {}
+        for name, offering in capabilities.items():
+            if isinstance(offering, dict):
+                effects = {str(value) for value in offering.get("effects", [])}
+                systems = [str(value) for value in offering.get("systems", [])]
+                description = str(offering.get("description") or name)
+            else:
+                effects = set(all_effects)
+                systems = []
+                description = str(offering)
+            if not effects or not effects <= all_effects:
+                raise MeshPlanError(f"Capability {name!r} has invalid effect authority")
+            self.capability_contracts[str(name)] = {
+                "description": description,
+                "effects": effects,
+                "systems": systems,
+            }
+        self.capabilities = {
+            name: contract["description"]
+            for name, contract in self.capability_contracts.items()
+        }
+        self.response_capability = response_capability
+        if response_capability and response_capability not in self.capabilities:
+            raise MeshPlanError(
+                f"Configured response capability {response_capability!r} is unavailable"
+            )
+        if (
+            response_capability
+            and "final_response"
+            not in self.capability_contracts[response_capability]["effects"]
+        ):
+            raise MeshPlanError(
+                f"Configured response capability {response_capability!r} "
+                "does not authorize final_response"
+            )
+
+    async def plan(self, goal: str, context: dict[str, Any] | None = None) -> MeshPlan:
+        source = (goal or "").strip()
+        if not source:
+            raise MeshPlanError("A mesh goal cannot be empty")
+        if not self.capabilities:
+            raise MeshPlanError("No mesh capabilities are available")
+        obligation_raw = await self._call_json(self._obligation_prompt(source))
+        try:
+            obligations = self._parse_obligations(obligation_raw, source)
+        except MeshPlanError as first_error:
+            try:
+                repaired_raw = await self._call_json(
+                    self._obligation_repair_prompt(
+                        source, obligation_raw, str(first_error)
+                    )
+                )
+                obligations = self._parse_obligations(repaired_raw, source)
+            except Exception as repair_error:
+                raise MeshPlanError(
+                    f"{first_error}; obligation repair failed: {repair_error}"
+                ) from repair_error
+        step_raw = await self._call_json(
+            self._step_prompt(source, obligations, context or {})
+        )
+        steps = self._ensure_response_step(self._parse_steps(step_raw, obligations))
+        plan = MeshPlan(goal=source, obligations=obligations, steps=steps)
+        audit = await self._call_json(self._audit_prompt(plan))
+        first_failure = audit.get("missing") or audit
+        for repair_attempt in range(1, 3):
+            if audit.get("complete") is True and not audit.get("missing"):
+                return plan
+            try:
+                repair_raw = await self._call_json(
+                    self._repair_prompt(plan, audit, context or {})
+                )
+                repaired_steps = self._ensure_response_step(
+                    self._parse_steps(repair_raw, obligations)
+                )
+                plan = MeshPlan(
+                    goal=source,
+                    obligations=obligations,
+                    steps=repaired_steps,
+                )
+                audit = await self._call_json(self._audit_prompt(plan))
+            except Exception as exc:
+                raise MeshPlanError(
+                    f"Mesh plan failed coverage audit: {first_failure}; "
+                    f"repair {repair_attempt} failed: {exc}"
+                ) from exc
+        if audit.get("complete") is not True or audit.get("missing"):
+            raise MeshPlanError(
+                "Mesh plan failed coverage audit after two repairs: "
+                f"{audit.get('missing') or audit}"
+            )
+        return plan
+
+    async def amend(
+        self,
+        goal: str,
+        *,
+        obligations: list[dict[str, Any]],
+        current_steps: list[dict[str, Any]],
+        reason: str,
+        revision: int,
+        context: dict[str, Any] | None = None,
+    ) -> MeshPlan:
+        """Replace unfinished work without changing the source obligation ledger."""
+        source = (goal or "").strip()
+        parsed_obligations = self._parse_obligations(
+            {"obligations": obligations}, source
+        )
+        step_raw = await self._call_json(
+            self._amendment_prompt(
+                source,
+                parsed_obligations,
+                current_steps,
+                reason,
+                context or {},
+            )
+        )
+        steps = self._ensure_response_step(
+            self._parse_steps(step_raw, parsed_obligations)
+        )
+        plan = MeshPlan(
+            goal=source,
+            obligations=parsed_obligations,
+            steps=steps,
+            revision=revision + 1,
+        )
+        audit = await self._call_json(self._audit_prompt(plan))
+        if audit.get("complete") is not True or audit.get("missing"):
+            raise MeshPlanError(
+                f"Mesh amendment failed coverage audit: {audit.get('missing') or audit}"
+            )
+        return plan
+
+    def _ensure_response_step(
+        self, steps: list[MeshPlannedStep]
+    ) -> list[MeshPlannedStep]:
+        capability = self.response_capability
+        if not capability or any(step.capability == capability for step in steps):
+            return steps
+        depended_on = {
+            dependency for step in steps for dependency in step.depends_on
+        }
+        sinks = [step.step_id for step in steps if step.step_id not in depended_on]
+        existing_ids = {step.step_id for step in steps}
+        step_id = "final_response"
+        suffix = 2
+        while step_id in existing_ids:
+            step_id = f"final_response_{suffix}"
+            suffix += 1
+        return [
+            *steps,
+            MeshPlannedStep(
+                step_id=step_id,
+                capability=capability,
+                effect="final_response",
+                systems=[],
+                task=(
+                    "Synthesize the completed peer artifacts into the explicit "
+                    "user-facing response. State the outcome and direct reason "
+                    "concisely; keep workflow internals in the artifact only."
+                ),
+                success_criterion=(
+                    "A concise user response states the outcome and direct reason "
+                    "without workflow IDs, step IDs, evidence pointers or trace details."
+                ),
+                expected_findings=["user-facing outcome"],
+                depends_on=sinks,
+                covers=[],
+            ),
+        ]
+
+    async def _call_json(self, prompt: str) -> dict[str, Any]:
+        try:
+            response = await self.llm.generate(
+                messages=[{"role": "user", "content": prompt}],
+                response_format={"type": "json_object"},
+                temperature=0.0,
+            )
+        except TypeError:
+            response = await self.llm.generate(
+                messages=[{"role": "user", "content": prompt}],
+                temperature=0.0,
+            )
+        content = response.get("content", "") if isinstance(response, dict) else str(response)
+        text = content.strip()
+        if text.startswith("```"):
+            text = "\n".join(
+                line for line in text.splitlines()
+                if not line.strip().startswith("```")
+            ).strip()
+        try:
+            parsed = json.loads(text)
+        except json.JSONDecodeError as exc:
+            raise MeshPlanError(f"Mesh planner response is not valid JSON: {exc}") from exc
+        if not isinstance(parsed, dict):
+            raise MeshPlanError("Mesh planner response must be a JSON object")
+        return parsed
+
+    @staticmethod
+    def _obligation_prompt(goal: str) -> str:
+        return f"""Extract the complete obligation ledger from one source goal.
+
+SOURCE GOAL:
+{goal}
+
+Return one valid json object with `obligations`. Each obligation has exactly:
+id, description, source_quote.
+- source_quote is an exact non-empty quote from SOURCE GOAL.
+- capture every requested outcome, constraint, prohibition, approval boundary,
+  fallback condition, scope limit and evidence requirement.
+- split independently verifiable obligations; do not add or execute work."""
+
+    @staticmethod
+    def _obligation_repair_prompt(
+        goal: str,
+        invalid: dict[str, Any],
+        validation_error: str,
+    ) -> str:
+        return f"""Repair one invalid obligation extraction against immutable source text.
+
+SOURCE GOAL (immutable):
+{goal}
+
+INVALID OBLIGATIONS:
+{json.dumps(invalid, ensure_ascii=False)}
+
+VALIDATION ERROR:
+{validation_error}
+
+Return one valid json object with `obligations`. Each obligation has exactly:
+id, description, source_quote.
+- Every source_quote must be one contiguous exact substring of SOURCE GOAL.
+- Preserve the intended meaning of every invalid obligation.
+- Do not add, remove, merge or split obligations.
+- Do not execute work or add requirements."""
+
+    def _step_prompt(
+        self,
+        goal: str,
+        obligations: list[GoalObligation],
+        context: dict[str, Any],
+    ) -> str:
+        catalog = self._render_capability_catalog()
+        public_context = {
+            key: value for key, value in context.items() if not str(key).startswith("_")
+        }
+        return f"""Compile one goal into a complete peer-executable DAG.
+
+SOURCE GOAL (preserve exactly):
+{goal}
+
+IMMUTABLE OBLIGATION LEDGER:
+{json.dumps([item.to_dict() for item in obligations], ensure_ascii=False)}
+
+LIVE CAPABILITY CATALOG:
+{catalog}
+
+PUBLIC CONTEXT:
+{json.dumps(public_context, ensure_ascii=False, default=str)}
+
+Return one valid json object with `steps`. Each step has exactly:
+step_id, capability, effect, systems, task, success_criterion,
+expected_findings, depends_on, covers.
+- capability must come from LIVE CAPABILITY CATALOG.
+- effect must be exactly one of: read, propose, write, notify, destructive, final_response.
+- systems lists every provider the step will call and must be authorized by the capability.
+- write, notify and destructive outcomes must name exactly one provider in systems.
+- covers contains obligation ids satisfied by the step.
+- use capabilities, never an agent ID or named instance.
+- reason about the information required to execute each effectful outcome. Every
+    required fact must come from the source goal or an ancestor step whose task and
+    success criterion resolve it. naming an entity does not supply its provider identifiers.
+- declare only real data dependencies; independent work should run in parallel only
+    when neither outcome needs information discovered by the other.
+- each task must include enough scope and constraints to execute independently.
+- model business outcomes, not provider calls or conditional branches.
+- keep an inspect-or-create, inspect-or-update, or check-then-act decision as one provider-owned outcome.
+  Use its mutating effect and one provider; the claiming peer receives both read and
+  authorized mutation tools and decides from current state.
+- a provider-owned outcome may resolve its own provider identifiers, folders, records,
+    and links before conditionally mutating; state that discovery explicitly in its task
+    and success criterion instead of inventing provider-call steps.
+- never make an always-required downstream outcome depend on an optional
+  mutation-only branch.
+
+Do not assign peers, choose winners, execute work or add requirements."""
+
+    def _repair_prompt(
+        self,
+        plan: MeshPlan,
+        audit: dict[str, Any],
+        context: dict[str, Any],
+    ) -> str:
+        public_context = {
+            key: value for key, value in context.items() if not str(key).startswith("_")
+        }
+        return f"""Repair one rejected peer-executable DAG before publication.
+
+SOURCE GOAL (immutable):
+{plan.goal}
+
+OBLIGATION LEDGER (immutable):
+{json.dumps([item.to_dict() for item in plan.obligations], ensure_ascii=False)}
+
+REJECTED DAG:
+{json.dumps([step.to_dict() for step in plan.steps], ensure_ascii=False)}
+
+INDEPENDENT AUDIT FINDINGS:
+{json.dumps(audit, ensure_ascii=False)}
+
+LIVE CAPABILITY CATALOG:
+{self._render_capability_catalog()}
+
+PUBLIC CONTEXT:
+{json.dumps(public_context, ensure_ascii=False, default=str)}
+
+Return one valid json object with a complete replacement `steps` list. Each step
+has exactly: step_id, capability, effect, systems, task, success_criterion,
+expected_findings, depends_on, covers.
+- resolve every audit finding without changing or adding obligations.
+- use capabilities, never agent IDs, named instances, atom names, or provider calls.
+- model business outcomes, not conditional branches.
+- keep inspect-or-create and check-then-act work as one provider-owned outcome;
+    its peer decides from current state whether the authorized mutation is necessary.
+- provider-owned outcomes should absorb missing same-provider resource discovery and
+    return concrete identifiers or links needed by dependents.
+- mutating outcomes use exactly one provider and an effect authorized by capability.
+- never make required downstream work depend on an optional mutation-only branch.
+- repair missing information dependencies: every effectful outcome must receive the
+    facts needed to fulfill the source objective from the source goal or an ancestor.
+- preserve real data dependencies and allow independent outcomes to run in parallel.
+
+Do not execute work or add requirements."""
+
+    def _amendment_prompt(
+        self,
+        goal: str,
+        obligations: list[GoalObligation],
+        current_steps: list[dict[str, Any]],
+        reason: str,
+        context: dict[str, Any],
+    ) -> str:
+        catalog = self._render_capability_catalog()
+        return f"""Amend the unfinished portion of one capability-addressed DAG.
+
+SOURCE GOAL (immutable):
+{goal}
+
+OBLIGATION LEDGER (immutable):
+{json.dumps([item.to_dict() for item in obligations], ensure_ascii=False)}
+
+CURRENT STEP LEDGER:
+{json.dumps(current_steps, ensure_ascii=False, default=str)}
+
+AMENDMENT REASON:
+{reason}
+
+LIVE CAPABILITY CATALOG:
+{catalog}
+
+PUBLIC CONTEXT:
+{json.dumps(context, ensure_ascii=False, default=str)}
+
+Return one valid json object with `steps`. Each step has exactly:
+step_id, capability, effect, systems, task, success_criterion,
+expected_findings, depends_on, covers.
+- reproduce every completed step exactly, including its id and definition.
+- replace only failed, blocked, waiting or pending work.
+- cover every immutable obligation and preserve dependencies on completed work.
+- capability must come from LIVE CAPABILITY CATALOG.
+- effect must be exactly one of: read, propose, write, notify, destructive, final_response.
+- systems lists every provider the step will call and must be authorized by the capability.
+- write, notify and destructive outcomes must name exactly one provider in systems.
+- use capabilities, never an agent ID or named instance.
+
+Do not assign peers, execute work, change completed work or add requirements."""
+
+    def _render_capability_catalog(self) -> str:
+        lines = []
+        for name, contract in sorted(self.capability_contracts.items()):
+            systems = ", ".join(contract["systems"]) or "none declared"
+            effects = ", ".join(sorted(contract["effects"]))
+            lines.append(
+                f"- {name}: {contract['description']} | effects: {effects} | systems: {systems}"
+            )
+        return "\n".join(lines)
+
+    @staticmethod
+    def _audit_prompt(plan: MeshPlan) -> str:
+        return f"""Audit a proposed mesh DAG against its immutable source goal.
+
+SOURCE GOAL:
+{plan.goal}
+
+OBLIGATIONS:
+{json.dumps([item.to_dict() for item in plan.obligations], ensure_ascii=False)}
+
+DAG STEPS:
+{json.dumps([step.to_dict() for step in plan.steps], ensure_ascii=False)}
+
+Return exactly one json object: {{"complete": true, "missing": []}} only if every requested
+outcome, constraint, prohibition, approval boundary, fallback condition, scope
+limit and evidence requirement in SOURCE GOAL exists in the obligation ledger
+and is covered by an executable DAG step. For every write, notify, or destructive
+step, verify that information needed to perform the intended action is supplied by the
+source goal or an ancestor step; naming a person, account, file, channel, or event is
+not equivalent to having its provider identifier or contact details. Flag parallel
+steps when one needs facts the other is expected to discover. A provider-owned
+inspect-or-create outcome is executable when its task explicitly discovers its own
+same-provider identifiers and its success criterion returns the concrete identifiers
+or links required downstream; do not demand atom-level steps for that discovery.
+Otherwise return complete=false and
+list each missing item with description and an exact source_quote."""
+
+    @staticmethod
+    def _parse_obligations(raw: dict[str, Any], goal: str) -> list[GoalObligation]:
+        raw_obligations = raw.get("obligations")
+        if not isinstance(raw_obligations, list) or not raw_obligations:
+            raise MeshPlanError("Mesh plan requires at least one obligation")
+
+        obligations = []
+        obligation_ids = set()
+        for index, item in enumerate(raw_obligations):
+            if not isinstance(item, dict):
+                raise MeshPlanError(f"Obligation {index} must be an object")
+            obligation_id = str(item.get("id") or "").strip()
+            description = str(item.get("description") or "").strip()
+            source_quote = str(item.get("source_quote") or "").strip()
+            if not obligation_id or obligation_id in obligation_ids:
+                raise MeshPlanError(f"Obligation {index} has a missing or duplicate id")
+            if not description:
+                raise MeshPlanError(f"Obligation {obligation_id} has no description")
+            if not source_quote or source_quote not in goal:
+                raise MeshPlanError(
+                    f"Obligation {obligation_id} source_quote is not present in the source goal"
+                )
+            obligation_ids.add(obligation_id)
+            obligations.append(GoalObligation(obligation_id, description, source_quote))
+        return obligations
+
+    def _parse_steps(
+        self,
+        raw: dict[str, Any],
+        obligations: list[GoalObligation],
+    ) -> list[MeshPlannedStep]:
+        raw_steps = raw.get("steps")
+        if not isinstance(raw_steps, list) or not raw_steps:
+            raise MeshPlanError("Mesh plan requires at least one step")
+        obligation_ids = {item.id for item in obligations}
+        steps = []
+        step_ids = set()
+        for index, item in enumerate(raw_steps):
+            if not isinstance(item, dict):
+                raise MeshPlanError(f"Step {index} must be an object")
+            allowed = {
+                "step_id", "capability", "effect", "systems", "task", "success_criterion",
+                "expected_findings", "depends_on", "covers",
+            }
+            unknown = set(item) - allowed
+            if unknown:
+                raise MeshPlanError(f"Step {index} has unsupported fields: {sorted(unknown)}")
+            step_id = str(item.get("step_id") or "").strip()
+            capability = str(item.get("capability") or "").strip()
+            effect = str(item.get("effect") or "").strip()
+            systems = [str(value).strip() for value in item.get("systems") or [] if str(value).strip()]
+            task = str(item.get("task") or "").strip()
+            criterion = str(item.get("success_criterion") or "").strip()
+            if not step_id or step_id in step_ids:
+                raise MeshPlanError(f"Step {index} has a missing or duplicate step_id")
+            if capability not in self.capabilities:
+                raise MeshPlanError(f"Step {step_id} requests unknown capability {capability!r}")
+            if effect not in {
+                "read", "propose", "write", "notify", "destructive", "final_response"
+            }:
+                raise MeshPlanError(f"Step {step_id} requires a valid effect")
+            if effect in {"write", "notify", "destructive"} and len(systems) != 1:
+                raise MeshPlanError(
+                    f"Step {step_id} with effect {effect!r} requires exactly one system"
+                )
+            authorized = self.capability_contracts[capability]["effects"]
+            if effect not in authorized:
+                raise MeshPlanError(
+                    f"Capability {capability!r} does not authorize effect {effect!r}"
+                )
+            authorized_systems = set(self.capability_contracts[capability]["systems"])
+            unauthorized_systems = set(systems) - authorized_systems
+            if unauthorized_systems:
+                raise MeshPlanError(
+                    f"Capability {capability!r} does not authorize systems: "
+                    f"{sorted(unauthorized_systems)}"
+                )
+            if not task or not criterion:
+                raise MeshPlanError(f"Step {step_id} requires task and success_criterion")
+            expected_raw = item.get("expected_findings") or []
+            expected_findings = (
+                [expected_raw.strip()] if isinstance(expected_raw, str) and expected_raw.strip()
+                else [str(value) for value in expected_raw]
+            )
+            step_ids.add(step_id)
+            steps.append(MeshPlannedStep(
+                step_id=step_id,
+                capability=capability,
+                effect=effect,
+                systems=systems,
+                task=task,
+                success_criterion=criterion,
+                expected_findings=expected_findings,
+                depends_on=[str(value) for value in item.get("depends_on") or []],
+                covers=[str(value) for value in item.get("covers") or []],
+            ))
+
+        for step in steps:
+            missing_dependencies = set(step.depends_on) - step_ids
+            if missing_dependencies or step.step_id in step.depends_on:
+                raise MeshPlanError(
+                    f"Step {step.step_id} has invalid dependencies: "
+                    f"{sorted(missing_dependencies | ({step.step_id} if step.step_id in step.depends_on else set()))}"
+                )
+            unknown_obligations = set(step.covers) - obligation_ids
+            if unknown_obligations:
+                raise MeshPlanError(
+                    f"Step {step.step_id} covers unknown obligations: {sorted(unknown_obligations)}"
+                )
+        covered = {obligation for step in steps for obligation in step.covers}
+        uncovered = obligation_ids - covered
+        if uncovered:
+            raise MeshPlanError(f"Mesh plan has uncovered obligation(s): {sorted(uncovered)}")
+        self._reject_cycles(steps)
+        return steps
+
+    @staticmethod
+    def _reject_cycles(steps: list[MeshPlannedStep]) -> None:
+        dependencies = {step.step_id: set(step.depends_on) for step in steps}
+        visiting = set()
+        visited = set()
+
+        def visit(step_id: str) -> None:
+            if step_id in visiting:
+                raise MeshPlanError("Mesh plan contains a dependency cycle")
+            if step_id in visited:
+                return
+            visiting.add(step_id)
+            for dependency in dependencies[step_id]:
+                visit(dependency)
+            visiting.remove(step_id)
+            visited.add(step_id)
+
+        for step_id in dependencies:
+            visit(step_id)

--- a/jarviscore/profiles/autoagent.py
+++ b/jarviscore/profiles/autoagent.py
@@ -19,6 +19,62 @@ if TYPE_CHECKING:
     from jarviscore.planning.goal_context import GoalExecution
 
 
+class _AutoAgentMeshProxy:
+    """Parent-side delegation surface for this agent's isolated code process."""
+
+    def __init__(self, agent: "AutoAgent"):
+        self.agent = agent
+
+    def list_peers(self) -> List[Dict[str, Any]]:
+        peers = getattr(self.agent, "peers", None)
+        return peers.list_peers() if peers is not None else []
+
+    async def delegate(
+        self,
+        *,
+        to: str,
+        task: str,
+        context: Optional[Dict[str, Any]] = None,
+        capability: Optional[str] = None,
+        timeout: Optional[float] = None,
+    ) -> Dict[str, Any]:
+        peers = getattr(self.agent, "peers", None)
+        if peers is None:
+            raise RuntimeError("This agent is not attached to a mesh.")
+        available = self.list_peers()
+        target = next(
+            (
+                peer for peer in available
+                if to and (peer.get("agent_id") == to or peer.get("role") == to)
+            ),
+            None,
+        )
+        if target is None and capability:
+            target = next(
+                (
+                    peer for peer in available
+                    if capability in (peer.get("capabilities") or [])
+                ),
+                None,
+            )
+        if target is None:
+            raise ValueError(
+                f"No peer matches role/id {to!r} or capability {capability!r}."
+            )
+        response = await peers.request(
+            str(target["agent_id"]),
+            {"task": task},
+            timeout=float(timeout or 7200.0),
+            context=dict(context or {}),
+        )
+        if response is None:
+            return {
+                "status": "failure",
+                "error": f"Peer {target['agent_id']!r} did not respond.",
+            }
+        return response
+
+
 
 
 class AutoAgent(Profile):
@@ -145,6 +201,67 @@ class AutoAgent(Profile):
         # ── Agent intelligence: profile block prepended to system prompt ──
         # Loaded lazily in setup() from jarviscore/profiles/agents/{role}.yaml
         self._profile_block: str = ""
+        self._peer_execution_lock = asyncio.Lock()
+
+    async def _handle_peer_request(self, message) -> Dict[str, Any]:
+        async with self._peer_execution_lock:
+            handler = getattr(self, "on_peer_request", None)
+            if callable(handler):
+                response = await handler(message)
+                if response is not None:
+                    return response
+            data = message.data if isinstance(message.data, dict) else {}
+            task_desc = data.get("query") or data.get("task")
+            if not isinstance(task_desc, str) or not task_desc.strip():
+                return {
+                    "status": "failure",
+                    "error": "Peer requests require a query or task.",
+                }
+            context = dict(message.context or {})
+            requested_capability = str(data.get("capability") or "").strip()
+            if requested_capability:
+                if requested_capability not in self.capabilities:
+                    return {
+                        "status": "failure",
+                        "error": (
+                            f"{self.role} does not own capability "
+                            f"{requested_capability!r}."
+                        ),
+                    }
+                context["capability"] = requested_capability
+                contract = (
+                    getattr(self, "capability_contracts", {}) or {}
+                ).get(requested_capability) or {}
+                systems = [str(value) for value in contract.get("systems") or []]
+                effects = [str(value) for value in contract.get("effects") or []]
+                if systems:
+                    context["systems"] = systems
+                    if len(systems) == 1:
+                        context["system"] = systems[0]
+                for effect in ("read", "propose", "write", "notify", "destructive"):
+                    if effect in effects:
+                        context["effect"] = effect
+                        break
+            context.update(
+                peer_sender=message.sender,
+                peer_correlation_id=message.correlation_id,
+            )
+            return await self.execute_task({"task": task_desc.strip(), "context": context})
+
+    async def _handle_peer_notify(self, message) -> None:
+        handler = getattr(self, "on_peer_notify", None)
+        if callable(handler):
+            await handler(message)
+        if self.mailbox is None:
+            return
+        context = dict(message.context or {})
+        self.mailbox.deliver(
+            message.sender,
+            message.data if isinstance(message.data, dict) else {"message": message.data},
+            workflow_id=context.get("workflow_id"),
+            step_id=context.get("step_id"),
+            context=context or None,
+        )
 
     async def setup(self):
         """
@@ -216,6 +333,7 @@ class AutoAgent(Profile):
         self.sandbox = create_coder_sandbox(
             timeout=timeout,
             nexus_call_proxy=nexus_proxy,
+            mesh_proxy=_AutoAgentMeshProxy(self),
             blob_storage=getattr(self, '_blob_storage', None),
             artifact_prefix=f"artifacts/{self.role}",
         )
@@ -262,16 +380,8 @@ class AutoAgent(Profile):
         if config.get("hitl_enabled", False):
             try:
                 from jarviscore.kernel.hitl import AdaptiveHITLPolicy
-                self._kernel.hitl_policy = AdaptiveHITLPolicy(
-                    enabled=True,
-                    max_confidence=config.get("hitl_max_confidence", 0.8),
-                    min_risk_score=config.get("hitl_min_risk_score", 0.7),
-                )
-                self._logger.info(
-                    "AdaptiveHITLPolicy enabled (max_confidence=%.2f, min_risk=%.2f)",
-                    config.get("hitl_max_confidence", 0.8),
-                    config.get("hitl_min_risk_score", 0.7),
-                )
+                self._kernel.hitl_policy = AdaptiveHITLPolicy(enabled=True)
+                self._logger.info("Typed human-only HITL admissibility enabled")
             except ImportError:
                 self._logger.debug("AdaptiveHITLPolicy import failed — HITL adaptive escalation disabled")
 
@@ -337,7 +447,18 @@ class AutoAgent(Profile):
         """
         from jarviscore.core.envelope import attach_result_summary
 
+        pending_messages = []
+        mailbox = getattr(self, "mailbox", None)
+        if mailbox is not None:
+            pending_messages = mailbox.peek(limit=10)
+            if pending_messages:
+                task = dict(task)
+                context = dict(task.get("context") or {})
+                context["_mailbox_context"] = mailbox.format_for_context(pending_messages)
+                task["context"] = context
         envelope = await self._execute_task_pipeline(task)
+        if pending_messages and isinstance(envelope, dict) and envelope.get("status") == "success":
+            mailbox.read(max_messages=len(pending_messages))
         if isinstance(envelope, dict):
             attach_result_summary(envelope)
         return envelope
@@ -382,6 +503,13 @@ class AutoAgent(Profile):
 
         self._logger.info(f"[AutoAgent] Executing via Kernel: {task_desc[:100]}...")
 
+        attach_mesh = getattr(self._kernel, "attach_mesh_capabilities", None)
+        if callable(attach_mesh):
+            attach_mesh(
+                peers=getattr(self, "peers", None),
+                mailbox=getattr(self, "mailbox", None),
+            )
+
         # ── Declared single-turn contracts bypass the kernel pipeline ───────
         # (issue #63/JC-003): execution_shape single_response promises "just
         # answer" — one structured completion against the system prompt, not a
@@ -405,13 +533,25 @@ class AutoAgent(Profile):
             self._direct_kernel_turn = False
             self._direct_kernel_complexity = None
             self._direct_kernel_reason = None
+            if isinstance(ctx, dict) and ctx.get("peer_requester_agent_id"):
+                self._direct_kernel_turn = True
+                self._direct_kernel_complexity = "moderate"
+                self._direct_kernel_reason = (
+                    "A peer capability request is a bounded specialist assignment; "
+                    "execute it through one agentic Kernel OODA loop."
+                )
+                complexity = None
+            else:
+                complexity = None
             try:
                 from jarviscore.planning.classifier import ComplexityVerdict, TaskComplexityClassifier
 
                 execution_contract: Dict[str, Any] = {}
                 if isinstance(ctx, dict) and isinstance(ctx.get("execution_contract"), dict):
                     execution_contract = cast(Dict[str, Any], ctx.get("execution_contract"))
-                if execution_contract.get("execution_shape") in {"single_response", "single_artifact"}:
+                if getattr(self, '_direct_kernel_turn', False):
+                    pass
+                elif execution_contract.get("execution_shape") in {"single_response", "single_artifact"}:
                     complexity = ComplexityVerdict(
                         level="moderate",
                         reason=(
@@ -457,6 +597,10 @@ class AutoAgent(Profile):
                     getattr(completed[-1].output, "payload", None)
                     if completed else None
                 )
+                final_metadata = (
+                    getattr(completed[-1].output, "metadata", None) or {}
+                    if completed else {}
+                )
                 return {
                     "status": execution.status if execution.status != "complete" else "success",
                     "output": final_payload if final_payload is not None else execution.result,
@@ -468,6 +612,16 @@ class AutoAgent(Profile):
                     "tokens": goal_tokens,
                     "cost_usd": goal_cost,
                     "repairs": 0,
+                    "yield_metadata": {
+                        key: final_metadata.get(key)
+                        for key in (
+                            "yield_pending", "typed_outcome", "hitl_type",
+                            "system", "connection_id", "workflow_id", "step_id",
+                            "action_id", "action", "consequence",
+                            "autonomous_paths_exhausted", "human_exclusive",
+                        )
+                        if final_metadata.get(key) is not None
+                    },
                 }
 
         # ── Build effective system prompt = profile intelligence + role prompt ──
@@ -878,6 +1032,14 @@ class AutoAgent(Profile):
         env_max_steps = os.environ.get("MAX_GOAL_STEPS")
         if env_max_steps:
             max_steps = int(env_max_steps)
+        from jarviscore.orchestration.envelopes import ExecutionBudget
+        budget = ExecutionBudget.from_record(
+            (context or {}).get("execution_budget")
+            if isinstance(context, dict)
+            else None
+        )
+        max_steps = min(max_steps, budget.max_steps)
+        max_replan_attempts = min(max_replan_attempts, budget.max_replans)
         if self._kernel is None:
             raise RuntimeError(
                 f"{self.__class__.__name__}.execute_goal() called before setup(). "
@@ -985,6 +1147,15 @@ class AutoAgent(Profile):
 
 
         while remaining and steps_run < max_steps:
+            if time.time() - execution.started_at >= budget.max_seconds:
+                _cancel_inflight()
+                execution.status = "blocked"
+                execution.error = (
+                    f"Goal execution reached its {budget.max_seconds:g}s "
+                    "workflow budget."
+                )
+                execution.completed_at = time.time()
+                return await self._finalize_incomplete(execution)
             # ── Dependency-aware step selection (issue #74, review fix) ──────
             # A replanned or model-ordered plan may list a step before its
             # dependency — never run a step whose depends_on are unsatisfied.
@@ -1084,6 +1255,7 @@ class AutoAgent(Profile):
 
             # ── Evaluate step ─────────────────────────────────────────────────
             try:
+                execution.remaining_plan = list(remaining)
                 evaluation = await evaluator.evaluate(step, output, execution)
             except EvaluatorError as exc:
                 self._logger.error(
@@ -1129,11 +1301,31 @@ class AutoAgent(Profile):
             # Durability: every completed step survives a crash (issue #73)
             await self._persist_goal(execution)
 
+            goal_tokens, _ = self._aggregate_goal_telemetry(execution)
+            if goal_tokens["total"] >= budget.max_tokens and remaining:
+                _cancel_inflight()
+                execution.status = "blocked"
+                execution.error = (
+                    f"Goal execution reached its {budget.max_tokens} token "
+                    "workflow budget."
+                )
+                execution.completed_at = time.time()
+                return await self._finalize_incomplete(execution)
+
             self._logger.info(
                 "[AutoAgent] Step %s: verdict=%s (confidence=%.2f) — %s",
                 step.step_id, evaluation.verdict, evaluation.confidence,
                 evaluation.evaluator_note[:120],
             )
+
+            if evaluation.goal_decision == "complete" and evaluation.passed:
+                self._logger.info(
+                    "[AutoAgent] Goal converged after %s: %s",
+                    step.step_id,
+                    evaluation.goal_note[:200],
+                )
+                _cancel_inflight()
+                remaining = []
 
             # ── Handle verdict ────────────────────────────────────────────────
             if evaluation.needs_hitl:
@@ -1171,7 +1363,7 @@ class AutoAgent(Profile):
                                 f"**Confidence:** {evaluation.confidence:.0%}"
                             ),
                             urgency="normal",
-                            category=self._hitl_category_from_output(output),
+                            category=evaluation.hitl_category,
                             context={
                                 "goal": goal,
                                 "step_id": step.step_id,
@@ -1214,7 +1406,9 @@ class AutoAgent(Profile):
                     revised = await planner.replan(
                         goal_execution=execution,
                         failed_step=completed_step,
-                        reason=evaluation.evaluator_note,
+                        reason=(
+                            evaluation.goal_note or evaluation.evaluator_note
+                        ),
                         pending_steps=list(remaining),
                         budget_note=(
                             f"{steps_run} of max {max_steps} steps used; "

--- a/jarviscore/skills/jarviscore/SKILL.md
+++ b/jarviscore/skills/jarviscore/SKILL.md
@@ -54,12 +54,16 @@ class ProcessorAgent(CustomAgent):
         return {"status": "success", "result": ...}
 ```
 
-## Two ways to run, one rule
+## Three ways to run
 
 - `mesh.run_task(agent=..., task=...)`: one task, one agent. Single asks and hand-rolled pipelines.
 - `mesh.workflow(id, steps)`: declared steps as one traced unit with ordering, dependencies, and retries.
+- `mesh.execute_goal(goal, workflow_id=...)`: Redis-backed natural-language goal compiled into capability-addressed work that peers claim independently.
 
 Rule: if you are pasting one agent's output into another agent's prompt by hand, use `workflow`.
+If the application does not know the steps and peers should own work by
+capability, use `execute_goal`; it requires Redis and at least one node with a
+planning LLM.
 
 ```python
 results = await mesh.workflow("wf-1", [
@@ -68,6 +72,12 @@ results = await mesh.workflow("wf-1", [
 ])
 print(results[0]["output"])   # results carry status, output, metadata
 ```
+
+For `execute_goal`, read `status`, `obligation_status` and `response_status`
+independently. Revisions append attempts; filter `steps` by `plan_revision` for
+current execution. Existing AutoAgent and CustomAgent results remain compatible.
+An optional semantic `interpretation` must use the obligation IDs in the current
+step's `covers` list rather than requirement prose.
 
 ## Configuration
 
@@ -110,6 +120,8 @@ Use the installed catalog rather than a fixed integration count. See the
 - Forgetting `await mesh.start()` before running tasks.
 - Using `AutoAgent` for deterministic logic (slow, expensive) or `CustomAgent` for open-ended tasks (you will rebuild the kernel badly).
 - Reading `result["payload"]`. The output key is `output`.
+- Treating distributed `status="completed"` as proof that every source obligation is satisfied.
+- Expecting `replan_goal()` to erase prior attempts; revisions are append-only.
 - Assuming P2P works without the `[p2p]` extra installed.
 
 ## Deeper documentation

--- a/jarviscore/storage/redis_store.py
+++ b/jarviscore/storage/redis_store.py
@@ -10,6 +10,7 @@ import logging
 import os
 import time
 from typing import Any, Dict, List, Optional, cast
+from uuid import uuid4
 
 import redis
 
@@ -18,6 +19,14 @@ from jarviscore.contracts.hitl import (
     HITLResolution,
     HITLStatus,
     normalize_hitl_decision,
+)
+from jarviscore.orchestration.envelopes import (
+    CapabilityMandate,
+    ExecutionBudget,
+    WorkflowEvidence,
+    WorkflowEnvelope,
+    neutral_context,
+    terminal_step_status,
 )
 
 logger = logging.getLogger(__name__)
@@ -354,26 +363,1036 @@ class RedisContextStore:
         return messages
 
     # ------------------------------------------------------------------
+    # Capability needs
+    # ------------------------------------------------------------------
+
+    def publish_capability_need(
+        self,
+        workflow_id: str,
+        *,
+        requester_agent_id: str,
+        requester_step_id: str,
+        capability: str,
+        question: str,
+        context: Optional[Dict[str, Any]] = None,
+    ) -> str:
+        """Publish a durable peer-resolvable gap without assigning an owner."""
+        need_id = f"need-{uuid4().hex}"
+        now = time.time()
+        record = CapabilityMandate.open(
+            mandate_id=need_id,
+            workflow_id=workflow_id,
+            requester_agent_id=requester_agent_id,
+            requester_step_id=requester_step_id,
+            capability=capability,
+            question=question,
+            context=context,
+            now=now,
+        ).to_record()
+        needs_key = f"capability_needs:{workflow_id}"
+        pipe = self._redis.pipeline(transaction=True)
+        pipe.hset(needs_key, mapping={need_id: json.dumps(record, default=str)})
+        pipe.expire(needs_key, self._ttl_seconds)
+        pipe.sadd("jarviscore:workflows_with_capability_needs", workflow_id)
+        pipe.expire("jarviscore:workflows_with_capability_needs", self._ttl_seconds)
+        pipe.xadd(f"ledgers:{workflow_id}", {
+            "event": "capability_need_published",
+            "need_id": need_id,
+            "requester_agent_id": requester_agent_id,
+            "requester_step_id": requester_step_id,
+            "capability": capability,
+            "timestamp": str(now),
+        })
+        pipe.expire(f"ledgers:{workflow_id}", self._ttl_seconds)
+        pipe.execute()
+        return need_id
+
+    def get_workflows_with_capability_needs(self) -> List[str]:
+        return sorted(self._redis.smembers(
+            "jarviscore:workflows_with_capability_needs"
+        ))
+
+    def get_capability_need(
+        self, workflow_id: str, need_id: str
+    ) -> Optional[Dict[str, Any]]:
+        raw = self._redis.hget(f"capability_needs:{workflow_id}", need_id)
+        return CapabilityMandate.from_record(json.loads(raw)).to_record() if raw else None
+
+    def get_open_capability_needs(self, workflow_id: str) -> List[Dict[str, Any]]:
+        records = []
+        for raw in self._redis.hvals(f"capability_needs:{workflow_id}"):
+            try:
+                record = CapabilityMandate.from_record(json.loads(raw)).to_record()
+            except (json.JSONDecodeError, TypeError):
+                continue
+            if record.get("status") in {"open", "claimed"}:
+                records.append(record)
+        return sorted(records, key=lambda item: float(item.get("created_at", 0)))
+
+    def claim_capability_need(
+        self,
+        workflow_id: str,
+        need_id: str,
+        claim_id: str,
+        capabilities: set[str],
+        lease_seconds: int = 60,
+    ) -> bool:
+        needs_key = f"capability_needs:{workflow_id}"
+        lock_key = f"capability_need_lock:{workflow_id}:{need_id}"
+        lease_seconds = max(1, int(lease_seconds))
+        pipe = self._redis.pipeline()
+        while True:
+            try:
+                pipe.watch(needs_key, lock_key)
+                if pipe.exists(lock_key):
+                    pipe.unwatch()
+                    return False
+                raw = pipe.hget(needs_key, need_id)
+                if raw is None:
+                    pipe.unwatch()
+                    return False
+                mandate = CapabilityMandate.from_record(json.loads(raw))
+                if (
+                    mandate.status != "open"
+                    or mandate.capability not in capabilities
+                    or mandate.requester_agent_id == claim_id.split(":", 1)[0]
+                ):
+                    pipe.unwatch()
+                    return False
+                now = time.time()
+                mandate = mandate.claimed(
+                    claim_id,
+                    claim_id.split(":", 1)[0],
+                    now + lease_seconds,
+                    now,
+                )
+                record = mandate.to_record()
+                pipe.multi()
+                pipe.set(lock_key, claim_id, ex=lease_seconds)
+                pipe.hset(needs_key, mapping={need_id: json.dumps(record, default=str)})
+                pipe.xadd(f"ledgers:{workflow_id}", {
+                    "event": "capability_need_claimed",
+                    "need_id": need_id,
+                    "agent_id": record["claimed_by"],
+                    "claim_id": claim_id,
+                    "timestamp": str(now),
+                })
+                pipe.expire(f"ledgers:{workflow_id}", self._ttl_seconds)
+                pipe.execute()
+                return True
+            except redis.WatchError:
+                continue
+
+    def fulfill_capability_need(
+        self,
+        workflow_id: str,
+        need_id: str,
+        claim_id: str,
+        result: Dict[str, Any],
+    ) -> bool:
+        needs_key = f"capability_needs:{workflow_id}"
+        lock_key = f"capability_need_lock:{workflow_id}:{need_id}"
+        pipe = self._redis.pipeline()
+        while True:
+            try:
+                pipe.watch(needs_key, lock_key)
+                raw = pipe.hget(needs_key, need_id)
+                if raw is None or pipe.get(lock_key) != claim_id:
+                    pipe.unwatch()
+                    return False
+                mandate = CapabilityMandate.from_record(json.loads(raw))
+                if (
+                    mandate.status != "claimed"
+                    or mandate.claim is None
+                    or mandate.claim.claim_id != claim_id
+                ):
+                    pipe.unwatch()
+                    return False
+                now = time.time()
+                failed = str(result.get("status") or "").lower() in {
+                    "error", "failed", "failure"
+                }
+                if failed:
+                    record = mandate.failed(
+                        str(result.get("error") or "Peer execution failed"), now
+                    ).to_record()
+                    event = "capability_need_failed"
+                else:
+                    record = mandate.fulfilled(
+                        claim_id.split(":", 1)[0], result, now
+                    ).to_record()
+                    event = "capability_need_fulfilled"
+                pipe.multi()
+                pipe.hset(needs_key, mapping={need_id: json.dumps(record, default=str)})
+                pipe.delete(lock_key)
+                pipe.xadd(f"ledgers:{workflow_id}", {
+                    "event": event,
+                    "need_id": need_id,
+                    "agent_id": claim_id.split(":", 1)[0],
+                    "timestamp": str(now),
+                })
+                pipe.expire(f"ledgers:{workflow_id}", self._ttl_seconds)
+                pipe.execute()
+                if not self.get_open_capability_needs(workflow_id):
+                    self._redis.srem(
+                        "jarviscore:workflows_with_capability_needs", workflow_id
+                    )
+                return True
+            except redis.WatchError:
+                continue
+
+    def fail_capability_need(
+        self,
+        workflow_id: str,
+        need_id: str,
+        requester_agent_id: str,
+        reason: str,
+    ) -> bool:
+        """End an active mandate from its requester and invalidate its claim."""
+        needs_key = f"capability_needs:{workflow_id}"
+        lock_key = f"capability_need_lock:{workflow_id}:{need_id}"
+        pipe = self._redis.pipeline()
+        while True:
+            try:
+                pipe.watch(needs_key, lock_key)
+                raw = pipe.hget(needs_key, need_id)
+                if raw is None:
+                    pipe.unwatch()
+                    return False
+                mandate = CapabilityMandate.from_record(json.loads(raw))
+                if (
+                    mandate.requester_agent_id != requester_agent_id
+                    or mandate.status not in {"open", "claimed"}
+                ):
+                    pipe.unwatch()
+                    return False
+                now = time.time()
+                record = mandate.failed(reason, now).to_record()
+                pipe.multi()
+                pipe.hset(needs_key, mapping={need_id: json.dumps(record, default=str)})
+                pipe.delete(lock_key)
+                pipe.xadd(f"ledgers:{workflow_id}", {
+                    "event": "capability_need_failed",
+                    "need_id": need_id,
+                    "agent_id": requester_agent_id,
+                    "timestamp": str(now),
+                })
+                pipe.expire(f"ledgers:{workflow_id}", self._ttl_seconds)
+                pipe.execute()
+                if not self.get_open_capability_needs(workflow_id):
+                    self._redis.srem(
+                        "jarviscore:workflows_with_capability_needs", workflow_id
+                    )
+                return True
+            except redis.WatchError:
+                continue
+
+    def renew_capability_need_claim(
+        self,
+        workflow_id: str,
+        need_id: str,
+        claim_id: str,
+        lease_seconds: int = 60,
+    ) -> bool:
+        """Extend an active capability claim while preserving fencing."""
+        needs_key = f"capability_needs:{workflow_id}"
+        lock_key = f"capability_need_lock:{workflow_id}:{need_id}"
+        cancelled_key = f"workflow_cancelled:{workflow_id}"
+        lease_seconds = max(1, int(lease_seconds))
+        pipe = self._redis.pipeline()
+        while True:
+            try:
+                pipe.watch(needs_key, lock_key, cancelled_key)
+                if pipe.exists(cancelled_key) or pipe.get(lock_key) != claim_id:
+                    pipe.unwatch()
+                    return False
+                raw = pipe.hget(needs_key, need_id)
+                if raw is None:
+                    pipe.unwatch()
+                    return False
+                mandate = CapabilityMandate.from_record(json.loads(raw))
+                if (
+                    mandate.status != "claimed"
+                    or mandate.claim is None
+                    or mandate.claim.claim_id != claim_id
+                ):
+                    pipe.unwatch()
+                    return False
+                now = time.time()
+                record = mandate.renewed(now + lease_seconds, now).to_record()
+                pipe.multi()
+                pipe.expire(lock_key, lease_seconds)
+                pipe.hset(
+                    needs_key,
+                    mapping={need_id: json.dumps(record, default=str)},
+                )
+                pipe.execute()
+                return True
+            except redis.WatchError:
+                continue
+
+    def recover_expired_capability_need(
+        self, workflow_id: str, need_id: str
+    ) -> bool:
+        needs_key = f"capability_needs:{workflow_id}"
+        lock_key = f"capability_need_lock:{workflow_id}:{need_id}"
+        pipe = self._redis.pipeline()
+        while True:
+            try:
+                pipe.watch(needs_key, lock_key)
+                raw = pipe.hget(needs_key, need_id)
+                if raw is None or pipe.exists(lock_key):
+                    pipe.unwatch()
+                    return False
+                mandate = CapabilityMandate.from_record(json.loads(raw))
+                if mandate.status != "claimed":
+                    pipe.unwatch()
+                    return False
+                record = mandate.reopened(time.time()).to_record()
+                pipe.multi()
+                pipe.hset(needs_key, mapping={need_id: json.dumps(record, default=str)})
+                pipe.execute()
+                return True
+            except redis.WatchError:
+                continue
+
+    # ------------------------------------------------------------------
     # Workflow DAG
     # ------------------------------------------------------------------
 
-    def init_workflow_graph(self, workflow_id: str, steps: List[Dict]) -> bool:
-        """Initialize Redis DAG for a workflow."""
-        key = f"workflow_graph:{workflow_id}"
+    def register_workflow_goal(
+        self,
+        workflow_id: str,
+        goal: str,
+        context: Optional[Dict[str, Any]] = None,
+        budget: Optional[Dict[str, Any]] = None,
+    ) -> bool:
+        """Persist source intent once; the same workflow id cannot change meaning."""
+        key = f"workflow_goal:{workflow_id}"
+        ledger_key = f"ledgers:{workflow_id}"
+        budget_key = f"workflow_budget:{workflow_id}"
+        normalized_budget = ExecutionBudget.from_record(budget).to_record()
+        encoded = json.dumps({
+            "workflow_id": workflow_id,
+            "goal": goal,
+            "context": neutral_context(context),
+            "budget": normalized_budget,
+        }, default=str)
+        pipe = self._redis.pipeline()
+        while True:
+            try:
+                pipe.watch(key)
+                existing = pipe.get(key)
+                if existing is not None:
+                    pipe.unwatch()
+                    if existing != encoded:
+                        raise ValueError(
+                            f"Workflow {workflow_id!r} is already bound to another goal"
+                        )
+                    return False
+                now = time.time()
+                pipe.multi()
+                pipe.set(key, encoded, ex=self._ttl_seconds)
+                pipe.hset(budget_key, mapping={
+                    "max_tokens_per_epoch": normalized_budget["max_tokens"],
+                    "used_tokens": 0,
+                    "cost_usd": 0.0,
+                    "call_count": 0,
+                    "epoch_count": 0,
+                })
+                pipe.expire(budget_key, self._ttl_seconds)
+                pipe.sadd("jarviscore:pending_goal_plans", workflow_id)
+                pipe.expire("jarviscore:pending_goal_plans", self._ttl_seconds)
+                pipe.xadd(ledger_key, {
+                    "event": "goal_registered",
+                    "timestamp": str(now),
+                })
+                pipe.expire(ledger_key, self._ttl_seconds)
+                pipe.execute()
+                return True
+            except redis.WatchError:
+                continue
+
+    def reserve_workflow_tokens(
+        self,
+        workflow_id: str,
+        epoch_id: str,
+        reservation_id: str,
+        tokens: int,
+        *,
+        lease_seconds: float = 900.0,
+    ) -> bool:
+        """Atomically reserve workflow-global LLM capacity before dispatch."""
+        budget_key = f"workflow_budget:{workflow_id}"
+        epoch_key = f"workflow_budget_epoch:{workflow_id}:{epoch_id}"
+        reservations_key = f"workflow_budget_reservations:{workflow_id}:{epoch_id}"
+        amount = max(1, int(tokens))
+        if not self._redis.exists(budget_key):
+            source = self.get_workflow_goal(workflow_id) or {}
+            budget = ExecutionBudget.from_record(source.get("budget")).to_record()
+            initial = self._redis.pipeline(transaction=True)
+            initial.hsetnx(budget_key, "max_tokens_per_epoch", budget["max_tokens"])
+            initial.hsetnx(budget_key, "used_tokens", 0)
+            initial.hsetnx(budget_key, "cost_usd", 0.0)
+            initial.hsetnx(budget_key, "call_count", 0)
+            initial.hsetnx(budget_key, "epoch_count", 0)
+            initial.expire(budget_key, self._ttl_seconds)
+            initial.execute()
+        if not self._redis.exists(epoch_key):
+            epoch_init = self._redis.pipeline(transaction=True)
+            epoch_init.hsetnx(epoch_key, "used_tokens", 0)
+            epoch_init.hsetnx(epoch_key, "reserved_tokens", 0)
+            epoch_init.hsetnx(epoch_key, "created_at", time.time())
+            epoch_init.expire(epoch_key, self._ttl_seconds)
+            epoch_init.hincrby(budget_key, "epoch_count", 1)
+            epoch_init.execute()
+        pipe = self._redis.pipeline()
+        while True:
+            try:
+                pipe.watch(budget_key, epoch_key, reservations_key)
+                budget = pipe.hgetall(budget_key)
+                if not budget:
+                    pipe.unwatch()
+                    return False
+                now = time.time()
+                live = {}
+                for key, raw in pipe.hgetall(reservations_key).items():
+                    try:
+                        value = json.loads(raw)
+                    except (TypeError, json.JSONDecodeError):
+                        continue
+                    if float(value.get("expires_at") or 0.0) > now:
+                        live[key] = value
+                epoch = pipe.hgetall(epoch_key)
+                used = int(float(epoch.get("used_tokens") or 0))
+                reserved = sum(int(item.get("tokens") or 0) for item in live.values())
+                limit = int(float(
+                    budget.get("max_tokens_per_epoch")
+                    or budget.get("max_tokens")
+                    or 0
+                ))
+                if "max_tokens_per_epoch" not in budget and limit:
+                    pipe.multi()
+                    pipe.hset(budget_key, "max_tokens_per_epoch", limit)
+                    pipe.execute()
+                    continue
+                if used + reserved + amount > limit:
+                    pipe.unwatch()
+                    return False
+                live[reservation_id] = {
+                    "tokens": amount,
+                    "expires_at": now + max(1.0, float(lease_seconds)),
+                }
+                pipe.multi()
+                pipe.delete(reservations_key)
+                if live:
+                    pipe.hset(reservations_key, mapping={
+                        key: json.dumps(value) for key, value in live.items()
+                    })
+                    pipe.expire(reservations_key, self._ttl_seconds)
+                pipe.hset(epoch_key, "reserved_tokens", reserved + amount)
+                pipe.expire(epoch_key, self._ttl_seconds)
+                pipe.execute()
+                return True
+            except redis.WatchError:
+                continue
+
+    def settle_workflow_tokens(
+        self,
+        workflow_id: str,
+        epoch_id: str,
+        reservation_id: str,
+        tokens: int,
+        cost_usd: float,
+    ) -> bool:
+        """Replace one live reservation with provider-reported usage."""
+        budget_key = f"workflow_budget:{workflow_id}"
+        epoch_key = f"workflow_budget_epoch:{workflow_id}:{epoch_id}"
+        reservations_key = f"workflow_budget_reservations:{workflow_id}:{epoch_id}"
+        pipe = self._redis.pipeline()
+        while True:
+            try:
+                pipe.watch(budget_key, epoch_key, reservations_key)
+                raw = pipe.hget(reservations_key, reservation_id)
+                budget = pipe.hgetall(budget_key)
+                epoch = pipe.hgetall(epoch_key)
+                if raw is None or not budget or not epoch:
+                    pipe.unwatch()
+                    return False
+                reservation = json.loads(raw)
+                reserved = max(0, int(float(epoch.get("reserved_tokens") or 0)))
+                epoch_used = max(0, int(float(epoch.get("used_tokens") or 0)))
+                used = max(0, int(float(budget.get("used_tokens") or 0)))
+                cost = max(0.0, float(budget.get("cost_usd") or 0.0))
+                calls = max(0, int(float(budget.get("call_count") or 0)))
+                pipe.multi()
+                pipe.hdel(reservations_key, reservation_id)
+                pipe.hset(epoch_key, mapping={
+                    "reserved_tokens": max(
+                        0, reserved - int(reservation.get("tokens") or 0)
+                    ),
+                    "used_tokens": epoch_used + max(0, int(tokens)),
+                })
+                pipe.hset(budget_key, mapping={
+                    "used_tokens": used + max(0, int(tokens)),
+                    "cost_usd": cost + max(0.0, float(cost_usd)),
+                    "call_count": calls + 1,
+                })
+                pipe.expire(budget_key, self._ttl_seconds)
+                pipe.execute()
+                return True
+            except redis.WatchError:
+                continue
+
+    def release_workflow_token_reservation(
+        self,
+        workflow_id: str,
+        epoch_id: str,
+        reservation_id: str,
+    ) -> bool:
+        """Release capacity when dispatch fails before reporting usage."""
+        budget_key = f"workflow_budget:{workflow_id}"
+        epoch_key = f"workflow_budget_epoch:{workflow_id}:{epoch_id}"
+        reservations_key = f"workflow_budget_reservations:{workflow_id}:{epoch_id}"
+        pipe = self._redis.pipeline()
+        while True:
+            try:
+                pipe.watch(epoch_key, reservations_key)
+                raw = pipe.hget(reservations_key, reservation_id)
+                if raw is None:
+                    pipe.unwatch()
+                    return False
+                reservation = json.loads(raw)
+                reserved = int(float(pipe.hget(epoch_key, "reserved_tokens") or 0))
+                pipe.multi()
+                pipe.hdel(reservations_key, reservation_id)
+                pipe.hset(
+                    epoch_key,
+                    "reserved_tokens",
+                    max(0, reserved - int(reservation.get("tokens") or 0)),
+                )
+                pipe.execute()
+                return True
+            except redis.WatchError:
+                continue
+
+    def get_workflow_budget_usage(
+        self,
+        workflow_id: str,
+        epoch_id: Optional[str] = None,
+    ) -> Optional[Dict[str, Any]]:
+        raw = self._redis.hgetall(f"workflow_budget:{workflow_id}")
+        if not raw:
+            return None
+        result = {
+            "max_tokens_per_epoch": int(
+                float(raw.get("max_tokens_per_epoch") or raw.get("max_tokens") or 0)
+            ),
+            "used_tokens": int(float(raw.get("used_tokens") or 0)),
+            "cost_usd": float(raw.get("cost_usd") or 0.0),
+            "call_count": int(float(raw.get("call_count") or 0)),
+            "epoch_count": int(float(raw.get("epoch_count") or 0)),
+        }
+        if epoch_id is not None:
+            epoch = self._redis.hgetall(
+                f"workflow_budget_epoch:{workflow_id}:{epoch_id}"
+            )
+            result.update({
+                "epoch_id": epoch_id,
+                "epoch_used_tokens": int(float(epoch.get("used_tokens") or 0)),
+                "epoch_reserved_tokens": int(
+                    float(epoch.get("reserved_tokens") or 0)
+                ),
+            })
+        return result
+
+    def get_workflow_goal(self, workflow_id: str) -> Optional[Dict[str, Any]]:
+        raw = self._redis.get(f"workflow_goal:{workflow_id}")
+        if not raw:
+            return None
+        try:
+            return json.loads(raw)
+        except (json.JSONDecodeError, TypeError):
+            return None
+
+    def get_pending_workflow_goals(self) -> List[str]:
+        return list(self._redis.smembers("jarviscore:pending_goal_plans"))
+
+    def save_workflow_planning_status(
+        self,
+        workflow_id: str,
+        status: str,
+        *,
+        planner_id: str = "",
+        error: str = "",
+    ) -> None:
+        payload = {
+            "status": status,
+            "planner_id": planner_id,
+            "error": error,
+            "updated_at": time.time(),
+        }
+        self._redis.set(
+            f"workflow_planning_status:{workflow_id}",
+            json.dumps(payload),
+            ex=self._ttl_seconds,
+        )
+        if status in {"published", "failed"}:
+            self._redis.srem("jarviscore:pending_goal_plans", workflow_id)
+        self.append_ledger_entry(workflow_id, {
+            "event": f"planning_{status}",
+            "planner_id": planner_id,
+            "error": error,
+        })
+
+    def get_workflow_planning_status(self, workflow_id: str) -> Optional[Dict[str, Any]]:
+        raw = self._redis.get(f"workflow_planning_status:{workflow_id}")
+        if not raw:
+            return None
+        try:
+            return json.loads(raw)
+        except (json.JSONDecodeError, TypeError):
+            return None
+
+    def claim_workflow_planning(
+        self, workflow_id: str, claimant_id: str, lease_seconds: int = 300
+    ) -> bool:
+        """Acquire the temporary right to compile a goal, never to assign its work."""
+        return bool(self._redis.set(
+            f"workflow_planning_lock:{workflow_id}",
+            claimant_id,
+            nx=True,
+            ex=max(1, int(lease_seconds)),
+        ))
+
+    def release_workflow_planning(self, workflow_id: str, claimant_id: str) -> bool:
+        key = f"workflow_planning_lock:{workflow_id}"
+        pipe = self._redis.pipeline()
+        while True:
+            try:
+                pipe.watch(key)
+                if pipe.get(key) != claimant_id:
+                    pipe.unwatch()
+                    return False
+                pipe.multi()
+                pipe.delete(key)
+                pipe.execute()
+                return True
+            except redis.WatchError:
+                continue
+
+    def unregister_active_workflow(self, workflow_id: str) -> None:
+        self._redis.srem("jarviscore:active_workflows", workflow_id)
+
+    def is_workflow_cancelled(self, workflow_id: str) -> bool:
+        return bool(self._redis.exists(f"workflow_cancelled:{workflow_id}"))
+
+    def cancel_workflow(self, workflow_id: str, *, reason: str) -> bool:
+        """Atomically tombstone a workflow and invalidate every unfinished claim."""
+        graph_key = f"workflow_graph:{workflow_id}"
+        needs_key = f"capability_needs:{workflow_id}"
+        cancelled_key = f"workflow_cancelled:{workflow_id}"
+        pipe = self._redis.pipeline()
+        while True:
+            try:
+                pipe.watch(graph_key, needs_key, cancelled_key)
+                if pipe.exists(cancelled_key):
+                    pipe.unwatch()
+                    return False
+                graph = {
+                    str(step_id): json.loads(raw)
+                    for step_id, raw in pipe.hgetall(graph_key).items()
+                }
+                needs = {
+                    str(need_id): json.loads(raw)
+                    for need_id, raw in pipe.hgetall(needs_key).items()
+                }
+                if not graph and not needs:
+                    pipe.unwatch()
+                    return False
+                now = time.time()
+                cancelled = {}
+                lock_keys = []
+                for step_id, record in graph.items():
+                    if record.get("status") not in {"completed", "failed", "cancelled"}:
+                        record.update({
+                            "status": "cancelled",
+                            "cancel_reason": reason,
+                            "updated_at": now,
+                        })
+                        record.pop("claim_expires_at", None)
+                        record.pop("resume_agent_id", None)
+                        record.pop("resume_context", None)
+                    cancelled[step_id] = json.dumps(record, default=str)
+                    lock_keys.append(f"step_lock:{workflow_id}:{step_id}")
+                cancelled_needs = {}
+                need_lock_keys = []
+                for need_id, record in needs.items():
+                    mandate = CapabilityMandate.from_record(record)
+                    cancelled_needs[need_id] = json.dumps(
+                        mandate.cancelled(reason, now).to_record(), default=str
+                    )
+                    need_lock_keys.append(
+                        f"capability_need_lock:{workflow_id}:{need_id}"
+                    )
+                pipe.multi()
+                pipe.set(
+                    cancelled_key,
+                    json.dumps({"reason": reason, "cancelled_at": now}),
+                    ex=self._ttl_seconds,
+                )
+                if cancelled:
+                    pipe.hset(graph_key, mapping=cancelled)
+                if cancelled_needs:
+                    pipe.hset(needs_key, mapping=cancelled_needs)
+                if lock_keys:
+                    pipe.delete(*lock_keys)
+                if need_lock_keys:
+                    pipe.delete(*need_lock_keys)
+                pipe.delete(f"workflow_planning_lock:{workflow_id}")
+                pipe.srem("jarviscore:active_workflows", workflow_id)
+                pipe.srem("jarviscore:pending_goal_plans", workflow_id)
+                pipe.srem(
+                    "jarviscore:workflows_with_capability_needs", workflow_id
+                )
+                pipe.xadd(f"ledgers:{workflow_id}", {
+                    "event": "workflow_cancelled",
+                    "reason": reason,
+                    "timestamp": str(now),
+                })
+                pipe.expire(graph_key, self._ttl_seconds)
+                if cancelled_needs:
+                    pipe.expire(needs_key, self._ttl_seconds)
+                pipe.expire(f"ledgers:{workflow_id}", self._ttl_seconds)
+                pipe.execute()
+                return True
+            except redis.WatchError:
+                continue
+
+    def publish_workflow(
+        self,
+        workflow_id: str,
+        *,
+        goal: str,
+        obligations: List[Dict],
+        steps: List[Dict],
+        context: Optional[Dict[str, Any]] = None,
+        budget: Optional[Dict[str, Any]] = None,
+        revision: int = 1,
+    ) -> bool:
+        """Atomically publish the source contract and complete executable DAG."""
+        graph_key = f"workflow_graph:{workflow_id}"
+        definition_key = f"workflow_definition:{workflow_id}"
+        normalized = []
         graph = {}
         for step in steps:
-            step_id = step.get("id") or step.get("step_id", "")
-            deps = step.get("depends_on", [])
-            graph[step_id] = json.dumps({
-                "status": "pending",
-                "depends_on": deps,
-                "agent": step.get("agent", ""),
-                "task": step.get("task", ""),
-            })
+            step_id = str(step.get("id") or step.get("step_id") or "")
+            if not step_id:
+                raise ValueError("Every workflow step requires an id")
+            record = dict(step)
+            record["id"] = step_id
+            record["status"] = "pending"
+            normalized.append(record)
+            graph[step_id] = json.dumps(record, default=str)
+        definition = WorkflowEnvelope(
+            workflow_id=workflow_id,
+            goal=goal,
+            context=context or {},
+            obligations=obligations,
+            steps=normalized,
+            budget=ExecutionBudget.from_record(budget),
+            revision=revision,
+            published_at=time.time(),
+        ).to_record()
+        pipe = self._redis.pipeline(transaction=True)
+        pipe.delete(graph_key)
         if graph:
-            self._redis.hset(key, mapping=graph)
-            self._redis.expire(key, self._ttl_seconds)
+            pipe.hset(graph_key, mapping=graph)
+        pipe.set(definition_key, json.dumps(definition, default=str))
+        pipe.sadd("jarviscore:active_workflows", workflow_id)
+        pipe.srem("jarviscore:pending_goal_plans", workflow_id)
+        pipe.xadd(f"ledgers:{workflow_id}", {
+            "event": "dag_published",
+            "revision": str(revision),
+            "step_count": str(len(normalized)),
+            "timestamp": str(time.time()),
+        })
+        pipe.set(
+            f"workflow_planning_status:{workflow_id}",
+            json.dumps({
+                "status": "published",
+                "planner_id": "",
+                "error": "",
+                "updated_at": time.time(),
+            }),
+            ex=self._ttl_seconds,
+        )
+        pipe.expire(graph_key, self._ttl_seconds)
+        pipe.expire(definition_key, self._ttl_seconds)
+        pipe.expire("jarviscore:active_workflows", self._ttl_seconds)
+        pipe.expire(f"ledgers:{workflow_id}", self._ttl_seconds)
+        pipe.execute()
         return True
+
+    def get_workflow_definition(self, workflow_id: str) -> Optional[Dict]:
+        raw = self._redis.get(f"workflow_definition:{workflow_id}")
+        if raw:
+            try:
+                return WorkflowEnvelope.from_record(json.loads(raw)).to_record()
+            except (json.JSONDecodeError, TypeError):
+                return None
+        steps = [
+            self.get_step_definition(workflow_id, step_id)
+            for step_id in self.get_all_step_ids(workflow_id)
+        ]
+        if not steps:
+            return None
+        return {
+            "workflow_id": workflow_id,
+            "goal": "",
+            "obligations": [],
+            "steps": [step for step in steps if step is not None],
+            "revision": 0,
+        }
+
+    def amend_workflow(
+        self,
+        workflow_id: str,
+        *,
+        expected_revision: int,
+        obligations: List[Dict],
+        steps: List[Dict],
+        reason: str,
+    ) -> bool:
+        """Atomically replace remaining work while retaining completed records."""
+        definition_key = f"workflow_definition:{workflow_id}"
+        graph_key = f"workflow_graph:{workflow_id}"
+        pipe = self._redis.pipeline()
+        while True:
+            try:
+                pipe.watch(definition_key, graph_key)
+                raw_definition = pipe.get(definition_key)
+                if not raw_definition:
+                    pipe.unwatch()
+                    raise KeyError(workflow_id)
+                current = json.loads(raw_definition)
+                if int(current.get("revision", 0)) != expected_revision:
+                    pipe.unwatch()
+                    raise ValueError("Workflow revision changed before amendment")
+                current_steps = {
+                    str(step.get("id") or step.get("step_id")): step
+                    for step in current.get("steps", [])
+                }
+                live = {
+                    step_id: json.loads(value)
+                    for step_id, value in pipe.hgetall(graph_key).items()
+                }
+                completed_ids = {
+                    step_id for step_id, record in live.items()
+                    if record.get("status") == "completed"
+                }
+                proposed = []
+                proposed_ids = set()
+                for step in steps:
+                    step_id = str(step.get("id") or step.get("step_id") or "")
+                    if not step_id or step_id in proposed_ids:
+                        pipe.unwatch()
+                        raise ValueError("Amended steps require unique non-empty ids")
+                    proposed_ids.add(step_id)
+                    proposed.append({**step, "id": step_id})
+                if not completed_ids <= proposed_ids:
+                    pipe.unwatch()
+                    raise ValueError("Amendment cannot remove completed steps")
+                for step_id in completed_ids:
+                    before = {
+                        key: value for key, value in current_steps[step_id].items()
+                        if key != "status"
+                    }
+                    after = {
+                        key: value for key, value in next(
+                            step for step in proposed if step["id"] == step_id
+                        ).items()
+                        if key != "status"
+                    }
+                    if before != after:
+                        pipe.unwatch()
+                        raise ValueError(f"Amendment cannot change completed step {step_id!r}")
+                all_ids = set(proposed_ids)
+                for step in proposed:
+                    unknown = set(step.get("depends_on", [])) - all_ids
+                    if unknown:
+                        pipe.unwatch()
+                        raise ValueError(f"Step {step['id']!r} has unknown dependencies: {sorted(unknown)}")
+                self._validate_acyclic_steps(proposed)
+                obligation_ids = {str(item.get("id")) for item in obligations}
+                covered = {
+                    str(obligation_id)
+                    for step in proposed
+                    for obligation_id in step.get("covers", [])
+                }
+                if obligation_ids - covered:
+                    pipe.unwatch()
+                    raise ValueError(
+                        f"Amendment leaves obligations uncovered: {sorted(obligation_ids - covered)}"
+                    )
+                graph = {}
+                normalized = []
+                for step in proposed:
+                    if step["id"] in completed_ids:
+                        record = live[step["id"]]
+                    else:
+                        record = {**step, "status": "pending"}
+                    normalized.append(record)
+                    graph[step["id"]] = json.dumps(record, default=str)
+                amended = {
+                    **current,
+                    "obligations": obligations,
+                    "steps": normalized,
+                    "revision": expected_revision + 1,
+                    "amended_at": time.time(),
+                    "amendment_reason": reason,
+                }
+                pipe.multi()
+                pipe.delete(graph_key)
+                pipe.hset(graph_key, mapping=graph)
+                pipe.set(definition_key, json.dumps(amended, default=str))
+                pipe.sadd("jarviscore:active_workflows", workflow_id)
+                pipe.xadd(f"ledgers:{workflow_id}", {
+                    "event": "dag_amended",
+                    "revision": str(expected_revision + 1),
+                    "reason": reason,
+                    "timestamp": str(time.time()),
+                })
+                pipe.expire(graph_key, self._ttl_seconds)
+                pipe.expire(definition_key, self._ttl_seconds)
+                pipe.expire(f"ledgers:{workflow_id}", self._ttl_seconds)
+                pipe.execute()
+                return True
+            except redis.WatchError:
+                continue
+
+    @staticmethod
+    def _validate_acyclic_steps(steps: List[Dict]) -> None:
+        dependencies = {
+            str(step["id"]): {str(value) for value in step.get("depends_on", [])}
+            for step in steps
+        }
+        visiting = set()
+        visited = set()
+
+        def visit(step_id: str) -> None:
+            if step_id in visiting:
+                raise ValueError("Workflow amendment contains a dependency cycle")
+            if step_id in visited:
+                return
+            visiting.add(step_id)
+            for dependency in dependencies[step_id]:
+                visit(dependency)
+            visiting.remove(step_id)
+            visited.add(step_id)
+
+        for step_id in dependencies:
+            visit(step_id)
+
+    def get_dependency_outputs(self, workflow_id: str, step_id: str) -> Dict[str, Any]:
+        step = self.get_step_definition(workflow_id, step_id) or {}
+        outputs = {}
+        for dependency_id in step.get("depends_on", []):
+            saved = self.get_step_output(workflow_id, str(dependency_id))
+            if saved is not None:
+                output = saved.get("output", saved)
+                if (
+                    isinstance(output, dict)
+                    and output.get("status") == "success"
+                    and "output" in output
+                ):
+                    output = output["output"]
+                outputs[str(dependency_id)] = output
+        return outputs
+
+    def get_workflow_outputs(
+        self, workflow_id: str, *, exclude_step_id: Optional[str] = None
+    ) -> Dict[str, Any]:
+        """Return every persisted artifact for workflow-level synthesis."""
+        outputs = {}
+        for output_id in self.list_step_output_ids(workflow_id):
+            if output_id == exclude_step_id:
+                continue
+            saved = self.get_step_output(workflow_id, output_id)
+            if saved is None:
+                continue
+            output = saved.get("output", saved)
+            if (
+                isinstance(output, dict)
+                and output.get("status") == "success"
+                and "output" in output
+            ):
+                output = output["output"]
+            outputs[output_id] = output
+        return outputs
+
+    def get_workflow_step_states(self, workflow_id: str) -> Dict[str, str]:
+        """Return every DAG step's current state for final-response synthesis."""
+        states = {}
+        for step_id, raw in self._redis.hgetall(
+            f"workflow_graph:{workflow_id}"
+        ).items():
+            try:
+                states[str(step_id)] = str(json.loads(raw).get("status") or "")
+            except (json.JSONDecodeError, TypeError):
+                continue
+        return states
+
+    def get_workflow_evidence(
+        self, workflow_id: str, *, exclude_step_id: Optional[str] = None
+    ) -> WorkflowEvidence:
+        """Build one canonical workflow-level evidence snapshot."""
+        artifacts = self.get_workflow_outputs(
+            workflow_id, exclude_step_id=exclude_step_id
+        )
+        interpretations = {}
+        for output_id in self.list_step_output_ids(workflow_id):
+            if output_id == exclude_step_id:
+                continue
+            saved = self.get_step_output(workflow_id, output_id)
+            envelope = saved.get("output") if isinstance(saved, dict) else None
+            interpretation = (
+                envelope.get("interpretation")
+                if isinstance(envelope, dict)
+                else None
+            )
+            if isinstance(interpretation, dict):
+                interpretations[output_id] = interpretation
+        return WorkflowEvidence(
+            artifacts=artifacts,
+            interpretations=interpretations,
+            states=self.get_workflow_step_states(workflow_id),
+        )
+
+    def get_dependency_interpretations(
+        self, workflow_id: str, step_id: str
+    ) -> Dict[str, Any]:
+        """Return semantic assessments without changing artifact payload shapes."""
+        step = self.get_step_definition(workflow_id, step_id) or {}
+        interpretations = {}
+        for dependency_id in step.get("depends_on", []):
+            saved = self.get_step_output(workflow_id, str(dependency_id))
+            envelope = saved.get("output") if isinstance(saved, dict) else None
+            interpretation = (
+                envelope.get("interpretation") if isinstance(envelope, dict) else None
+            )
+            if isinstance(interpretation, dict):
+                interpretations[str(dependency_id)] = interpretation
+        return interpretations
+
+    def init_workflow_graph(self, workflow_id: str, steps: List[Dict]) -> bool:
+        """Initialize Redis DAG for a workflow."""
+        return self.publish_workflow(
+            workflow_id,
+            goal="",
+            obligations=[],
+            steps=steps,
+        )
 
     def get_step_status(self, workflow_id: str, step_id: str) -> Optional[str]:
         """Read step status from workflow DAG."""
@@ -403,7 +1422,7 @@ class RedisContextStore:
         return True
 
     def are_dependencies_met(self, workflow_id: str, step_id: str) -> bool:
-        """Check if all dependencies for a step are completed."""
+        """Check execution completion and semantic authorization for a step."""
         key = f"workflow_graph:{workflow_id}"
         raw = self._redis.hget(key, step_id)
         if raw is None:
@@ -412,26 +1431,418 @@ class RedisContextStore:
             step_data = json.loads(raw)
         except (json.JSONDecodeError, TypeError):
             return True
-        deps = step_data.get("depends_on", [])
-        if not deps:
+        graph = {
+            str(dependency_id): json.loads(value)
+            for dependency_id, value in self._redis.hgetall(key).items()
+        }
+        return self._dependencies_authorize(step_data, graph)
+
+    @staticmethod
+    def _dependencies_authorize(step: Dict, graph: Dict[str, Dict]) -> bool:
+        dependencies = [str(value) for value in step.get("depends_on", [])]
+        if not dependencies:
             return True
-        for dep_id in deps:
-            dep_status = self.get_step_status(workflow_id, dep_id)
-            if dep_status != "completed":
-                return False
+        records = [graph.get(dependency_id, {}) for dependency_id in dependencies]
+        effect = str(step.get("effect") or "read")
+        if effect == "final_response":
+            return all(
+                record.get("status") in {
+                    "completed", "failed", "waiting", "blocked", "cancelled"
+                }
+                for record in records
+            )
+        if not all(record.get("status") == "completed" for record in records):
+            return False
         return True
 
-    def claim_step(self, workflow_id: str, step_id: str,
-                   agent_id: str) -> bool:
-        """Atomically claim a step for an agent (prevents double-execution)."""
+    def get_dependency_statuses(self, workflow_id: str, step_id: str) -> Dict[str, str]:
+        step = self.get_step_definition(workflow_id, step_id) or {}
+        return {
+            str(dependency_id): self.get_step_status(workflow_id, str(dependency_id))
+            for dependency_id in step.get("depends_on", [])
+        }
+
+    def get_dependency_blockers(self, workflow_id: str, step_id: str) -> Dict[str, str]:
+        """Return terminal dependency outcomes that forbid this step's effect."""
+        graph_key = f"workflow_graph:{workflow_id}"
+        graph = {
+            str(dependency_id): json.loads(value)
+            for dependency_id, value in self._redis.hgetall(graph_key).items()
+        }
+        step = graph.get(str(step_id), {})
+        effect = str(step.get("effect") or "read")
+        if effect == "final_response":
+            return {}
+        blockers = {}
+        for dependency_id in map(str, step.get("depends_on", [])):
+            dependency = graph.get(dependency_id, {})
+            status = dependency.get("status")
+            if status in {"failed", "waiting", "blocked", "cancelled"}:
+                blockers[dependency_id] = f"execution:{status}"
+                continue
+        return blockers
+
+    def block_step(
+        self,
+        workflow_id: str,
+        step_id: str,
+        blockers: Dict[str, str],
+    ) -> bool:
+        key = f"workflow_graph:{workflow_id}"
+        raw = self._redis.hget(key, step_id)
+        if raw is None:
+            return False
+        data = json.loads(raw)
+        data.update({
+            "status": "blocked",
+            "blocked_by": blockers,
+            "updated_at": time.time(),
+        })
+        pipe = self._redis.pipeline(transaction=True)
+        pipe.hset(key, mapping={step_id: json.dumps(data)})
+        pipe.xadd(f"ledgers:{workflow_id}", {
+            "event": "step_blocked",
+            "step_id": step_id,
+            "blockers": json.dumps(blockers),
+            "timestamp": str(time.time()),
+        })
+        pipe.expire(f"ledgers:{workflow_id}", self._ttl_seconds)
+        pipe.execute()
+        return True
+
+    def requeue_blocked_step(self, workflow_id: str, step_id: str) -> bool:
+        key = f"workflow_graph:{workflow_id}"
+        raw = self._redis.hget(key, step_id)
+        if raw is None:
+            return False
+        data = json.loads(raw)
+        if data.get("status") != "blocked":
+            return False
+        if not data.get("blocked_by"):
+            return False
+        if not self.are_dependencies_met(workflow_id, step_id):
+            return False
+        data.update({"status": "pending", "updated_at": time.time()})
+        data.pop("blocked_by", None)
+        pipe = self._redis.pipeline(transaction=True)
+        pipe.hset(key, mapping={step_id: json.dumps(data)})
+        pipe.xadd(f"ledgers:{workflow_id}", {
+            "event": "step_requeued",
+            "step_id": step_id,
+            "timestamp": str(time.time()),
+        })
+        pipe.expire(f"ledgers:{workflow_id}", self._ttl_seconds)
+        pipe.execute()
+        return True
+
+    def claim_step(
+        self,
+        workflow_id: str,
+        step_id: str,
+        agent_id: str,
+        lease_seconds: int = 60,
+    ) -> bool:
+        """Atomically lease a step to one execution identity."""
         lock_key = f"step_lock:{workflow_id}:{step_id}"
-        # redis-py >=7.x rejects SET NX EX in one call — split into two:
-        # SET key value NX (atomic claim), then EXPIRE only if acquired.
-        acquired = self._redis.set(lock_key, agent_id, nx=True)
-        if acquired:
-            self._redis.expire(lock_key, self._ttl_seconds)
-            self.update_step_status(workflow_id, step_id, "in_progress")
-        return bool(acquired)
+        cancelled_key = f"workflow_cancelled:{workflow_id}"
+        lease_seconds = max(1, int(lease_seconds))
+        graph_key = f"workflow_graph:{workflow_id}"
+        owner_id = agent_id.split(":", 1)[0]
+        pipe = self._redis.pipeline()
+        while True:
+            try:
+                pipe.watch(lock_key, graph_key, cancelled_key)
+                if pipe.exists(cancelled_key) or pipe.exists(lock_key):
+                    pipe.unwatch()
+                    return False
+                raw = pipe.hget(graph_key, step_id)
+                if raw is None:
+                    pipe.unwatch()
+                    return False
+                data = json.loads(raw)
+                if data.get("status") != "pending":
+                    pipe.unwatch()
+                    return False
+                graph = {
+                    str(dependency_id): json.loads(value)
+                    for dependency_id, value in pipe.hgetall(graph_key).items()
+                }
+                if not self._dependencies_authorize(data, graph):
+                    pipe.unwatch()
+                    return False
+                now = time.time()
+                data.update({
+                    "status": "in_progress",
+                    "claimed_by": owner_id,
+                    "claim_id": agent_id,
+                    "claim_expires_at": now + lease_seconds,
+                    "updated_at": now,
+                })
+                pipe.multi()
+                pipe.set(lock_key, agent_id, ex=lease_seconds)
+                pipe.hset(graph_key, mapping={step_id: json.dumps(data)})
+                pipe.xadd(f"ledgers:{workflow_id}", {
+                    "event": "step_claimed",
+                    "step_id": step_id,
+                    "agent_id": owner_id,
+                    "claim_id": agent_id,
+                    "timestamp": str(now),
+                })
+                pipe.expire(f"ledgers:{workflow_id}", self._ttl_seconds)
+                pipe.execute()
+                return True
+            except redis.WatchError:
+                continue
+
+    def resume_workflow_step(
+        self,
+        workflow_id: str,
+        step_id: str,
+        context: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        """Requeue a waiting step on the same peer with durable resume context."""
+        graph_key = f"workflow_graph:{workflow_id}"
+        pipe = self._redis.pipeline()
+        while True:
+            try:
+                pipe.watch(graph_key)
+                raw = pipe.hget(graph_key, step_id)
+                if raw is None:
+                    pipe.unwatch()
+                    raise KeyError(step_id)
+                data = json.loads(raw)
+                if data.get("status") != "waiting":
+                    pipe.unwatch()
+                    raise ValueError(f"Step {step_id!r} is not waiting")
+                owner = data.get("completed_by") or data.get("claimed_by")
+                data.update({
+                    "status": "pending",
+                    "resume_agent_id": owner,
+                    "resume_context": dict(context or {}),
+                    "updated_at": time.time(),
+                })
+                data.pop("blocked_by", None)
+                pipe.multi()
+                pipe.hset(graph_key, mapping={step_id: json.dumps(data, default=str)})
+                pipe.sadd("jarviscore:active_workflows", workflow_id)
+                pipe.xadd(f"ledgers:{workflow_id}", {
+                    "event": "step_resumed",
+                    "step_id": step_id,
+                    "agent_id": str(owner or ""),
+                    "timestamp": str(time.time()),
+                })
+                pipe.expire(f"ledgers:{workflow_id}", self._ttl_seconds)
+                pipe.execute()
+                return data
+            except redis.WatchError:
+                continue
+
+    def renew_step_claim(
+        self,
+        workflow_id: str,
+        step_id: str,
+        agent_id: str,
+        lease_seconds: int = 60,
+    ) -> bool:
+        lock_key = f"step_lock:{workflow_id}:{step_id}"
+        cancelled_key = f"workflow_cancelled:{workflow_id}"
+        graph_key = f"workflow_graph:{workflow_id}"
+        lease_seconds = max(1, int(lease_seconds))
+        pipe = self._redis.pipeline()
+        while True:
+            try:
+                pipe.watch(lock_key, graph_key, cancelled_key)
+                if pipe.exists(cancelled_key) or pipe.get(lock_key) != agent_id:
+                    pipe.unwatch()
+                    return False
+                raw = pipe.hget(graph_key, step_id)
+                if raw is None:
+                    pipe.unwatch()
+                    return False
+                data = json.loads(raw)
+                data.update({
+                    "claimed_by": agent_id.split(":", 1)[0],
+                    "claim_expires_at": time.time() + lease_seconds,
+                    "updated_at": time.time(),
+                })
+                pipe.multi()
+                pipe.expire(lock_key, lease_seconds)
+                pipe.hset(graph_key, mapping={step_id: json.dumps(data)})
+                pipe.execute()
+                return True
+            except redis.WatchError:
+                continue
+
+    def recover_expired_step_claim(self, workflow_id: str, step_id: str) -> bool:
+        lock_key = f"step_lock:{workflow_id}:{step_id}"
+        cancelled_key = f"workflow_cancelled:{workflow_id}"
+        graph_key = f"workflow_graph:{workflow_id}"
+        pipe = self._redis.pipeline()
+        while True:
+            try:
+                pipe.watch(lock_key, graph_key, cancelled_key)
+                if pipe.exists(cancelled_key) or pipe.exists(lock_key):
+                    pipe.unwatch()
+                    return False
+                raw = pipe.hget(graph_key, step_id)
+                if raw is None:
+                    pipe.unwatch()
+                    return False
+                data = json.loads(raw)
+                if data.get("status") != "in_progress":
+                    pipe.unwatch()
+                    return False
+                data.update({"status": "pending", "updated_at": time.time()})
+                data.pop("claimed_by", None)
+                data.pop("claim_expires_at", None)
+                pipe.multi()
+                pipe.hset(graph_key, mapping={step_id: json.dumps(data)})
+                pipe.xadd(f"ledgers:{workflow_id}", {
+                    "event": "step_claim_expired",
+                    "step_id": step_id,
+                    "timestamp": str(time.time()),
+                })
+                pipe.expire(f"ledgers:{workflow_id}", self._ttl_seconds)
+                pipe.execute()
+                return True
+            except redis.WatchError:
+                continue
+
+    def finish_claimed_step(
+        self,
+        workflow_id: str,
+        step_id: str,
+        agent_id: str,
+        output: Any,
+        *,
+        status: str | None = None,
+    ) -> bool:
+        """Commit output and terminal status only while the caller owns the lease."""
+        lock_key = f"step_lock:{workflow_id}:{step_id}"
+        cancelled_key = f"workflow_cancelled:{workflow_id}"
+        graph_key = f"workflow_graph:{workflow_id}"
+        output_key = f"step_output:{workflow_id}:{step_id}"
+        result_status = output.get("status") if isinstance(output, dict) else None
+        terminal = status or terminal_step_status(result_status)
+        if terminal not in {"completed", "failed", "waiting", "blocked"}:
+            raise ValueError(f"Invalid terminal step status: {terminal}")
+        try:
+            serialized = json.dumps(output) if output is not None else None
+        except Exception:
+            serialized = str(output)
+        if serialized and len(serialized) > self._STEP_OUTPUT_MAX_BYTES:
+            serialized = json.dumps({
+                "_overflow": True,
+                "_size_bytes": len(serialized),
+                "_preview": serialized[: self._STEP_OUTPUT_PREVIEW_BYTES],
+                "_note": (
+                    "Output exceeded STEP_OUTPUT_MAX_BYTES. Retrieve full result "
+                    f"from blob storage using workflow_id={workflow_id}, step_id={step_id}."
+                ),
+            })
+        pipe = self._redis.pipeline()
+        while True:
+            try:
+                pipe.watch(lock_key, graph_key, cancelled_key)
+                if pipe.exists(cancelled_key) or pipe.get(lock_key) != agent_id:
+                    pipe.unwatch()
+                    return False
+                raw = pipe.hget(graph_key, step_id)
+                if raw is None:
+                    pipe.unwatch()
+                    return False
+                data = json.loads(raw)
+                now = time.time()
+                interpretation = (
+                    output.get("interpretation") if isinstance(output, dict) else None
+                )
+                data.update({
+                    "status": terminal,
+                    "completed_by": agent_id.split(":", 1)[0],
+                    "claim_id": agent_id,
+                    "updated_at": now,
+                })
+                if isinstance(interpretation, dict):
+                    data["semantic_outcome"] = interpretation.get("verdict")
+                    data["semantic_decision"] = interpretation.get("decision")
+                data.pop("claim_expires_at", None)
+                data.pop("resume_agent_id", None)
+                data.pop("resume_context", None)
+                mapping = {
+                    "output": serialized,
+                    "summary": "",
+                    "context_vars": "{}",
+                    "timestamp": now,
+                }
+                pipe.multi()
+                pipe.hset(output_key, mapping={k: v for k, v in mapping.items() if v is not None})
+                pipe.expire(output_key, self._ttl_seconds)
+                pipe.hset(graph_key, mapping={step_id: json.dumps(data)})
+                pipe.xadd(f"ledgers:{workflow_id}", {
+                    "event": f"step_{terminal}",
+                    "step_id": step_id,
+                    "agent_id": agent_id.split(":", 1)[0],
+                    "claim_id": agent_id,
+                    "timestamp": str(now),
+                })
+                pipe.expire(f"ledgers:{workflow_id}", self._ttl_seconds)
+                pipe.delete(lock_key)
+                pipe.execute()
+                return True
+            except redis.WatchError:
+                continue
+
+    def continue_claimed_step(
+        self,
+        workflow_id: str,
+        step_id: str,
+        claim_id: str,
+        *,
+        resume_agent_id: str,
+    ) -> bool:
+        """Release an exhausted epoch without terminalizing its durable step."""
+        lock_key = f"step_lock:{workflow_id}:{step_id}"
+        graph_key = f"workflow_graph:{workflow_id}"
+        cancelled_key = f"workflow_cancelled:{workflow_id}"
+        pipe = self._redis.pipeline()
+        while True:
+            try:
+                pipe.watch(lock_key, graph_key, cancelled_key)
+                if pipe.exists(cancelled_key) or pipe.get(lock_key) != claim_id:
+                    pipe.unwatch()
+                    return False
+                raw = pipe.hget(graph_key, step_id)
+                if raw is None:
+                    pipe.unwatch()
+                    return False
+                data = json.loads(raw)
+                now = time.time()
+                data.update({
+                    "status": "pending",
+                    "resume_agent_id": resume_agent_id,
+                    "resume_context": {
+                        "_resume": True,
+                        "_new_execution_epoch": True,
+                    },
+                    "updated_at": now,
+                    "execution_epochs": int(data.get("execution_epochs") or 1) + 1,
+                })
+                data.pop("claim_expires_at", None)
+                pipe.multi()
+                pipe.hset(graph_key, mapping={step_id: json.dumps(data, default=str)})
+                pipe.xadd(f"ledgers:{workflow_id}", {
+                    "event": "step_epoch_continued",
+                    "step_id": step_id,
+                    "agent_id": resume_agent_id,
+                    "claim_id": claim_id,
+                    "timestamp": str(now),
+                })
+                pipe.expire(f"ledgers:{workflow_id}", self._ttl_seconds)
+                pipe.delete(lock_key)
+                pipe.execute()
+                return True
+            except redis.WatchError:
+                continue
 
     def get_step_definition(self, workflow_id: str, step_id: str) -> Optional[Dict]:
         """Get full step definition (task, agent, deps) from workflow DAG."""

--- a/jarviscore/storage/redis_store.py
+++ b/jarviscore/storage/redis_store.py
@@ -685,7 +685,11 @@ class RedisContextStore:
                 existing = pipe.get(key)
                 if existing is not None:
                     pipe.unwatch()
-                    if existing != encoded:
+                    try:
+                        same_binding = json.loads(existing) == json.loads(encoded)
+                    except (json.JSONDecodeError, TypeError):
+                        same_binding = existing == encoded
+                    if not same_binding:
                         raise ValueError(
                             f"Workflow {workflow_id!r} is already bound to another goal"
                         )
@@ -981,6 +985,75 @@ class RedisContextStore:
             except redis.WatchError:
                 continue
 
+    def claim_workflow_reconciliation(
+        self,
+        workflow_id: str,
+        revision: int,
+        claimant_id: str,
+        lease_seconds: int = 300,
+    ) -> bool:
+        return bool(self._redis.set(
+            f"workflow_reconciliation_lock:{workflow_id}:{revision}",
+            claimant_id,
+            nx=True,
+            ex=max(1, int(lease_seconds)),
+        ))
+
+    def release_workflow_reconciliation(
+        self, workflow_id: str, revision: int, claimant_id: str
+    ) -> bool:
+        key = f"workflow_reconciliation_lock:{workflow_id}:{revision}"
+        pipe = self._redis.pipeline()
+        while True:
+            try:
+                pipe.watch(key)
+                if pipe.get(key) != claimant_id:
+                    pipe.unwatch()
+                    return False
+                pipe.multi()
+                pipe.delete(key)
+                pipe.execute()
+                return True
+            except redis.WatchError:
+                continue
+
+    def save_workflow_reconciliation_settlement(
+        self, workflow_id: str, revision: int, settlement: Dict[str, Any]
+    ) -> bool:
+        key = f"workflow_reconciliation_settlement:{workflow_id}:{revision}"
+        payload = {**settlement, "revision": revision}
+        pipe = self._redis.pipeline()
+        while True:
+            try:
+                pipe.watch(key)
+                if pipe.exists(key):
+                    pipe.unwatch()
+                    return False
+                pipe.multi()
+                pipe.set(key, json.dumps(payload, default=str), ex=self._ttl_seconds)
+                pipe.xadd(f"ledgers:{workflow_id}", {
+                    field: json.dumps(value) if not isinstance(value, str) else value
+                    for field, value in payload.items()
+                })
+                pipe.expire(f"ledgers:{workflow_id}", self._ttl_seconds)
+                pipe.execute()
+                return True
+            except redis.WatchError:
+                continue
+
+    def get_workflow_reconciliation_settlement(
+        self, workflow_id: str, revision: int
+    ) -> Optional[Dict[str, Any]]:
+        raw = self._redis.get(
+            f"workflow_reconciliation_settlement:{workflow_id}:{revision}"
+        )
+        if not raw:
+            return None
+        try:
+            return json.loads(raw)
+        except (json.JSONDecodeError, TypeError):
+            return None
+
     def unregister_active_workflow(self, workflow_id: str) -> None:
         self._redis.srem("jarviscore:active_workflows", workflow_id)
 
@@ -1092,6 +1165,7 @@ class RedisContextStore:
             record = dict(step)
             record["id"] = step_id
             record["status"] = "pending"
+            record["plan_revision"] = revision
             normalized.append(record)
             graph[step_id] = json.dumps(record, default=str)
         definition = WorkflowEnvelope(
@@ -1104,11 +1178,16 @@ class RedisContextStore:
             revision=revision,
             published_at=time.time(),
         ).to_record()
+        projection = self._initial_obligation_projection(
+            obligations, normalized, revision
+        )
+        projection_key = f"workflow_obligations:{workflow_id}"
         pipe = self._redis.pipeline(transaction=True)
         pipe.delete(graph_key)
         if graph:
             pipe.hset(graph_key, mapping=graph)
         pipe.set(definition_key, json.dumps(definition, default=str))
+        pipe.set(projection_key, json.dumps(projection, default=str))
         pipe.sadd("jarviscore:active_workflows", workflow_id)
         pipe.srem("jarviscore:pending_goal_plans", workflow_id)
         pipe.xadd(f"ledgers:{workflow_id}", {
@@ -1129,10 +1208,57 @@ class RedisContextStore:
         )
         pipe.expire(graph_key, self._ttl_seconds)
         pipe.expire(definition_key, self._ttl_seconds)
+        pipe.expire(projection_key, self._ttl_seconds)
         pipe.expire("jarviscore:active_workflows", self._ttl_seconds)
         pipe.expire(f"ledgers:{workflow_id}", self._ttl_seconds)
         pipe.execute()
         return True
+
+    @staticmethod
+    def _initial_obligation_projection(
+        obligations: List[Dict], steps: List[Dict], revision: int
+    ) -> Dict[str, Dict[str, Any]]:
+        projection = {}
+        for obligation in obligations:
+            obligation_id = str(obligation.get("id") or "")
+            if not obligation_id:
+                continue
+            current_step_ids = [
+                str(step.get("id") or step.get("step_id"))
+                for step in steps
+                if obligation_id in map(str, step.get("covers", []))
+            ]
+            projection[obligation_id] = {
+                **obligation,
+                "state": "pending",
+                "revision": revision,
+                "current_step_ids": current_step_ids,
+                "superseded_step_ids": [],
+                "attempt_states": {
+                    step_id: "pending" for step_id in current_step_ids
+                },
+                "attempt_interpretations": {},
+            }
+        return projection
+
+    def get_obligation_projection(
+        self, workflow_id: str
+    ) -> Dict[str, Dict[str, Any]]:
+        """Return the durable current truth for every source obligation."""
+        raw = self._redis.get(f"workflow_obligations:{workflow_id}")
+        if raw:
+            try:
+                return json.loads(raw)
+            except (json.JSONDecodeError, TypeError):
+                return {}
+        definition = self.get_workflow_definition(workflow_id)
+        if definition is None:
+            return {}
+        return self._initial_obligation_projection(
+            definition.get("obligations", []),
+            definition.get("steps", []),
+            int(definition.get("revision", 0)),
+        )
 
     def get_workflow_definition(self, workflow_id: str) -> Optional[Dict]:
         raw = self._redis.get(f"workflow_definition:{workflow_id}")
@@ -1164,13 +1290,18 @@ class RedisContextStore:
         steps: List[Dict],
         reason: str,
     ) -> bool:
-        """Atomically replace remaining work while retaining completed records."""
+        """Atomically append a revision delta while retaining immutable attempts."""
         definition_key = f"workflow_definition:{workflow_id}"
         graph_key = f"workflow_graph:{workflow_id}"
+        projection_key = f"workflow_obligations:{workflow_id}"
+        cancelled_key = f"workflow_cancelled:{workflow_id}"
         pipe = self._redis.pipeline()
         while True:
             try:
-                pipe.watch(definition_key, graph_key)
+                pipe.watch(definition_key, graph_key, projection_key, cancelled_key)
+                if pipe.exists(cancelled_key):
+                    pipe.unwatch()
+                    raise ValueError("A cancelled workflow cannot be amended")
                 raw_definition = pipe.get(definition_key)
                 if not raw_definition:
                     pipe.unwatch()
@@ -1179,18 +1310,17 @@ class RedisContextStore:
                 if int(current.get("revision", 0)) != expected_revision:
                     pipe.unwatch()
                     raise ValueError("Workflow revision changed before amendment")
-                current_steps = {
-                    str(step.get("id") or step.get("step_id")): step
-                    for step in current.get("steps", [])
-                }
                 live = {
                     step_id: json.loads(value)
                     for step_id, value in pipe.hgetall(graph_key).items()
                 }
-                completed_ids = {
-                    step_id for step_id, record in live.items()
-                    if record.get("status") == "completed"
-                }
+                current_ids = set(live)
+                if obligations != current.get("obligations", []):
+                    pipe.unwatch()
+                    raise ValueError("Amendment cannot change source obligations")
+                if not steps:
+                    pipe.unwatch()
+                    raise ValueError("Amendment requires at least one new step")
                 proposed = []
                 proposed_ids = set()
                 for step in steps:
@@ -1198,55 +1328,85 @@ class RedisContextStore:
                     if not step_id or step_id in proposed_ids:
                         pipe.unwatch()
                         raise ValueError("Amended steps require unique non-empty ids")
-                    proposed_ids.add(step_id)
-                    proposed.append({**step, "id": step_id})
-                if not completed_ids <= proposed_ids:
-                    pipe.unwatch()
-                    raise ValueError("Amendment cannot remove completed steps")
-                for step_id in completed_ids:
-                    before = {
-                        key: value for key, value in current_steps[step_id].items()
-                        if key != "status"
-                    }
-                    after = {
-                        key: value for key, value in next(
-                            step for step in proposed if step["id"] == step_id
-                        ).items()
-                        if key != "status"
-                    }
-                    if before != after:
+                    if step_id in current_ids:
                         pipe.unwatch()
-                        raise ValueError(f"Amendment cannot change completed step {step_id!r}")
-                all_ids = set(proposed_ids)
+                        raise ValueError(f"Amended step {step_id!r} already exists")
+                    proposed_ids.add(step_id)
+                    proposed.append({
+                        **step,
+                        "id": step_id,
+                        "status": "pending",
+                        "plan_revision": expected_revision + 1,
+                    })
+                all_ids = current_ids | proposed_ids
                 for step in proposed:
                     unknown = set(step.get("depends_on", [])) - all_ids
                     if unknown:
                         pipe.unwatch()
                         raise ValueError(f"Step {step['id']!r} has unknown dependencies: {sorted(unknown)}")
-                self._validate_acyclic_steps(proposed)
-                obligation_ids = {str(item.get("id")) for item in obligations}
-                covered = {
+                combined = [*live.values(), *proposed]
+                self._validate_acyclic_steps(combined)
+                covered_by_delta = {
                     str(obligation_id)
                     for step in proposed
                     for obligation_id in step.get("covers", [])
                 }
-                if obligation_ids - covered:
-                    pipe.unwatch()
-                    raise ValueError(
-                        f"Amendment leaves obligations uncovered: {sorted(obligation_ids - covered)}"
+                raw_projection = pipe.get(projection_key)
+                projection = (
+                    json.loads(raw_projection)
+                    if raw_projection
+                    else self._initial_obligation_projection(
+                        current.get("obligations", []),
+                        list(live.values()),
+                        expected_revision,
                     )
-                graph = {}
-                normalized = []
-                for step in proposed:
-                    if step["id"] in completed_ids:
-                        record = live[step["id"]]
-                    else:
-                        record = {**step, "status": "pending"}
-                    normalized.append(record)
-                    graph[step["id"]] = json.dumps(record, default=str)
+                )
+                for obligation_id in covered_by_delta:
+                    record = projection.get(obligation_id)
+                    if record is None:
+                        continue
+                    current_step_ids = [
+                        step["id"] for step in proposed
+                        if obligation_id in map(str, step.get("covers", []))
+                    ]
+                    superseded = list(record.get("superseded_step_ids", []))
+                    superseded.extend(
+                        step_id for step_id in record.get("current_step_ids", [])
+                        if step_id not in superseded
+                    )
+                    projection[obligation_id] = {
+                        **record,
+                        "state": "pending",
+                        "revision": expected_revision + 1,
+                        "current_step_ids": current_step_ids,
+                        "superseded_step_ids": superseded,
+                        "attempt_states": {
+                            step_id: "pending" for step_id in current_step_ids
+                        },
+                        "attempt_interpretations": {},
+                    }
+                superseded_ids = []
+                for step_id, record in live.items():
+                    if (
+                        record.get("status") in {"pending", "waiting", "blocked"}
+                        and covered_by_delta.intersection(map(str, record.get("covers", [])))
+                    ):
+                        record = {
+                            **record,
+                            "status": "superseded",
+                            "superseded_by_revision": expected_revision + 1,
+                        }
+                        live[step_id] = record
+                        superseded_ids.append(step_id)
+                graph = {
+                    step_id: json.dumps(record, default=str)
+                    for step_id, record in {**live, **{
+                        step["id"]: step for step in proposed
+                    }}.items()
+                }
+                normalized = [*live.values(), *proposed]
                 amended = {
                     **current,
-                    "obligations": obligations,
                     "steps": normalized,
                     "revision": expected_revision + 1,
                     "amended_at": time.time(),
@@ -1256,15 +1416,19 @@ class RedisContextStore:
                 pipe.delete(graph_key)
                 pipe.hset(graph_key, mapping=graph)
                 pipe.set(definition_key, json.dumps(amended, default=str))
+                pipe.set(projection_key, json.dumps(projection, default=str))
                 pipe.sadd("jarviscore:active_workflows", workflow_id)
                 pipe.xadd(f"ledgers:{workflow_id}", {
                     "event": "dag_amended",
                     "revision": str(expected_revision + 1),
                     "reason": reason,
+                    "added_step_ids": json.dumps(sorted(proposed_ids)),
+                    "superseded_step_ids": json.dumps(sorted(superseded_ids)),
                     "timestamp": str(time.time()),
                 })
                 pipe.expire(graph_key, self._ttl_seconds)
                 pipe.expire(definition_key, self._ttl_seconds)
+                pipe.expire(projection_key, self._ttl_seconds)
                 pipe.expire(f"ledgers:{workflow_id}", self._ttl_seconds)
                 pipe.execute()
                 return True
@@ -1367,6 +1531,7 @@ class RedisContextStore:
             artifacts=artifacts,
             interpretations=interpretations,
             states=self.get_workflow_step_states(workflow_id),
+            obligations=self.get_obligation_projection(workflow_id),
         )
 
     def get_dependency_interpretations(
@@ -1722,6 +1887,7 @@ class RedisContextStore:
         cancelled_key = f"workflow_cancelled:{workflow_id}"
         graph_key = f"workflow_graph:{workflow_id}"
         output_key = f"step_output:{workflow_id}:{step_id}"
+        projection_key = f"workflow_obligations:{workflow_id}"
         result_status = output.get("status") if isinstance(output, dict) else None
         terminal = status or terminal_step_status(result_status)
         if terminal not in {"completed", "failed", "waiting", "blocked"}:
@@ -1743,7 +1909,7 @@ class RedisContextStore:
         pipe = self._redis.pipeline()
         while True:
             try:
-                pipe.watch(lock_key, graph_key, cancelled_key)
+                pipe.watch(lock_key, graph_key, projection_key, cancelled_key)
                 if pipe.exists(cancelled_key) or pipe.get(lock_key) != agent_id:
                     pipe.unwatch()
                     return False
@@ -1765,6 +1931,52 @@ class RedisContextStore:
                 if isinstance(interpretation, dict):
                     data["semantic_outcome"] = interpretation.get("verdict")
                     data["semantic_decision"] = interpretation.get("decision")
+                raw_projection = pipe.get(projection_key)
+                projection = json.loads(raw_projection) if raw_projection else {}
+                for obligation_id in map(str, data.get("covers", [])):
+                    record = projection.get(obligation_id)
+                    if not record or step_id not in record.get("current_step_ids", []):
+                        continue
+                    satisfied = set(map(str, interpretation.get(
+                        "satisfied_requirements", []
+                    ))) if isinstance(interpretation, dict) else set()
+                    unmet = set(map(str, interpretation.get(
+                        "unmet_requirements", []
+                    ))) if isinstance(interpretation, dict) else set()
+                    verdict = str(interpretation.get("verdict") or "") if isinstance(
+                        interpretation, dict
+                    ) else ""
+                    if obligation_id in satisfied or verdict == "satisfied":
+                        attempt_state = "satisfied"
+                    elif terminal == "waiting":
+                        attempt_state = "pending"
+                    elif obligation_id in unmet or isinstance(interpretation, dict):
+                        attempt_state = "unresolved"
+                    else:
+                        attempt_state = (
+                            "satisfied" if terminal == "completed" else "unresolved"
+                        )
+                    attempt_states = {
+                        **record.get("attempt_states", {}),
+                        step_id: attempt_state,
+                    }
+                    attempt_interpretations = dict(
+                        record.get("attempt_interpretations", {})
+                    )
+                    if isinstance(interpretation, dict):
+                        attempt_interpretations[step_id] = interpretation
+                    states = list(attempt_states.values())
+                    state = (
+                        "satisfied" if "satisfied" in states
+                        else "pending" if "pending" in states
+                        else "unresolved"
+                    )
+                    projection[obligation_id] = {
+                        **record,
+                        "state": state,
+                        "attempt_states": attempt_states,
+                        "attempt_interpretations": attempt_interpretations,
+                    }
                 data.pop("claim_expires_at", None)
                 data.pop("resume_agent_id", None)
                 data.pop("resume_context", None)
@@ -1778,6 +1990,9 @@ class RedisContextStore:
                 pipe.hset(output_key, mapping={k: v for k, v in mapping.items() if v is not None})
                 pipe.expire(output_key, self._ttl_seconds)
                 pipe.hset(graph_key, mapping={step_id: json.dumps(data)})
+                if projection:
+                    pipe.set(projection_key, json.dumps(projection, default=str))
+                    pipe.expire(projection_key, self._ttl_seconds)
                 pipe.xadd(f"ledgers:{workflow_id}", {
                     "event": f"step_{terminal}",
                     "step_id": step_id,

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -110,6 +110,7 @@ nav:
       - Custom Sub-agents: guides/custom-subagents.md
       - FastAPI: guides/fastapi.md
       - Workflow DAGs: guides/workflows.md
+      - Durable Goal Execution: guides/goal-execution.md
       - HITL Escalation: guides/hitl.md
       - Nexus Credentials: guides/nexus.md
       - Knowledge Base: guides/knowledge-base.md
@@ -142,7 +143,7 @@ nav:
   - Enterprise: infrastructure/enterprise.md
 
 extra:
-  version: "1.2.0"
+  version: "1.11.0"
   social:
     - icon: material/web
       link: https://developers.prescottdata.io

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "jarviscore-framework"
-version = "1.10.0"
+version = "1.11.0"
 description = "Orchestrate multi-agent systems with peer-to-peer coordination, unified memory, and built-in auth."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/test_07_distributed_single_node.py
+++ b/tests/test_07_distributed_single_node.py
@@ -302,6 +302,34 @@ class TestDistributedWorkflowExecution:
         assert "gen-step" in memory
         assert "analyze-step" in memory
 
+    @pytest.mark.asyncio
+    async def test_claimed_step_receives_goal_graph_and_dependency_outputs(self):
+        from jarviscore.testing import MockRedisContextStore
+
+        store = MockRedisContextStore()
+        mesh = Mesh(config={"p2p_enabled": False})
+        analyzer = mesh.add(DataAnalyzerAgent)
+        mesh._redis_store = store
+        store.publish_workflow(
+            "wf-shared-view",
+            goal="Generate evidence and analyse it",
+            obligations=[{"id": "o1", "description": "Analyse generated evidence", "source_quote": "analyse it"}],
+            steps=[
+                {"id": "generate", "capability": "data_generation", "task": "Generate", "depends_on": []},
+                {"id": "analyse", "capability": "analysis", "task": "Analyse", "depends_on": ["generate"], "covers": ["o1"]},
+            ],
+        )
+        store.save_step_output("wf-shared-view", "generate", output={"rows": [1, 2, 3]})
+        store.update_step_status("wf-shared-view", "generate", "completed")
+
+        step = store.get_step_definition("wf-shared-view", "analyse")
+        await mesh._execute_distributed_step(analyzer, "wf-shared-view", "analyse", step)
+
+        context = analyzer.context_received[-1]
+        assert context["objective"] == "Generate evidence and analyse it"
+        assert context["previous_step_results"] == {"generate": {"rows": [1, 2, 3]}}
+        assert {item["id"] for item in context["workflow_plan"]["steps"]} == {"generate", "analyse"}
+
 
 # ═══════════════════════════════════════════════════════════════════════════════
 # TEST CLASS: Step Broadcasting

--- a/tests/test_atom_catalogue.py
+++ b/tests/test_atom_catalogue.py
@@ -12,12 +12,16 @@ with its stage stated rather than filtered out, and what the agent is told to do
 about it lives in the prompt rather than in a sentence injected into state.
 """
 
+import hashlib
 import tempfile
+from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
 from jarviscore.execution.code_registry import create_function_registry
+from jarviscore.execution.atom_contract import read_contract
+from jarviscore.integrations.seed_registry import seed_registry
 from jarviscore.kernel.defaults.coder import CoderSubAgent
 
 
@@ -50,27 +54,155 @@ class TestCatalogueIsLoaded:
             registry = create_function_registry(directory, seed=False)
             assert registry.function_metadata == {}
 
-    def test_a_registry_with_history_is_not_reseeded(self, monkeypatch):
-        """Re-seeding would overwrite execution counts earned by real runs."""
+    def test_a_registry_with_history_receives_only_missing_shipped_atoms(self, monkeypatch):
         calls = []
 
         def fake_seed(registry, **kwargs):
-            calls.append(registry)
-            registry.register_function(
-                "hubspot_list_contacts",
-                "def hubspot_list_contacts(auth_info):\n    return {}\n",
-                metadata={"system": "hubspot", "description": "list contacts"},
-            )
+            calls.append(kwargs)
+            if not registry.has_function("hubspot_list_contacts"):
+                registry.register_function(
+                    "hubspot_list_contacts",
+                    "def hubspot_list_contacts(auth_info):\n    return {}\n",
+                    metadata={"system": "hubspot", "description": "list contacts"},
+                )
             return {"registered": ["hubspot_list_contacts"], "failed": []}
 
         monkeypatch.setattr(
             "jarviscore.integrations.seed_registry.seed_registry", fake_seed,
         )
         with tempfile.TemporaryDirectory() as directory:
-            create_function_registry(directory)
+            first = create_function_registry(directory)
+            first.update_function_metadata("hubspot_list_contacts", {"success_count": 7})
             assert len(calls) == 1
-            create_function_registry(directory)      # same path, now populated
-            assert len(calls) == 1
+            second = create_function_registry(directory)
+            assert len(calls) == 2
+            assert all(call == {"missing_only": True} for call in calls)
+            assert second.get_function_metadata("hubspot_list_contacts")["success_count"] == 7
+
+    def test_stale_invalid_builtin_is_upgraded_without_losing_history(self):
+        legacy = """
+async def google_calendar_delete_event(event_id: str, calendar_id='primary'):
+    return await nexus_call('DELETE', f'https://example.test/{event_id}')
+"""
+        with tempfile.TemporaryDirectory() as directory:
+            registry = create_function_registry(directory, seed=False)
+            registry.register_function(
+                "google_calendar_delete_event",
+                legacy,
+                metadata={
+                    "system": "google_calendar",
+                    "description": "Delete an event",
+                    "capabilities": ["delete_event"],
+                },
+            )
+            registry.update_function_metadata(
+                "google_calendar_delete_event",
+                {"execution_count": 9, "success_count": 7, "failure_count": 2},
+            )
+
+            seed_registry(registry, systems=["google_calendar"], missing_only=True)
+
+            source = registry.get_function_code("google_calendar_delete_event")
+            contract = read_contract(
+                source, system="google_calendar",
+                expected_name="google_calendar_delete_event",
+            )
+            metadata = registry.get_function_metadata("google_calendar_delete_event")
+            assert contract.ok
+            assert metadata["version"] == 2
+            assert metadata["execution_count"] == 9
+            assert metadata["success_count"] == 7
+            assert metadata["failure_count"] == 2
+
+    def test_stale_token_retrieving_builtin_is_upgraded(self):
+        stale = """
+async def google_drive_create_folder(folder_name: str, parent_folder_id: str=None) -> dict:
+    token = _get_nexus_token(None)
+    return await nexus_call('POST', 'https://example.test', headers={'Authorization': token})
+"""
+        with tempfile.TemporaryDirectory() as directory:
+            registry = create_function_registry(directory, seed=False)
+            registry.register_function(
+                "google_drive_create_folder",
+                stale,
+                metadata={
+                    "system": "google_drive",
+                    "description": "Create folder",
+                    "capabilities": ["folders"],
+                },
+            )
+            registry.update_function_metadata(
+                "google_drive_create_folder",
+                {"execution_count": 4, "failure_count": 4},
+            )
+
+            seed_registry(registry, systems=["google_drive"], missing_only=True)
+
+            source = registry.get_function_code("google_drive_create_folder")
+            metadata = registry.get_function_metadata("google_drive_create_folder")
+            assert "_get_nexus_token" not in source
+            assert metadata["version"] == 2
+            assert metadata["execution_count"] == 4
+            assert metadata["failure_count"] == 4
+
+    def test_changed_valid_catalogue_atom_converges_but_repair_is_preserved(self):
+        with tempfile.TemporaryDirectory() as directory:
+            registry = create_function_registry(directory, seed=False)
+            stale_valid = '''\
+async def google_calendar_list_events(calendar_id: str='primary') -> dict:
+    """List calendar events without participant details."""
+    response = await nexus_call('GET', 'https://example.test/events')
+    return {'success': True, 'events': response['json'].get('items', [])}
+'''
+            registry.register_function(
+                "google_calendar_list_events",
+                stale_valid,
+                metadata={
+                    "system": "google_calendar",
+                    "description": "List events",
+                    "capabilities": ["events"],
+                    "catalogue_managed": True,
+                    "catalogue_source_hash": hashlib.sha256(
+                        stale_valid.encode("utf-8")
+                    ).hexdigest(),
+                },
+            )
+
+            seed_registry(registry, systems=["google_calendar"], missing_only=True)
+            upgraded = registry.get_function_metadata(
+                "google_calendar_list_events"
+            )
+            assert upgraded["version"] == 2
+            assert "attendees" in registry.get_function_code(
+                "google_calendar_list_events"
+            )
+
+            registry.update_function_metadata(
+                "google_calendar_list_events",
+                {"repair_of_version": 2},
+            )
+            repaired_source = registry.get_function_code(
+                "google_calendar_list_events"
+            ).replace("'status': e.get('status'),", "'status': 'locally-repaired',")
+            registry.register_function(
+                "google_calendar_list_events",
+                repaired_source,
+                metadata={
+                    "system": "google_calendar",
+                    "description": "List repaired events",
+                    "capabilities": ["events"],
+                    "repair_of_version": 2,
+                },
+            )
+            seed_registry(registry, systems=["google_calendar"], missing_only=True)
+
+            preserved = registry.get_function_metadata(
+                "google_calendar_list_events"
+            )
+            assert preserved["version"] == 3
+            assert "locally-repaired" in registry.get_function_code(
+                "google_calendar_list_events"
+            )
 
     def test_a_broken_catalogue_does_not_stop_the_agent(self, monkeypatch, caplog):
         monkeypatch.setattr(
@@ -257,3 +389,107 @@ class TestDecisionsAreTaughtNotInjected:
         assert "register_function" in prompt
         # Reuse is the first move, not the thing you try once stuck.
         assert prompt.index("check_registry") < prompt.index("delegate_research")
+
+
+class TestFailedAtomRepairLifecycle:
+
+    @pytest.mark.asyncio
+    async def test_failed_atom_is_replaced_only_after_repaired_source_succeeds(self):
+        original = '''\
+async def google_drive_export_file(file_id: str, mime_type: str = "text/plain") -> dict:
+    """Export a Google Workspace file."""
+    response = await nexus_call("GET", f"https://example.test/files/{file_id}")
+    return {"success": False, "error": response["body"]}
+'''
+        repaired = '''\
+async def google_drive_export_file(file_id: str, mime_type: str = "text/plain") -> dict:
+    """Export a Google Workspace file."""
+    response = await nexus_call(
+        "GET",
+        f"https://www.googleapis.com/drive/v3/files/{file_id}/export",
+        params={"mimeType": mime_type},
+    )
+    if not response["ok"]:
+        return {"success": False, "error": response["body"]}
+    return {"success": True, "data": response["content"].decode("utf-8")}
+'''
+        with tempfile.TemporaryDirectory() as directory:
+            registry = create_function_registry(directory, seed=False)
+            registry.register_function(
+                "google_drive_export_file",
+                original,
+                metadata={
+                    "system": "google_drive",
+                    "description": "Export a Google Workspace file",
+                    "capabilities": ["export_file"],
+                },
+            )
+            registry.update_execution_stats(
+                "google_drive_export_file", success=True, execution_time=0.1,
+            )
+            old_path = Path(
+                registry.get_function_metadata("google_drive_export_file")["atom_path"]
+            )
+
+            coder = CoderSubAgent(
+                agent_id="repair-coder",
+                llm_client=MagicMock(),
+                sandbox=MagicMock(),
+                code_registry=registry,
+            )
+            coder.sandbox.execute = AsyncMock(return_value={
+                "status": "success",
+                "output": {"success": True, "data": "Introduction"},
+            })
+            coder._run_context = {"system": "google_drive"}
+            failed = {
+                "status": "failure",
+                "error": "Only files with binary content can be downloaded.",
+                "execution_time": 0.2,
+            }
+            coder._record_atom_outcome(
+                "google_drive_export_file",
+                failed,
+                params={"file_id": "doc-1", "mime_type": "text/plain"},
+            )
+
+            inspected = coder._tool_inspect_atom_for_repair("google_drive_export_file")
+            candidate = coder._tool_repair_atom("google_drive_export_file", repaired)
+            executed = await coder._tool_execute_code(candidate_id=candidate["candidate_id"])
+            registered = coder._tool_register_function(
+                function_name="google_drive_export_file",
+                candidate_id=candidate["candidate_id"],
+                system="google_drive",
+            )
+
+            metadata = registry.get_function_metadata("google_drive_export_file")
+            assert inspected["source"] == original
+            assert failed["atom_repair"]["available"] is True
+            assert executed["status"] == "success"
+            assert registered["status"] == "registered"
+            assert metadata["version"] == 2
+            assert metadata["registry_stage"] == "verified"
+            assert metadata["repair_of_version"] == 1
+            assert "binary content" in metadata["repair_failure"]
+            assert registry.get_function_code("google_drive_export_file") == repaired
+            assert old_path.read_text() == original
+
+    def test_unexecuted_candidate_cannot_replace_registry_source(self):
+        coder = CoderSubAgent.__new__(CoderSubAgent)
+        coder.code_registry = MagicMock()
+        coder._candidates = [{
+            "candidate_id": 1,
+            "code": "def hubspot_list_deals(): return {}",
+            "status": "validated",
+            "system": "hubspot",
+        }]
+
+        result = coder._tool_register_function(
+            function_name="hubspot_list_deals",
+            candidate_id=1,
+            system="hubspot",
+            description="List deals",
+        )
+
+        assert result["semantic_error"] == "REGISTRY_EXECUTION_PROOF_REQUIRED"
+        coder.code_registry.register_function.assert_not_called()

--- a/tests/test_autoagent.py
+++ b/tests/test_autoagent.py
@@ -349,6 +349,48 @@ class TestAutoAgentExecution:
         assert kernel.calls[0]["use_default_role_as_fallback"] is True
 
     @pytest.mark.asyncio
+    async def test_peer_capability_request_bypasses_nested_goal_planning(self):
+        """Focused peer help stays agentic without becoming another goal program."""
+        from types import SimpleNamespace
+
+        class ClassifierMustNotRun:
+            async def generate(self, **kwargs):
+                raise AssertionError("peer capability work must not run the classifier")
+
+        class FakeKernel:
+            def __init__(self):
+                self.auth_manager = None
+                self.calls = []
+
+            async def execute(self, **kwargs):
+                self.calls.append(kwargs)
+                return SimpleNamespace(
+                    status="success",
+                    payload={"email": "verified@example.com"},
+                    summary="verified",
+                    metadata={"tokens": {"input": 0, "output": 0, "total": 0}},
+                )
+
+        agent = GoalDirectAutoAgent()
+        setattr(agent, "llm", ClassifierMustNotRun())
+        kernel = FakeKernel()
+        setattr(agent, "_kernel", kernel)
+
+        result = await agent.execute_task({
+            "task": "Resolve the missing contact identity.",
+            "context": {
+                "peer_requester_agent_id": "revenue-operations",
+                "capability": "contact_verification",
+            },
+        })
+
+        assert result["status"] == "success"
+        assert result["payload"] == {"email": "verified@example.com"}
+        assert result["goal_execution"]["planner_mode"] == "direct_kernel"
+        assert "bounded specialist assignment" in result["goal_execution"]["reason"]
+        assert len(kernel.calls) == 1
+
+    @pytest.mark.asyncio
     async def test_goal_oriented_agent_honors_single_response_execution_contract(self):
         """A single-response contract is ONE completion against the system
         prompt — no classifier, no planner, no kernel routing (issue #63).
@@ -398,6 +440,33 @@ class TestAutoAgentExecution:
         assert llm.calls[0]["messages"][0]["content"].endswith(
             GoalDirectAutoAgent.system_prompt
         )
+
+    @pytest.mark.asyncio
+    async def test_single_artifact_contract_accepts_raw_json_after_kernel_work(self):
+        from jarviscore.kernel.kernel import Kernel
+        from jarviscore.testing import MockLLMClient
+
+        artifact = {"status": "ready", "items": [{"id": "acme"}]}
+        llm = MockLLMClient(responses=[
+            {"content": json.dumps({
+                "role": "communicator",
+                "confidence": 0.95,
+                "reason": "Return the structured deliverable.",
+                "evidence_required": False,
+            })},
+            {"content": json.dumps(artifact)},
+        ])
+        agent = GoalDirectAutoAgent()
+        agent.llm = llm
+        agent._kernel = Kernel(llm_client=llm)
+
+        result = await agent.execute_task({
+            "task": "Return the validated artifact.",
+            "context": {"execution_contract": {"execution_shape": "single_artifact"}},
+        })
+
+        assert result["status"] == "success"
+        assert result["output"] == artifact
 
     @pytest.mark.asyncio
     async def test_kernel_routes_access_requests_before_default_coder_role(self):

--- a/tests/test_autoagent_dx.py
+++ b/tests/test_autoagent_dx.py
@@ -47,6 +47,40 @@ class _MiniAuto(AutoAgent):
 class TestAutoAgentLoudFailures:
 
     @pytest.mark.asyncio
+    async def test_mailbox_context_is_acknowledged_only_after_success(self, monkeypatch):
+        class _Mailbox:
+            def __init__(self):
+                self.messages = [{"sender": "peer", "message": {"evidence": "ready"}}]
+                self.acked = 0
+
+            def peek(self, limit=10):
+                return self.messages[:limit]
+
+            def read(self, max_messages=5):
+                self.acked += max_messages
+                return self.messages[:max_messages]
+
+            def format_for_context(self, messages):
+                return "peer evidence is ready"
+
+        agent = _MiniAuto()
+        agent.mailbox = _Mailbox()
+        seen = []
+
+        async def execute(task):
+            seen.append(task)
+            return {"status": "failure" if len(seen) == 1 else "success", "output": "done"}
+
+        monkeypatch.setattr(agent, "_execute_task_pipeline", execute)
+
+        await agent.execute_task({"task": "work", "context": {}})
+        assert seen[0]["context"]["_mailbox_context"] == "peer evidence is ready"
+        assert agent.mailbox.acked == 0
+
+        await agent.execute_task({"task": "work", "context": {}})
+        assert agent.mailbox.acked == 1
+
+    @pytest.mark.asyncio
     async def test_used_before_start_raises_descriptive_error(self):
         agent = _MiniAuto()
         with pytest.raises(RuntimeError, match="before mesh.start"):

--- a/tests/test_capability_offering.py
+++ b/tests/test_capability_offering.py
@@ -20,6 +20,33 @@ async def insightly_get_account(account_id: str) -> dict:
     return {"status": "success", "data": response["json"]}
 '''
 
+CREATE_ATOM_SOURCE = '''\
+ATOM_POLICY = {
+    "effect": "write",
+    "approval": "never",
+    "idempotency_fields": ["account_name"],
+    "consequence": "Creates one account record.",
+}
+
+async def insightly_create_account(account_name: str) -> dict:
+    """Create an organisation record in Insightly."""
+    response = await nexus_call(
+        "POST", "https://api.na1.insightly.com/v3.1/Organisations",
+        json={"ORGANISATION_NAME": account_name},
+    )
+    return {"status": "success", "data": response["json"]}
+'''
+
+GMAIL_ATOM_SOURCE = '''\
+async def gmail_list_messages(query: str = "") -> dict:
+    """List Gmail messages matching a query."""
+    response = await nexus_call(
+        "GET", "https://gmail.googleapis.com/gmail/v1/users/me/messages",
+        params={"q": query},
+    )
+    return {"status": "success", "data": response["json"]}
+'''
+
 
 class FakeRegistry:
     """Minimal stand-in for the FunctionRegistry surface coder.py touches."""
@@ -47,7 +74,15 @@ def coder():
     agent._atoms = {}
     agent._run_context = {}
     agent.code_registry = FakeRegistry(
-        {"insightly_get_account": {"system": "insightly", "code": ATOM_SOURCE}}
+        {
+            "insightly_get_account": {"system": "insightly", "code": ATOM_SOURCE},
+            "insightly_create_account": {
+                "system": "insightly", "code": CREATE_ATOM_SOURCE,
+            },
+            "gmail_list_messages": {
+                "system": "gmail", "code": GMAIL_ATOM_SOURCE,
+            },
+        }
     )
 
     def register_tool(name, fn, description, phase=None):
@@ -107,7 +142,48 @@ def test_candidate_makes_the_atom_a_callable_tool(coder):
     }
     coder._offer_system_capabilities(coder._resolved_system())
     assert "insightly_get_account" in coder._tools
+    assert set(coder._atom_tools) == {
+        "insightly_get_account", "insightly_create_account",
+    }
+
+
+def test_provider_bound_outcome_offers_read_and_write_atoms_for_agent_reasoning(coder):
+    coder._run_context = {
+        "system": "insightly",
+        "effect": "write",
+        "systems": ["insightly"],
+    }
+
+    coder._offer_system_capabilities(coder._resolved_system())
+
+    assert set(coder._atom_tools) == {
+        "insightly_get_account", "insightly_create_account",
+    }
+
+
+def test_read_outcome_never_offers_write_atoms(coder):
+    coder._run_context = {
+        "system": "insightly",
+        "effect": "read",
+        "systems": ["insightly"],
+    }
+
+    coder._offer_system_capabilities(coder._resolved_system())
+
     assert coder._atom_tools == ["insightly_get_account"]
+
+
+def test_multi_provider_read_offers_each_connected_system_atom(coder):
+    coder._run_context = {
+        "systems": ["insightly", "gmail"],
+        "effect": "read",
+    }
+
+    coder._offer_system_capabilities_for(["insightly", "gmail"])
+
+    assert set(coder._atom_tools) == {
+        "insightly_get_account", "gmail_list_messages",
+    }
 
 
 def test_unresolved_system_offers_nothing(coder):

--- a/tests/test_destructive_atoms.py
+++ b/tests/test_destructive_atoms.py
@@ -18,6 +18,22 @@ async def gmail_delete_message(message_id: str) -> dict:
     return await nexus_call("DELETE", f"https://example.test/messages/{message_id}")
 '''
 
+WRITE_SOURCE = '''
+ATOM_POLICY = {
+    "effect": "write",
+    "approval": "never",
+    "idempotency_fields": ["summary", "start_datetime", "end_datetime"],
+    "consequence": "Creates one calendar event.",
+}
+async def google_calendar_create_event(
+    summary: str, start_datetime: str, end_datetime: str
+) -> dict:
+    """Create one calendar event."""
+    return await nexus_call("POST", "https://example.test/events", json={
+        "summary": summary, "start": start_datetime, "end": end_datetime,
+    })
+'''
+
 
 class Registry:
     def get_function_code(self, name):
@@ -56,6 +72,18 @@ def test_idempotency_fields_must_name_parameters():
     assert "must name parameters" in contract.report()
 
 
+def test_write_atom_requires_idempotency_identity_and_consequence():
+    invalid = WRITE_SOURCE.replace(
+        '"idempotency_fields": ["summary", "start_datetime", "end_datetime"],',
+        '"idempotency_fields": [],',
+    )
+    contract = read_contract(
+        invalid, system="google_calendar", expected_name="google_calendar_create_event"
+    )
+    assert not contract.ok
+    assert "write atoms require idempotency_fields" in contract.report()
+
+
 @pytest.mark.asyncio
 async def test_approval_precedes_execution_and_retry_is_idempotent():
     atom = read_contract(
@@ -80,6 +108,39 @@ async def test_approval_precedes_execution_and_retry_is_idempotent():
     agent._run_context["_approved_actions"] = [waiting["action_id"]]
     first = await call(message_id="m-1")
     retry = await call(message_id="m-1")
+
+    assert first == retry
+    agent._tool_execute_code.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_write_atom_executes_without_approval_and_retry_is_idempotent():
+    atom = read_contract(
+        WRITE_SOURCE,
+        system="google_calendar",
+        expected_name="google_calendar_create_event",
+    ).atom
+    assert atom is not None
+    agent = CoderSubAgent.__new__(CoderSubAgent)
+    agent._atoms = {atom.name: atom}
+    agent._run_context = {"workflow_id": "wf", "step_id": "calendar"}
+    agent.code_registry = Registry()
+    agent.redis_store = ExecutionStore()
+    agent._tool_execute_code = AsyncMock(
+        return_value={"status": "success", "data": {"event_id": "evt-1"}}
+    )
+    call = agent._atom_tool(atom.name)
+
+    first = await call(
+        summary="Discovery Call",
+        start_datetime="2026-09-10T13:00:00+03:00",
+        end_datetime="2026-09-10T13:30:00+03:00",
+    )
+    retry = await call(
+        summary="Discovery Call",
+        start_datetime="2026-09-10T13:00:00+03:00",
+        end_datetime="2026-09-10T13:30:00+03:00",
+    )
 
     assert first == retry
     agent._tool_execute_code.assert_awaited_once()

--- a/tests/test_done_gate_evidence.py
+++ b/tests/test_done_gate_evidence.py
@@ -8,6 +8,7 @@ move rather than letting it burn the lease.
 """
 
 import asyncio
+import json
 from typing import Any, Dict, List, Optional
 
 import pytest
@@ -420,20 +421,149 @@ class TestCoderGate:
         from jarviscore.kernel.defaults.coder import CoderSubAgent
         return CoderSubAgent.__new__(CoderSubAgent)
 
-    def test_unproven_work_reports_the_calls_that_were_made(self):
+    def test_failed_action_can_finish_with_an_honest_blocked_result(self):
         state = _state(tool_history=[
             ToolResult(tool_name="write_code", status="failure", error="boom"),
             ToolResult(tool_name="check_registry", status="success", tool_output={}),
         ])
+        parsed = {"result": {"status": "blocked", "reason": "Provider call failed"}}
 
-        ok, evidence = self._coder()._can_complete(state, {"result": "42"})
+        ok, reason = self._coder()._can_complete(state, parsed)
+
+        assert ok is True
+        assert reason == ""
+        assert parsed["result"]["status"] == "blocked"
+
+    def test_blocked_result_requires_a_peer_resolution_attempt(self):
+        coder = self._coder()
+        coder._tools = {"ask_capability": object(), "ask_peer": object()}
+        state = _state(tool_history=[
+            ToolResult(tool_name="hubspot_list_contacts", status="success", tool_output=[]),
+        ])
+        parsed = {"result": {"status": "blocked", "reason": "Contact unresolved"}}
+
+        ok, evidence = coder._can_complete(state, parsed)
 
         assert ok is False
-        assert evidence.check == "proof_of_work"
-        assert evidence.observed["write_code_calls"] == 1
-        assert evidence.observed["execute_code_calls"] == 0
-        assert evidence.observed["successful_executions"] == 0
-        assert evidence.observed["tool_calls"] == 2
+        assert evidence.check == "peer_resolution_review"
+        assert evidence.observed["peer_tool_calls"] == 0
+
+        ok, repeated = coder._can_complete(state, parsed)
+        assert ok is False
+        assert repeated.check == "peer_resolution_review"
+
+    def test_unresolved_facts_require_peer_resolution_even_for_existing_record(self):
+        coder = self._coder()
+        coder._tools = {"ask_capability": object()}
+        state = _state(tool_history=[
+            ToolResult(
+                tool_name="hubspot_search_contacts",
+                status="success",
+                tool_output={"contacts": []},
+            ),
+        ])
+        parsed = {"result": {
+            "status": "existing",
+            "deal_id": "deal-1",
+            "unresolved": [{"fact": "Contact identity remains unresolved"}],
+        }}
+
+        ok, evidence = coder._can_complete(state, parsed)
+
+        assert ok is False
+        assert evidence.check == "peer_resolution_review"
+
+    def test_peer_responder_is_not_forced_to_delegate_its_response_again(self):
+        coder = self._coder()
+        coder._tools = {"ask_capability": object()}
+        state = _state(
+            context={"peer_requester_agent_id": "requester-1"},
+            tool_history=[
+                ToolResult(
+                    tool_name="hubspot_search_contacts",
+                    status="success",
+                    tool_output={"contacts": []},
+                ),
+            ],
+        )
+        parsed = {"result": {
+            "status": "research_incomplete",
+            "unresolved": [{"fact": "No additional CRM record was found"}],
+        }}
+
+        ok, reason = coder._can_complete(state, parsed)
+
+        assert ok is True
+        assert reason == ""
+
+    def test_peer_attempt_allows_honest_blocked_completion(self):
+        coder = self._coder()
+        coder._tools = {"ask_capability": object()}
+        state = _state(tool_history=[
+            ToolResult(
+                tool_name="ask_capability",
+                status="failure",
+                error="No peer fulfilled the need",
+                tool_output={"peer_request_attempted": True},
+            ),
+        ])
+
+        ok, reason = coder._can_complete(
+            state, {"result": {"status": "blocked", "reason": "Contact unresolved"}}
+        )
+
+        assert ok is True
+        assert reason == ""
+
+    def test_malformed_peer_call_does_not_satisfy_resolution_attempt(self):
+        coder = self._coder()
+        coder._tools = {"ask_peer": object()}
+        state = _state(tool_history=[
+            ToolResult(
+                tool_name="ask_peer",
+                status="failure",
+                error="Missing required peer arguments: role, question",
+                tool_output={
+                    "status": "error",
+                    "semantic_error": "INVALID_PEER_TOOL_ARGUMENTS",
+                    "peer_request_attempted": False,
+                },
+            ),
+        ])
+
+        ok, evidence = coder._can_complete(
+            state,
+            {"result": {"status": "blocked", "reason": "Deck unavailable"}},
+        )
+
+        assert ok is False
+        assert evidence.check == "peer_resolution_review"
+
+    def test_no_attempt_cannot_finish_with_an_unsupported_result(self):
+        state = _state(tool_history=[])
+
+        ok, evidence = self._coder()._can_complete(
+            state, {"result": {"status": "blocked", "reason": "Assumed failure"}}
+        )
+
+        assert ok is False
+        assert evidence.check == "meaningful_attempt"
+
+    def test_first_turn_prompt_requires_a_relevant_tool_not_success(self):
+        coder = self._coder()
+        coder.role = "coder"
+        coder._tools = {
+            "ask_capability": object(), "ask_peer": object(), "write_code": object()
+        }
+        coder._atom_tools = ["hubspot_list_deals"]
+
+        prompt = coder._build_user_prompt(_state(tool_history=[]), "## MISSION")
+
+        assert "MUST use one relevant tool" in prompt
+        assert "hubspot_list_deals" in prompt
+        assert "ask_peer" in prompt
+        assert "ask_capability" in prompt
+        assert "successful execution" not in prompt
 
     def test_a_successful_execution_satisfies_the_gate(self):
         """The gate checks proof exists; it does not swap the answer for it."""
@@ -447,4 +577,120 @@ class TestCoderGate:
         assert ok is True
         assert reason == ""
         assert parsed["result"] == {"answer": "forty-two"}
-        assert parsed["evidence"] == 42
+        assert "evidence" not in parsed
+
+    @pytest.mark.asyncio
+    async def test_effect_intent_review_redirects_unsupported_mutation(self):
+        from types import SimpleNamespace
+
+        class ReviewLLM:
+            async def generate(self, **kwargs):
+                return {"content": json.dumps({
+                    "decision": "redirect",
+                    "reason": "Deal absence has not been verified.",
+                    "missing_evidence": ["Inspect existing deals"],
+                })}
+
+        coder = self._coder()
+        coder.llm_client = ReviewLLM()
+        coder._atoms = {
+            "provider_create_record": SimpleNamespace(
+                policy=SimpleNamespace(effect="write")
+            )
+        }
+        state = _state(
+            task="Create the record only if absent",
+            context={"objective": "Create the record only if absent"},
+            tool_history=[
+                ToolResult(
+                    tool_name="provider_search_contacts",
+                    status="success",
+                    tool_output={"contacts": []},
+                ),
+            ],
+        )
+
+        result = await coder._pre_execute_hook(
+            "provider_create_record", {"name": "Acme"}, state
+        )
+
+        assert result["semantic_error"] == "EFFECT_INTENT_REDIRECT"
+        assert result["missing_evidence"] == ["Inspect existing deals"]
+
+    @pytest.mark.asyncio
+    async def test_effect_intent_review_allows_supported_mutation(self):
+        from types import SimpleNamespace
+
+        class ReviewLLM:
+            async def generate(self, **kwargs):
+                return {"content": json.dumps({
+                    "decision": "allow",
+                    "reason": "The requested target was inspected and is absent.",
+                    "missing_evidence": [],
+                })}
+
+        coder = self._coder()
+        coder.llm_client = ReviewLLM()
+        coder._atoms = {
+            "provider_create_record": SimpleNamespace(
+                policy=SimpleNamespace(effect="write")
+            )
+        }
+        state = _state(tool_history=[
+            ToolResult(
+                tool_name="provider_search_records",
+                status="success",
+                tool_output={"records": []},
+            ),
+        ])
+
+        result = await coder._pre_execute_hook(
+            "provider_create_record", {"name": "Acme"}, state
+        )
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_effect_intent_review_skips_an_already_satisfied_mutation(self):
+        from types import SimpleNamespace
+
+        class ReviewLLM:
+            async def generate(self, **kwargs):
+                return {"content": json.dumps({
+                    "decision": "already_satisfied",
+                    "reason": "The requested meeting already exists.",
+                    "missing_evidence": [],
+                    "supporting_evidence": [
+                        "event-1 has the requested attendee and schedule"
+                    ],
+                })}
+
+        coder = self._coder()
+        coder.llm_client = ReviewLLM()
+        coder._atoms = {
+            "provider_create_event": SimpleNamespace(
+                policy=SimpleNamespace(effect="write")
+            )
+        }
+        state = _state(tool_history=[
+            ToolResult(
+                tool_name="provider_list_events",
+                status="success",
+                tool_output={
+                    "events": [{
+                        "id": "event-1",
+                        "attendees": ["ephy@example.com"],
+                    }],
+                },
+            ),
+        ])
+
+        result = await coder._pre_execute_hook(
+            "provider_create_event",
+            {"attendees": ["ephy@example.com"]},
+            state,
+        )
+
+        assert result["status"] == "success"
+        assert result["skipped"] is True
+        assert result["semantic_outcome"] == "EFFECT_ALREADY_SATISFIED"

--- a/tests/test_done_gate_evidence.py
+++ b/tests/test_done_gate_evidence.py
@@ -622,7 +622,10 @@ class TestCoderGate:
         from types import SimpleNamespace
 
         class ReviewLLM:
+            prompt = ""
+
             async def generate(self, **kwargs):
+                self.prompt = kwargs["messages"][0]["content"]
                 return {"content": json.dumps({
                     "decision": "allow",
                     "reason": "The requested target was inspected and is absent.",
@@ -630,25 +633,43 @@ class TestCoderGate:
                 })}
 
         coder = self._coder()
-        coder.llm_client = ReviewLLM()
+        review = ReviewLLM()
+        coder.llm_client = review
         coder._atoms = {
             "provider_create_record": SimpleNamespace(
                 policy=SimpleNamespace(effect="write")
             )
         }
-        state = _state(tool_history=[
-            ToolResult(
-                tool_name="provider_search_records",
-                status="success",
-                tool_output={"records": []},
-            ),
-        ])
+        state = _state(
+            task="Create the invitation draft from completed prerequisites",
+            context={
+                "objective": "Complete the customer acceleration workflow",
+                "previous_step_results": {
+                    "crm": {"deal_id": "deal-1"},
+                    "calendar": {"event_id": "event-1"},
+                },
+                "previous_step_interpretations": {
+                    "calendar": {"verdict": "satisfied"},
+                },
+            },
+            tool_history=[
+                ToolResult(
+                    tool_name="provider_search_records",
+                    status="success",
+                    tool_output={"records": []},
+                ),
+            ],
+        )
 
         result = await coder._pre_execute_hook(
             "provider_create_record", {"name": "Acme"}, state
         )
 
         assert result is None
+        assert "Scoped step task: Create the invitation draft" in review.prompt
+        assert '"deal_id": "deal-1"' in review.prompt
+        assert '"event_id": "event-1"' in review.prompt
+        assert '"verdict": "satisfied"' in review.prompt
 
     @pytest.mark.asyncio
     async def test_effect_intent_review_skips_an_already_satisfied_mutation(self):

--- a/tests/test_epistemic_reasoning.py
+++ b/tests/test_epistemic_reasoning.py
@@ -168,6 +168,24 @@ class TestEpistemicDecisionPrompt:
         prompt = self._build_prompt(state)
         assert "Turn 7" in prompt
 
+    def test_prompt_resolves_peer_answerable_gaps_before_stopping(self):
+        class StubAgent(BaseSubAgent):
+            def get_system_prompt(self):
+                return "Test system prompt"
+
+            def setup_tools(self):
+                self.register_tool("ask_peer", lambda **_: {}, "Ask a peer")
+                self.register_tool(
+                    "ask_capability", lambda **_: {}, "Ask by capability"
+                )
+
+        agent = StubAgent(agent_id="test", role="researcher", llm_client=None)
+        prompt = agent._build_user_prompt(_make_state(), "## MISSION\n**Task:** Test")
+
+        assert "Before concluding blocked" in prompt
+        assert "ask_peer" in prompt
+        assert "ask_capability" in prompt
+
     def test_prompt_includes_role(self):
         prompt = self._build_prompt()
         assert "RESEARCHER AGENT" in prompt

--- a/tests/test_execution_envelopes.py
+++ b/tests/test_execution_envelopes.py
@@ -1,0 +1,164 @@
+import json
+
+import pytest
+
+from jarviscore.orchestration.envelopes import (
+    CapabilityMandate,
+    ClaimRecord,
+    DependencyAuthorization,
+    ExecutionBudget,
+    EffectIntentDecision,
+    FulfillmentRecord,
+    WorkflowEvidence,
+    WorkflowEnvelope,
+    neutral_context,
+    terminal_step_status,
+)
+
+
+def test_neutral_context_copies_data_and_removes_authority():
+    original = {
+        "source_context": {"lead": {"email": "lead@example.com"}},
+        "workflow_id": "wf-1",
+        "system": "hubspot",
+        "effect": "write",
+        "_secret": "hidden",
+    }
+
+    neutral = neutral_context(original)
+    neutral["source_context"]["lead"]["email"] = "changed@example.com"
+
+    assert neutral == {
+        "source_context": {"lead": {"email": "changed@example.com"}},
+        "workflow_id": "wf-1",
+    }
+    assert original["source_context"]["lead"]["email"] == "lead@example.com"
+
+
+def test_workflow_envelope_round_trips_neutral_context():
+    envelope = WorkflowEnvelope(
+        workflow_id="wf-1",
+        goal="Resolve the lead",
+        context={"source_context": {"lead": {"email": "lead@example.com"}}},
+        obligations=[{"id": "o1"}],
+        steps=[{"id": "s1", "status": "pending"}],
+        revision=2,
+        published_at=12.5,
+    )
+
+    restored = WorkflowEnvelope.from_record(envelope.to_record())
+
+    assert restored == envelope
+
+
+def test_capability_mandate_preserves_existing_redis_shape():
+    mandate = CapabilityMandate.open(
+        mandate_id="need-1",
+        workflow_id="wf-1",
+        requester_agent_id="requester-1",
+        requester_step_id="s1",
+        capability="contact_verification",
+        question="Resolve the contact.",
+        context={"source_context": {"lead": {"email": "lead@example.com"}}},
+        now=10.0,
+    )
+    claimed = CapabilityMandate(
+        **{
+            **mandate.__dict__,
+            "status": "fulfilled",
+            "updated_at": 20.0,
+            "claim": ClaimRecord("resolver-1:claim", "resolver-1", 30.0),
+            "fulfillment": FulfillmentRecord(
+                "resolver-1", {"status": "success", "output": {"verified": True}}
+            ),
+        }
+    )
+
+    record = claimed.to_record()
+    restored = CapabilityMandate.from_record(record)
+
+    assert record["id"] == "need-1"
+    assert record["claim_id"] == "resolver-1:claim"
+    assert record["fulfilled_by"] == "resolver-1"
+    assert restored == claimed
+
+
+def test_workflow_evidence_is_a_defensive_snapshot():
+    artifacts = {"step_1": {"deal_id": "deal-1"}}
+    evidence = WorkflowEvidence(
+        artifacts=artifacts,
+        interpretations={"step_1": {"decision": "proceed"}},
+        states={"step_1": "completed", "step_2": "blocked"},
+    )
+
+    record = evidence.to_record()
+    record["artifacts"]["step_1"]["deal_id"] = "changed"
+
+    assert evidence.artifacts["step_1"]["deal_id"] == "deal-1"
+
+
+def test_execution_budget_is_bounded_and_round_trips_with_workflow():
+    budget = ExecutionBudget.from_record({
+        "max_steps": 12,
+        "max_replans": 2,
+        "max_peer_depth": 2,
+        "peer_timeout_seconds": 45,
+    })
+    envelope = WorkflowEnvelope(
+        workflow_id="wf-budget",
+        goal="Bound the work",
+        budget=budget,
+    )
+
+    restored = WorkflowEnvelope.from_record(envelope.to_record())
+
+    assert restored.budget == budget
+    assert restored.to_record()["budget"]["max_steps"] == 12
+
+
+def test_agent_yield_is_a_durable_waiting_step():
+    assert terminal_step_status("yield") == "waiting"
+    assert terminal_step_status("waiting") == "waiting"
+    assert terminal_step_status("hitl") == "waiting"
+    assert terminal_step_status("blocked") == "blocked"
+    assert terminal_step_status("success") == "completed"
+    assert terminal_step_status("failure") == "failed"
+
+
+def test_effect_intent_decision_requires_typed_grounded_json():
+    decision = EffectIntentDecision.from_response(
+        '{"decision":"redirect","reason":"Deal absence is unverified",'
+        '"missing_evidence":["Inspect existing deals"]}'
+    )
+    assert decision.decision == "redirect"
+    assert decision.missing_evidence == ("Inspect existing deals",)
+
+
+def test_effect_intent_decision_can_prove_the_effect_is_already_satisfied():
+    decision = EffectIntentDecision.from_response(json.dumps({
+        "decision": "already_satisfied",
+        "reason": "The requested meeting already exists with the intended attendee.",
+        "missing_evidence": [],
+        "supporting_evidence": ["event-1 includes ephy@example.com"],
+    }))
+
+    assert decision.decision == "already_satisfied"
+    assert decision.supporting_evidence == (
+        "event-1 includes ephy@example.com",
+    )
+
+
+def test_effect_intent_already_satisfied_requires_evidence():
+    with pytest.raises(ValueError, match="requires supporting_evidence"):
+        EffectIntentDecision.from_response(json.dumps({
+            "decision": "already_satisfied",
+            "reason": "It exists.",
+            "missing_evidence": [],
+        }))
+
+
+def test_dependency_authorization_is_typed():
+    decision = DependencyAuthorization.from_response(
+        '{"decision":"allow","reason":"The unresolved cleanup is unrelated."}'
+    )
+    assert decision.decision == "allow"

--- a/tests/test_kernel.py
+++ b/tests/test_kernel.py
@@ -6,6 +6,7 @@ multi-dispatch retry, HITL escalation, and cost aggregation.
 """
 
 import json
+from types import SimpleNamespace
 
 import pytest
 from jarviscore.kernel import Kernel
@@ -137,6 +138,16 @@ class TestTaskClassification:
         assert output.metadata["dispatches"][0]["role"] == "database"
         assert "COMMUNICATION SPECIALIST" in mock_llm.calls[0]["messages"][0]["content"]
 
+    def test_workflow_budget_caps_existing_role_lease(self, kernel):
+        lease = kernel._lease_for_role(
+            "coder",
+            {"max_tokens": 60_000, "max_seconds": 45},
+        )
+
+        assert lease.max_total_tokens == 60_000
+        assert lease.thinking_budget + lease.action_budget == 60_000
+        assert lease.wall_clock_ms == 45_000
+
 
 # ── Model Routing ─────────────────────────────────────────────────────
 
@@ -174,6 +185,121 @@ class TestSubagentCreation:
     def test_unknown_role_raises(self, kernel):
         with pytest.raises(ValueError, match="Unknown subagent role"):
             kernel._create_subagent("hacker", "test")
+
+    def test_mesh_capabilities_reach_every_subagent_including_cached(self, kernel):
+        class FakePeerTool:
+            tool_names = ["ask_peer", "broadcast_update", "list_peers"]
+
+            @property
+            def schema(self):
+                return [
+                    {"name": name, "description": name, "input_schema": {"type": "object"}}
+                    for name in self.tool_names
+                ]
+
+            async def execute(self, name, args):
+                return {"name": name, "args": args}
+
+        class FakePeers:
+            def as_tool(self):
+                return FakePeerTool()
+
+        cached = kernel._create_subagent("researcher", "test_researcher")
+        kernel._subagent_cache["test:researcher"] = cached
+        mailbox = object()
+
+        kernel.attach_mesh_capabilities(peers=FakePeers(), mailbox=mailbox)
+
+        for role in ("coder", "researcher", "communicator", "browser"):
+            subagent = cached if role == "researcher" else kernel._create_subagent(role, f"test_{role}")
+            assert {"ask_peer", "broadcast_update", "list_peers"} <= set(subagent.tool_names)
+        assert kernel.mailbox is mailbox
+
+    @pytest.mark.asyncio
+    async def test_ask_peer_carries_shared_context_without_caller_authority(self, kernel):
+        class FakePeerTool:
+            tool_names = ["ask_peer"]
+
+            def __init__(self):
+                self.calls = []
+
+            @property
+            def schema(self):
+                return [{"name": "ask_peer", "description": "ask", "input_schema": {}}]
+
+            async def execute(self, name, args, context=None):
+                self.calls.append((name, args, context))
+                return {"status": "success"}
+
+        class FakePeers:
+            def __init__(self, tool):
+                self.tool = tool
+
+            def as_tool(self):
+                return self.tool
+
+        peer_tool = FakePeerTool()
+        kernel.attach_mesh_capabilities(peers=FakePeers(peer_tool))
+        subagent = kernel._create_subagent("coder", "calendar-agent")
+        subagent._current_state = SimpleNamespace(
+            workflow_id="wf-1",
+            step_id="calendar",
+            context={
+                "objective": "Coordinate the full customer workflow",
+                "workflow_plan": {"steps": [{"id": "calendar"}]},
+                "previous_step_results": {"crm": {"email": "known@example.com"}},
+                "system": "google_calendar",
+                "systems": ["google_calendar"],
+                "effect": "write",
+                "capability": "calendar_scheduling",
+                "_nexus_connection_id": "secret-handle",
+            },
+        )
+
+        await subagent._tools["ask_peer"].func(
+            role="revenue_operations", question="Resolve the lead identity"
+        )
+
+        _, _, context = peer_tool.calls[0]
+        assert context["workflow_id"] == "wf-1"
+        assert context["objective"] == "Coordinate the full customer workflow"
+        assert context["previous_step_results"]["crm"]["email"] == "known@example.com"
+        assert context["peer_requester_step_id"] == "calendar"
+        assert not ({"system", "systems", "effect", "capability", "step_id"} & set(context))
+        assert all(not key.startswith("_") for key in context)
+
+    @pytest.mark.asyncio
+    async def test_every_subagent_can_inspect_its_workflow_and_read_step_output(
+        self, kernel
+    ):
+        class Store:
+            def get_workflow_definition(self, workflow_id):
+                assert workflow_id == "wf-1"
+                return {
+                    "workflow_id": workflow_id,
+                    "goal": "Research then analyse",
+                    "obligations": [{"id": "o1"}],
+                    "steps": [{"id": "research"}, {"id": "analyse"}],
+                }
+
+            def get_step_definition(self, workflow_id, step_id):
+                return {"id": step_id, "status": "completed", "completed_by": "peer-1"}
+
+            def get_step_output(self, workflow_id, step_id):
+                return {"output": {"evidence": ["source-1"]}}
+
+        kernel.redis_store = Store()
+        subagent = kernel._create_subagent("researcher", "test_researcher")
+        subagent._current_state = SimpleNamespace(workflow_id="wf-1")
+
+        workflow = await subagent._execute_tool("inspect_workflow", {})
+        step = await subagent._execute_tool(
+            "read_workflow_step", {"step_id": "research"}
+        )
+
+        assert workflow["goal"] == "Research then analyse"
+        assert workflow["steps"][0]["completed_by"] == "peer-1"
+        assert step["output"] == {"evidence": ["source-1"]}
 
 
 # ── Execute: Success Path ─────────────────────────────────────────────
@@ -280,19 +406,18 @@ class TestKernelExecuteFailure:
     @pytest.mark.asyncio
     async def test_all_dispatches_fail(self, kernel, mock_llm):
         """Protocol-invalid responses must not become successful work."""
-        # Empty responses use the mock default, which violates TOOL/DONE and
-        # cannot satisfy coder proof-of-work.
-        mock_llm.responses = []  # Will use default response
+        mock_llm.responses = [
+            _router_response("coder"),
+            _llm_response("This response has neither TOOL nor DONE."),
+            _llm_response("Still not following the execution protocol."),
+            _llm_response("No valid action or completion marker."),
+        ]
         output = await kernel.execute(
             task="Do something complex",
             max_dispatches=2,
             agent_default_role="coder",
         )
         assert output.status == "failure"
-        # An agent that resubmits the same rejected result without doing any work
-        # in between cannot converge, so each dispatch ends on the gate that
-        # stopped it instead of burning the turn fuse first (#144). The kernel
-        # then reports the honest workflow-level outcome.
         assert output.metadata["typed_outcome"] == "FAIL_ALL_DISPATCHES_EXHAUSTED"
 
     @pytest.mark.asyncio
@@ -433,7 +558,58 @@ class TestDeclaredSystemCredentials:
         assert output.payload == {"contacts": 2}
 
     @pytest.mark.asyncio
-    async def test_an_unconsented_app_asks_for_consent_not_registration(
+    async def test_provider_mutation_uses_coder_without_preselecting_an_atom(
+        self, kernel, mock_llm, monkeypatch
+    ):
+        _patch_vault(monkeypatch, connected={"hubspot"})
+
+        decision = await kernel._route_task(
+            "Establish the lead's deal and current stage",
+            {"system": "hubspot", "effect": "write"},
+            agent_default_role="researcher",
+            use_default_role_as_fallback=True,
+        )
+
+        assert decision.role == "coder"
+        assert decision.reason == "Provider mutation requires the credentialed Coder harness."
+        assert mock_llm.calls == []
+
+    @pytest.mark.asyncio
+    async def test_provider_authority_overrides_planner_browser_hint(self, kernel):
+        decision = await kernel._route_task(
+            "Search the connected Drive account",
+            context={
+                "system": "google_drive",
+                "systems": ["google_drive"],
+                "effect": "read",
+                "_agent_default_kernel_role": "browser",
+            },
+            agent_default_role="researcher",
+            use_default_role_as_fallback=True,
+        )
+
+        assert decision.role == "coder"
+        assert decision.reason == (
+            "Connected-system work requires the credentialed Coder harness."
+        )
+
+    @pytest.mark.asyncio
+    async def test_multi_provider_read_capability_uses_credentialed_coder(
+        self, kernel, mock_llm
+    ):
+        decision = await kernel._route_task(
+            "Resolve the contact from connected systems",
+            {"systems": ["gmail", "hubspot"], "effect": "read"},
+            agent_default_role="researcher",
+            use_default_role_as_fallback=True,
+        )
+
+        assert decision.role == "coder"
+        assert decision.reason == "Connected-system work requires the credentialed Coder harness."
+        assert mock_llm.calls == []
+
+    @pytest.mark.asyncio
+    async def test_unconsented_app_without_channel_reports_auth_required(
         self, kernel, mock_llm, monkeypatch
     ):
         """Telling someone to register what they already registered is a dead end."""
@@ -444,9 +620,9 @@ class TestDeclaredSystemCredentials:
         )
 
         assert output.status == "yield"
-        assert output.metadata["typed_outcome"] == "YIELD_CONSENT_REQUIRED"
-        assert output.metadata["escalation_reason"] == "consent_required"
-        assert "no account has been connected" in output.summary
+        assert output.metadata["typed_outcome"] == "YIELD_AUTH_REQUIRED"
+        assert output.metadata["escalation_reason"] == "auth_required"
+        assert "not connected here" in output.summary
         assert output.metadata["dispatches"] == []
 
     @pytest.mark.asyncio

--- a/tests/test_kernel_defaults.py
+++ b/tests/test_kernel_defaults.py
@@ -6,6 +6,7 @@ loop, artifact tracking, and error handling without real LLM calls.
 """
 
 import json
+from unittest.mock import AsyncMock
 
 import pytest
 from jarviscore.kernel.defaults import CoderSubAgent, ResearcherSubAgent, CommunicatorSubAgent
@@ -62,6 +63,45 @@ class TestCoderSubAgent:
             "- Scoreboard\n- Provider Registry\n- Engineering Docs"
         )
         assert parsed["result"]["files"][0] == "Scoreboard"
+
+    def test_combined_done_result_terminates_with_the_structured_artifact(
+        self, mock_llm
+    ):
+        coder = CoderSubAgent(agent_id="c1", llm_client=mock_llm)
+        parsed = coder._parse_response(
+            'DONE/RESULT\n'
+            '{"status":"scheduled","title":"Discovery Call",'
+            '"execution_state":"executed","event_id":"event-1",'
+            '"attendees":["ephy@example.com"]}'
+        )
+
+        assert parsed["type"] == "done"
+        assert parsed["result"]["event_id"] == "event-1"
+        assert parsed["result"]["attendees"] == ["ephy@example.com"]
+
+    @pytest.mark.asyncio
+    async def test_budget_refusal_checkpoints_for_a_new_execution_epoch(self):
+        from jarviscore.orchestration.budget import WorkflowBudgetExceeded
+
+        class ExhaustedLLM:
+            async def generate(self, **kwargs):
+                raise WorkflowBudgetExceeded("epoch capacity exhausted")
+
+        memory = AsyncMock()
+        memory.load_checkpoint.return_value = None
+        coder = CoderSubAgent(agent_id="c1", llm_client=ExhaustedLLM())
+
+        result = await coder.run(
+            task="Continue durable work",
+            context={"workflow_id": "wf-long", "step_id": "step-1"},
+            max_turns=1,
+            memory=memory,
+        )
+
+        assert result.status == "epoch_exhausted"
+        assert result.metadata["typed_outcome"] == "CONTINUE_NEW_EXECUTION_EPOCH"
+        assert result.metadata["checkpointed"] is True
+        memory.save_checkpoint.assert_awaited_once()
 
     """Tests for CoderSubAgent."""
 

--- a/tests/test_kernel_hitl.py
+++ b/tests/test_kernel_hitl.py
@@ -65,11 +65,11 @@ class TestPolicyDisabled:
 
 class TestPolicyConfidence:
 
-    def test_low_confidence_triggers(self):
+    def test_low_confidence_never_triggers(self):
         policy = AdaptiveHITLPolicy(enabled=True, max_confidence=0.8)
         should, reason = policy.should_escalate(confidence=0.5)
-        assert should is True
-        assert "low_confidence" in reason
+        assert should is False
+        assert reason == ""
 
     def test_high_confidence_passes(self):
         policy = AdaptiveHITLPolicy(enabled=True, max_confidence=0.8)
@@ -85,11 +85,11 @@ class TestPolicyConfidence:
 
 class TestPolicyRiskScore:
 
-    def test_high_risk_triggers(self):
+    def test_untyped_high_risk_never_triggers(self):
         policy = AdaptiveHITLPolicy(enabled=True, min_risk_score=0.7)
         should, reason = policy.should_escalate(risk_score=0.9)
-        assert should is True
-        assert "high_risk" in reason
+        assert should is False
+        assert reason == ""
 
     def test_low_risk_passes(self):
         policy = AdaptiveHITLPolicy(enabled=True, min_risk_score=0.7)
@@ -105,25 +105,40 @@ class TestPolicyRiskScore:
 
 class TestPolicyReasonCodes:
 
-    def test_matching_reason_code_triggers(self):
+    def test_explicit_critical_action_triggers(self):
         policy = AdaptiveHITLPolicy(
-            enabled=True, reason_codes=["destructive_action", "external_api"]
+            enabled=True, reason_codes=["critical_action"]
         )
-        should, reason = policy.should_escalate(reason_code="destructive_action")
+        should, reason = policy.should_escalate(reason_code="critical_action")
         assert should is True
-        assert "reason_code:destructive_action" in reason
+        assert "category:critical_action" in reason
 
     def test_non_matching_reason_code_passes(self):
         policy = AdaptiveHITLPolicy(
-            enabled=True, reason_codes=["destructive_action"]
+            enabled=True, reason_codes=["critical_action"]
         )
         should, _ = policy.should_escalate(reason_code="safe_action")
         assert should is False
 
-    def test_empty_reason_codes_list(self):
+    def test_data_required_needs_exhaustion_and_human_exclusivity(self):
         policy = AdaptiveHITLPolicy(enabled=True, reason_codes=[])
-        should, _ = policy.should_escalate(reason_code="anything")
+        should, _ = policy.should_escalate(reason_code="data_required")
         assert should is False
+        should, reason = policy.should_escalate(
+            reason_code="data_required",
+            autonomous_paths_exhausted=True,
+            human_exclusive=True,
+        )
+        assert should is True
+        assert reason == "category:data_required"
+
+    def test_execution_failure_is_not_a_human_category(self):
+        policy = AdaptiveHITLPolicy(enabled=True)
+        should, reason = policy.should_escalate(
+            reason_code="execution_failure", confidence=0.1, risk_score=0.99
+        )
+        assert should is False
+        assert reason == ""
 
 
 class TestPolicyNoTriggers:

--- a/tests/test_llm_fallback.py
+++ b/tests/test_llm_fallback.py
@@ -10,6 +10,70 @@ from types import SimpleNamespace
 from unittest.mock import MagicMock, AsyncMock, patch
 import jarviscore.execution.llm as _llm_module
 from jarviscore.execution.llm import UnifiedLLMClient, LLMProvider
+from jarviscore.orchestration.budget import (
+    WorkflowBudgetExceeded,
+    workflow_budget_scope,
+)
+from jarviscore.testing import MockRedisContextStore
+
+
+def _budget_test_client(result):
+    llm = UnifiedLLMClient.__new__(UnifiedLLMClient)
+    llm.config = {"llm_default_max_tokens": 20}
+    llm._semaphore = None
+    llm._generate_inner = AsyncMock(return_value=result)
+    return llm
+
+
+@pytest.mark.asyncio
+async def test_generate_settles_exact_usage_into_the_workflow_budget():
+    store = MockRedisContextStore()
+    store.register_workflow_goal(
+        "wf-llm-budget",
+        "Bound every model call",
+        budget={"max_tokens": 1000},
+    )
+    llm = _budget_test_client({
+        "content": "done",
+        "tokens": {"input": 12, "output": 5, "total": 17},
+        "cost_usd": 0.004,
+    })
+
+    with workflow_budget_scope(store, "wf-llm-budget"):
+        result = await llm.generate(prompt="hello", max_tokens=20)
+
+    assert result["content"] == "done"
+    assert store.get_workflow_budget_usage("wf-llm-budget", "default") == {
+        "max_tokens_per_epoch": 1000,
+        "used_tokens": 17,
+        "cost_usd": 0.004,
+        "call_count": 1,
+        "epoch_count": 1,
+        "epoch_id": "default",
+        "epoch_used_tokens": 17,
+        "epoch_reserved_tokens": 0,
+    }
+
+
+@pytest.mark.asyncio
+async def test_generate_never_dispatches_without_global_capacity():
+    store = MockRedisContextStore()
+    store.register_workflow_goal(
+        "wf-llm-exhausted",
+        "Reject an unaffordable call",
+        budget={"max_tokens": 10},
+    )
+    llm = _budget_test_client({
+        "content": "must not run",
+        "tokens": {"input": 1, "output": 1, "total": 2},
+        "cost_usd": 0.001,
+    })
+
+    with workflow_budget_scope(store, "wf-llm-exhausted"):
+        with pytest.raises(WorkflowBudgetExceeded):
+            await llm.generate(prompt="this call cannot fit", max_tokens=20)
+
+    llm._generate_inner.assert_not_awaited()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_mesh_goal.py
+++ b/tests/test_mesh_goal.py
@@ -44,7 +44,7 @@ class AnalysisPeer(Agent):
 
     async def execute_task(self, task):
         self.received.append(task)
-        evidence = task["context"]["previous_step_results"]["research"]
+        evidence = next(iter(task["context"]["previous_step_results"].values()))
         return {
             "status": "success",
             "output": {"used": evidence},
@@ -110,6 +110,32 @@ class HoldingPeer(Agent):
                 "satisfied_requirements": [],
                 "unmet_requirements": ["Verified identity"],
                 "evidence_refs": [],
+            },
+        }
+
+
+class RemediatingPeer(Agent):
+    role = "remediating_peer"
+    capabilities = ["verification"]
+
+    def __init__(self, llm, agent_id=None):
+        super().__init__(agent_id)
+        self.llm = llm
+        self.received = []
+
+    async def execute_task(self, task):
+        self.received.append(task)
+        remediating = task["id"] == "verify_content"
+        return {
+            "status": "success",
+            "output": {"content_verified": remediating},
+            "interpretation": {
+                "verdict": "satisfied" if remediating else "partial",
+                "decision": "proceed" if remediating else "hold",
+                "meaning": "Content is verified." if remediating else "Content is unverified.",
+                "satisfied_requirements": ["o1"] if remediating else ["o0"],
+                "unmet_requirements": [] if remediating else ["o1"],
+                "evidence_refs": ["document-readback"] if remediating else [],
             },
         }
 
@@ -181,6 +207,22 @@ class ResponsePeer(Agent):
             "status": "success",
             "output": {"decision": "hold"},
             "result_summary": "Identity was not verified, so no external write was performed.",
+        }
+
+
+class FailingResponsePeer(ResponsePeer):
+    async def execute_task(self, task):
+        self.received.append(task)
+        return {"status": "failure", "error": "response synthesis failed"}
+
+
+class RevisionResponsePeer(ResponsePeer):
+    async def execute_task(self, task):
+        self.received.append(task)
+        return {
+            "status": "success",
+            "output": {"decision": "proceed"},
+            "result_summary": f"Response for revision {len(self.received)}.",
         }
 
 
@@ -402,15 +444,16 @@ async def test_waiting_goal_resumes_same_peer_and_unblocks_downstream(monkeypatc
 async def test_failed_goal_can_be_replanned_under_a_revision_lease(monkeypatch):
     amended_steps = [
         {
-            "step_id": "research", "capability": "research", "effect": "read",
+            "step_id": "research_v2", "capability": "research", "effect": "read",
             "task": "Retry evidence collection", "success_criterion": "Evidence exists",
             "expected_findings": ["evidence"], "depends_on": [], "covers": ["o1"],
         },
         {
-            "step_id": "analyse", "capability": "analysis", "effect": "read",
+            "step_id": "analyse_v2", "capability": "analysis", "effect": "read",
             "task": "Analyse the replacement evidence",
             "success_criterion": "Analysis uses evidence",
-            "expected_findings": ["analysis"], "depends_on": ["research"], "covers": ["o2"],
+            "expected_findings": ["analysis"], "depends_on": ["research_v2"],
+            "covers": ["o2"],
         },
     ]
     llm = MockLLMClient(responses=[
@@ -448,11 +491,94 @@ async def test_failed_goal_can_be_replanned_under_a_revision_lease(monkeypatch):
     assert store.get_workflow_definition("wf-replan")["revision"] == 2
     assert researcher.received[1]["task"] == "Retry evidence collection"
     assert analyst.received[0]["context"]["previous_step_results"] == {
-        "research": {"evidence": ["source-2"]},
+        "research_v2": {"evidence": ["source-2"]},
     }
     assert "dag_amended" in [
         event["event"] for event in store.get_ledger_full("wf-replan")
     ]
+
+
+@pytest.mark.asyncio
+async def test_execute_goal_reconciles_actionable_semantic_hold(monkeypatch):
+    initial_steps = [{
+        "step_id": "locate", "capability": "verification", "effect": "read",
+        "task": "Locate and verify usable content", "success_criterion": "Content is verified",
+        "expected_findings": ["content verification"], "depends_on": [],
+        "covers": ["o0", "o1"],
+    }]
+    amended_steps = [{
+        "step_id": "verify_content", "capability": "verification", "effect": "read",
+        "task": "Inspect the located resource and verify its content",
+        "success_criterion": "Content is verified by readback",
+        "expected_findings": ["content verification"], "depends_on": ["locate"],
+        "covers": ["o1"],
+    }]
+    llm = MockLLMClient(responses=[
+        {"content": json.dumps({"obligations": [{
+            "id": "o0", "description": "Locate the resource",
+            "source_quote": "Locate",
+        }, {
+            "id": "o1", "description": "Verify usable content",
+            "source_quote": "verify usable content",
+        }]})},
+        {"content": json.dumps({"steps": initial_steps})},
+        {"content": json.dumps({"complete": True, "missing": []})},
+        {"content": json.dumps({
+            "decision": "amend", "reason": "The available verification capability can inspect content.",
+        })},
+        {"content": json.dumps({"steps": amended_steps})},
+        {"content": json.dumps({"complete": True, "missing": []})},
+        {"content": json.dumps({
+            "decision": "settle_blocked", "reason": "The remaining fact needs human input.",
+        })},
+    ])
+    store = MockRedisContextStore()
+    monkeypatch.setattr(Mesh, "_init_redis", lambda self, settings: store)
+    monkeypatch.setattr(Mesh, "_init_blob_storage", lambda self, settings: None)
+    monkeypatch.setattr(Mesh, "_init_nexus", lambda self: None)
+    monkeypatch.setattr(Mesh, "_init_athena", lambda self, settings: None)
+    mesh = Mesh(config={
+        "p2p_enabled": False,
+        "distributed_poll_interval": 0.01,
+        "mesh_response_capability": "final_response",
+    })
+    peer = mesh.add(RemediatingPeer(llm, agent_id="verifier"))
+    responder = mesh.add(RevisionResponsePeer(agent_id="responder"))
+
+    await mesh.start()
+    try:
+        result = await mesh.execute_goal(
+            "Locate and verify usable content", workflow_id="wf-auto-reconcile", timeout=2,
+        )
+    finally:
+        await mesh.stop()
+
+    assert result["status"] == "completed"
+    assert result["obligation_status"] == "satisfied"
+    assert result["response_status"] == "completed"
+    assert result["result_summary"] == "Response for revision 2."
+    assert len(responder.received) == 2
+    assert result["revision"] == 2, (
+        store.get_workflow_planning_status("wf-auto-reconcile"),
+        [{
+            key: event.get(key)
+            for key in ("event", "decision", "reason", "error", "revision")
+            if event.get(key) is not None
+        } for event in store.get_ledger_full("wf-auto-reconcile")
+         if "reconcil" in str(event.get("event")) or event.get("event") == "dag_amended"],
+    )
+    assert [task["id"] for task in peer.received] == ["locate", "verify_content"]
+    assert store.get_step_status("wf-auto-reconcile", "locate") == "completed"
+    assert store.get_step_status("wf-auto-reconcile", "verify_content") == "completed"
+    projection = store.get_obligation_projection("wf-auto-reconcile")
+    assert projection["o0"]["current_step_ids"] == ["locate"]
+    assert projection["o0"]["superseded_step_ids"] == []
+    assert projection["o1"]["current_step_ids"] == ["verify_content"]
+    assert projection["o1"]["superseded_step_ids"] == ["locate"]
+    events = [event["event"] for event in store.get_ledger_full("wf-auto-reconcile")]
+    assert "semantic_reconciliation_requested" in events
+    assert "dag_amended" in events
+    assert "semantic_reconciliation_settled" in events
 
 
 @pytest.mark.asyncio
@@ -641,6 +767,50 @@ async def test_hold_blocks_multi_system_effects_but_final_response_still_runs(mo
         ("final_response", "final_response", []),
     ]
     assert all("agent" not in step and "atom" not in step for step in persisted["steps"])
+
+
+@pytest.mark.asyncio
+async def test_failed_final_response_does_not_erase_satisfied_obligations(monkeypatch):
+    store = MockRedisContextStore()
+    monkeypatch.setattr(Mesh, "_init_redis", lambda self, settings: store)
+    monkeypatch.setattr(Mesh, "_init_blob_storage", lambda self, settings: None)
+    monkeypatch.setattr(Mesh, "_init_nexus", lambda self: None)
+    monkeypatch.setattr(Mesh, "_init_athena", lambda self, settings: None)
+    mesh = Mesh(config={"p2p_enabled": False, "distributed_poll_interval": 0.01})
+    mesh.add(SubmitterPeer, agent_id="worker")
+    mesh.add(FailingResponsePeer, agent_id="responder")
+
+    await mesh.start()
+    store.publish_workflow(
+        "wf-response-failure",
+        goal="Submit work and report it",
+        obligations=[{
+            "id": "o1", "description": "Submit work", "source_quote": "Submit work",
+        }],
+        steps=[
+            {
+                "id": "submit", "capability": "submission", "effect": "write",
+                "systems": ["provider"], "task": "Submit work", "depends_on": [],
+                "covers": ["o1"],
+            },
+            {
+                "id": "respond", "capability": "final_response",
+                "effect": "final_response", "systems": [], "task": "Report outcome",
+                "depends_on": ["submit"], "covers": [],
+            },
+        ],
+    )
+    try:
+        result = await mesh.execute_goal(
+            "Submit work and report it", workflow_id="wf-response-failure", timeout=1,
+        )
+    finally:
+        await mesh.stop()
+
+    assert result["status"] == "failed"
+    assert result["obligation_status"] == "satisfied"
+    assert result["response_status"] == "failed"
+    assert result["result_summary"] == ""
 
 
 @pytest.mark.asyncio

--- a/tests/test_mesh_goal.py
+++ b/tests/test_mesh_goal.py
@@ -1,0 +1,818 @@
+import asyncio
+import json
+import time
+from typing import ClassVar
+
+import pytest
+
+from jarviscore import Agent, Mesh
+from jarviscore.testing import MockLLMClient, MockRedisContextStore
+
+
+class ResearchPeer(Agent):
+    role = "research_peer"
+    capabilities: ClassVar[list[str]] = ["research"]
+
+    def __init__(self, llm, agent_id=None):
+        super().__init__(agent_id)
+        self.llm = llm
+        self.received = []
+
+    async def execute_task(self, task):
+        self.received.append(task)
+        return {
+            "status": "success",
+            "output": {"evidence": ["source-1"]},
+            "interpretation": {
+                "verdict": "satisfied",
+                "meaning": "The required evidence was found.",
+                "decision": "proceed",
+                "satisfied_requirements": ["Evidence exists"],
+                "unmet_requirements": [],
+                "evidence_refs": ["source-1"],
+            },
+        }
+
+
+class AnalysisPeer(Agent):
+    role = "analysis_peer"
+    capabilities: ClassVar[list[str]] = ["analysis"]
+
+    def __init__(self, agent_id=None):
+        super().__init__(agent_id)
+        self.received = []
+
+    async def execute_task(self, task):
+        self.received.append(task)
+        evidence = task["context"]["previous_step_results"]["research"]
+        return {
+            "status": "success",
+            "output": {"used": evidence},
+            "result_summary": "The evidence was analysed successfully.",
+        }
+
+
+class FailingResearchPeer(ResearchPeer):
+    async def execute_task(self, task):
+        self.received.append(task)
+        return {"status": "failure", "error": "source unavailable"}
+
+
+class RecoveringResearchPeer(ResearchPeer):
+    async def execute_task(self, task):
+        self.received.append(task)
+        if len(self.received) == 1:
+            return {"status": "failure", "error": "source unavailable"}
+        return {"status": "success", "output": {"evidence": ["source-2"]}}
+
+
+class WaitingResearchPeer(ResearchPeer):
+    async def execute_task(self, task):
+        self.received.append(task)
+        if task.get("context", {}).get("_resume"):
+            return {"status": "success", "output": {"evidence": ["approved-source"]}}
+        return {"status": "waiting", "reason": "approval required"}
+
+
+class SubmitterPeer(Agent):
+    role = "submitter"
+    capabilities: ClassVar[list[str]] = ["submission"]
+
+    async def execute_task(self, task):
+        return {"status": "success", "output": "submitted"}
+
+
+class SlowPeer(Agent):
+    def __init__(self, role, capability, agent_id=None):
+        self.role = role
+        self.capabilities = [capability]
+        super().__init__(agent_id)
+        self.started = None
+
+    async def execute_task(self, task):
+        self.started = time.perf_counter()
+        await asyncio.sleep(0.1)
+        return {"status": "success", "output": self.role}
+
+
+class HoldingPeer(Agent):
+    role = "holding_peer"
+    capabilities = ["verification"]
+
+    async def execute_task(self, task):
+        return {
+            "status": "success",
+            "output": {"verified": False},
+            "interpretation": {
+                "verdict": "partial",
+                "decision": "hold",
+                "meaning": "The identity is not verified.",
+                "satisfied_requirements": [],
+                "unmet_requirements": ["Verified identity"],
+                "evidence_refs": [],
+            },
+        }
+
+
+class WritePeer(Agent):
+    role = "write_peer"
+    capabilities = ["external_write"]
+
+    def __init__(self, agent_id=None):
+        super().__init__(agent_id)
+        self.received = []
+
+    async def execute_task(self, task):
+        self.received.append(task)
+        return {"status": "success", "output": {"written": True}}
+
+
+class EdgeAwareWritePeer(WritePeer):
+    capabilities = ["edge_aware_write"]
+
+    def __init__(self, llm, agent_id=None):
+        super().__init__(agent_id)
+        self.llm = llm
+
+
+class PartialContactPeer(Agent):
+    role = "partial_contact"
+    capabilities = ["partial_contact"]
+
+    async def execute_task(self, task):
+        return {
+            "status": "success",
+            "output": {"email": "lead@example.com"},
+            "interpretation": {
+                "verdict": "partial",
+                "decision": "hold",
+                "meaning": "Contact is verified; duplicate cleanup remains.",
+                "satisfied_requirements": ["Verified contact"],
+                "unmet_requirements": ["Duplicate cleanup"],
+                "evidence_refs": ["contact-1"],
+            },
+        }
+
+
+class NotifyPeer(Agent):
+    role = "notify_peer"
+    capabilities = ["team_notification"]
+
+    def __init__(self, agent_id=None):
+        super().__init__(agent_id)
+        self.received = []
+
+    async def execute_task(self, task):
+        self.received.append(task)
+        return {"status": "success", "output": {"notified": True}}
+
+
+class ResponsePeer(Agent):
+    role = "response_peer"
+    capabilities = ["final_response"]
+
+    def __init__(self, agent_id=None):
+        super().__init__(agent_id)
+        self.received = []
+
+    async def execute_task(self, task):
+        self.received.append(task)
+        return {
+            "status": "success",
+            "output": {"decision": "hold"},
+            "result_summary": "Identity was not verified, so no external write was performed.",
+        }
+
+
+class CollateralPeer(Agent):
+    role = "collateral_peer"
+    capabilities = ["sales_collateral"]
+
+    async def execute_task(self, task):
+        return {
+            "status": "success",
+            "output": {"document_id": "deck-1", "status": "existing"},
+        }
+
+
+class NeedRequesterPeer(Agent):
+    role = "need_requester"
+    capabilities = ["coordination"]
+
+    async def execute_task(self, task):
+        return {"status": "success", "output": "requester"}
+
+
+class NeedResolverPeer(Agent):
+    role = "need_resolver"
+    capabilities = ["contact_verification"]
+    capability_contracts = {
+        "contact_verification": {
+            "effects": ["read"], "systems": ["gmail", "hubspot"],
+        },
+    }
+
+    def __init__(self, agent_id=None):
+        super().__init__(agent_id)
+        self.received = []
+
+    async def execute_task(self, task):
+        self.received.append(task)
+        return {
+            "status": "success",
+            "output": {"email": "ephy@example.com", "source": "connected systems"},
+        }
+
+
+def goal_responses():
+    return [
+        {"content": json.dumps({"obligations": [
+            {"id": "o1", "description": "Find evidence", "source_quote": "Find evidence"},
+            {"id": "o2", "description": "Analyse it", "source_quote": "analyse it"},
+        ]})},
+        {"content": json.dumps({"steps": [
+            {
+                "step_id": "research", "capability": "research", "effect": "read",
+                "task": "Find evidence", "success_criterion": "Evidence exists",
+                "expected_findings": ["evidence"], "depends_on": [], "covers": ["o1"],
+            },
+            {
+                "step_id": "analyse", "capability": "analysis", "effect": "read",
+                "task": "Analyse the evidence", "success_criterion": "Analysis uses evidence",
+                "expected_findings": ["analysis"], "depends_on": ["research"], "covers": ["o2"],
+            },
+        ]})},
+        {"content": json.dumps({"complete": True, "missing": []})},
+    ]
+
+
+@pytest.mark.asyncio
+async def test_execute_goal_compiles_publishes_and_peers_claim_by_capability(monkeypatch):
+    obligations = [
+            {"id": "o1", "description": "Find evidence", "source_quote": "Find evidence"},
+            {"id": "o2", "description": "Analyse it", "source_quote": "analyse it"},
+        ]
+    steps = [
+            {
+                "step_id": "research", "capability": "research", "effect": "read",
+                "task": "Find evidence", "success_criterion": "Evidence exists",
+                "expected_findings": ["evidence"], "depends_on": [], "covers": ["o1"],
+            },
+            {
+                "step_id": "analyse", "capability": "analysis", "effect": "read",
+                "task": "Analyse the evidence", "success_criterion": "Analysis uses evidence",
+                "expected_findings": ["analysis"], "depends_on": ["research"], "covers": ["o2"],
+            },
+        ]
+    llm = MockLLMClient(responses=[
+        {"content": json.dumps({"obligations": obligations})},
+        {"content": json.dumps({"steps": steps})},
+        {"content": json.dumps({"complete": True, "missing": []})},
+    ])
+    store = MockRedisContextStore()
+    monkeypatch.setattr(Mesh, "_init_redis", lambda self, settings: store)
+    monkeypatch.setattr(Mesh, "_init_blob_storage", lambda self, settings: None)
+    monkeypatch.setattr(Mesh, "_init_nexus", lambda self: None)
+    monkeypatch.setattr(Mesh, "_init_athena", lambda self, settings: None)
+    mesh = Mesh(config={"p2p_enabled": False, "distributed_poll_interval": 0.01})
+    researcher = mesh.add(ResearchPeer(llm, agent_id="researcher-1"))
+    analyst = mesh.add(AnalysisPeer(agent_id="analyst-1"))
+
+    await mesh.start()
+    try:
+        result = await mesh.execute_goal(
+            "Find evidence and analyse it",
+            workflow_id="wf-natural-goal",
+            context={
+                "source_context": {
+                    "trigger": "contact_form",
+                    "lead": {"email": "lead@example.com"},
+                },
+            },
+            timeout=2,
+        )
+    finally:
+        await mesh.stop()
+
+    assert result["status"] == "completed"
+    assert result["result_summary"] == "The evidence was analysed successfully."
+    assert [step["status"] for step in result["steps"]] == ["completed", "completed"]
+    assert researcher.received[0]["context"]["objective"] == "Find evidence and analyse it"
+    assert researcher.received[0]["context"]["source_context"]["lead"]["email"] == (
+        "lead@example.com"
+    )
+    assert analyst.received[0]["context"]["source_context"]["trigger"] == "contact_form"
+    assert analyst.received[0]["context"]["previous_step_results"] == {
+        "research": {"evidence": ["source-1"]},
+    }
+    assert analyst.received[0]["context"]["previous_step_interpretations"] == {
+        "research": {
+            "verdict": "satisfied",
+            "meaning": "The required evidence was found.",
+            "decision": "proceed",
+            "satisfied_requirements": ["Evidence exists"],
+            "unmet_requirements": [],
+            "evidence_refs": ["source-1"],
+        },
+    }
+    persisted = store.get_workflow_definition("wf-natural-goal")
+    assert [step["capability"] for step in persisted["steps"]] == ["research", "analysis"]
+    assert all("agent" not in step for step in persisted["steps"])
+    events = store.get_ledger_full("wf-natural-goal")
+    event_types = [event["event"] for event in events]
+    assert event_types.index("goal_registered") < event_types.index("dag_published")
+    assert event_types.count("step_claimed") == 2
+    assert event_types.count("step_completed") == 2
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("peer_class", "expected_status", "upstream_status"),
+    [
+        (FailingResearchPeer, "failed", "failed"),
+        (WaitingResearchPeer, "waiting", "waiting"),
+    ],
+)
+async def test_execute_goal_propagates_non_success_without_hanging(
+    monkeypatch, peer_class, expected_status, upstream_status
+):
+    llm = MockLLMClient(responses=goal_responses())
+    store = MockRedisContextStore()
+    monkeypatch.setattr(Mesh, "_init_redis", lambda self, settings: store)
+    monkeypatch.setattr(Mesh, "_init_blob_storage", lambda self, settings: None)
+    monkeypatch.setattr(Mesh, "_init_nexus", lambda self: None)
+    monkeypatch.setattr(Mesh, "_init_athena", lambda self, settings: None)
+    mesh = Mesh(config={"p2p_enabled": False, "distributed_poll_interval": 0.01})
+    mesh.add(peer_class(llm, agent_id="researcher-1"))
+    analyst = mesh.add(AnalysisPeer(agent_id="analyst-1"))
+
+    await mesh.start()
+    try:
+        result = await mesh.execute_goal(
+            "Find evidence and analyse it",
+            workflow_id=f"wf-{expected_status}",
+            timeout=1,
+        )
+    finally:
+        await mesh.stop()
+
+    assert result["status"] == expected_status
+    assert [step["status"] for step in result["steps"]] == [upstream_status, "blocked"]
+    assert analyst.received == []
+
+
+@pytest.mark.asyncio
+async def test_waiting_goal_resumes_same_peer_and_unblocks_downstream(monkeypatch):
+    llm = MockLLMClient(responses=goal_responses())
+    store = MockRedisContextStore()
+    monkeypatch.setattr(Mesh, "_init_redis", lambda self, settings: store)
+    monkeypatch.setattr(Mesh, "_init_blob_storage", lambda self, settings: None)
+    monkeypatch.setattr(Mesh, "_init_nexus", lambda self: None)
+    monkeypatch.setattr(Mesh, "_init_athena", lambda self, settings: None)
+    mesh = Mesh(config={"p2p_enabled": False, "distributed_poll_interval": 0.01})
+    waiting = mesh.add(WaitingResearchPeer(llm, agent_id="researcher-1"))
+    analyst = mesh.add(AnalysisPeer(agent_id="analyst-1"))
+
+    await mesh.start()
+    try:
+        first = await mesh.execute_goal(
+            "Find evidence and analyse it",
+            workflow_id="wf-resume",
+            timeout=1,
+        )
+        resumed = await mesh.resume_goal(
+            "wf-resume",
+            "research",
+            context={"human_response": "approved"},
+            timeout=1,
+        )
+    finally:
+        await mesh.stop()
+
+    assert first["status"] == "waiting"
+    assert resumed["status"] == "completed"
+    assert waiting.received[1]["context"]["_resume"] is True
+    assert waiting.received[1]["context"]["human_response"] == "approved"
+    assert analyst.received[0]["context"]["previous_step_results"] == {
+        "research": {"evidence": ["approved-source"]},
+    }
+
+
+@pytest.mark.asyncio
+async def test_failed_goal_can_be_replanned_under_a_revision_lease(monkeypatch):
+    amended_steps = [
+        {
+            "step_id": "research", "capability": "research", "effect": "read",
+            "task": "Retry evidence collection", "success_criterion": "Evidence exists",
+            "expected_findings": ["evidence"], "depends_on": [], "covers": ["o1"],
+        },
+        {
+            "step_id": "analyse", "capability": "analysis", "effect": "read",
+            "task": "Analyse the replacement evidence",
+            "success_criterion": "Analysis uses evidence",
+            "expected_findings": ["analysis"], "depends_on": ["research"], "covers": ["o2"],
+        },
+    ]
+    llm = MockLLMClient(responses=[
+        *goal_responses(),
+        {"content": json.dumps({"steps": amended_steps})},
+        {"content": json.dumps({"complete": True, "missing": []})},
+    ])
+    store = MockRedisContextStore()
+    monkeypatch.setattr(Mesh, "_init_redis", lambda self, settings: store)
+    monkeypatch.setattr(Mesh, "_init_blob_storage", lambda self, settings: None)
+    monkeypatch.setattr(Mesh, "_init_nexus", lambda self: None)
+    monkeypatch.setattr(Mesh, "_init_athena", lambda self, settings: None)
+    mesh = Mesh(config={"p2p_enabled": False, "distributed_poll_interval": 0.01})
+    researcher = mesh.add(RecoveringResearchPeer(llm, agent_id="researcher-1"))
+    analyst = mesh.add(AnalysisPeer(agent_id="analyst-1"))
+
+    await mesh.start()
+    try:
+        failed = await mesh.execute_goal(
+            "Find evidence and analyse it",
+            workflow_id="wf-replan",
+            timeout=1,
+        )
+        recovered = await mesh.replan_goal(
+            "wf-replan",
+            reason="The first source was unavailable",
+            timeout=1,
+        )
+    finally:
+        await mesh.stop()
+
+    assert failed["status"] == "failed"
+    assert recovered["status"] == "completed"
+    assert recovered["goal"] == "Find evidence and analyse it"
+    assert store.get_workflow_definition("wf-replan")["revision"] == 2
+    assert researcher.received[1]["task"] == "Retry evidence collection"
+    assert analyst.received[0]["context"]["previous_step_results"] == {
+        "research": {"evidence": ["source-2"]},
+    }
+    assert "dag_amended" in [
+        event["event"] for event in store.get_ledger_full("wf-replan")
+    ]
+
+
+@pytest.mark.asyncio
+async def test_execute_goal_surfaces_durable_planning_failure_without_timeout(monkeypatch):
+    llm = MockLLMClient(responses=[{"content": "not json"}])
+    store = MockRedisContextStore()
+    monkeypatch.setattr(Mesh, "_init_redis", lambda self, settings: store)
+    monkeypatch.setattr(Mesh, "_init_blob_storage", lambda self, settings: None)
+    monkeypatch.setattr(Mesh, "_init_nexus", lambda self: None)
+    monkeypatch.setattr(Mesh, "_init_athena", lambda self, settings: None)
+    mesh = Mesh(config={"p2p_enabled": False, "distributed_poll_interval": 0.01})
+    mesh.add(ResearchPeer(llm, agent_id="researcher-1"))
+
+    await mesh.start()
+    try:
+        with pytest.raises(RuntimeError, match="planning failed.*not valid JSON"):
+            await mesh.execute_goal(
+                "Find evidence",
+                workflow_id="wf-invalid-plan",
+                timeout=1,
+            )
+    finally:
+        await mesh.stop()
+
+    assert store.get_workflow_planning_status("wf-invalid-plan")["status"] == "failed"
+    assert "wf-invalid-plan" not in store.get_pending_workflow_goals()
+
+
+@pytest.mark.asyncio
+async def test_goal_submitter_need_not_be_the_node_that_compiles_or_executes(monkeypatch):
+    llm = MockLLMClient(responses=goal_responses())
+    store = MockRedisContextStore()
+    monkeypatch.setattr(Mesh, "_init_redis", lambda self, settings: store)
+    monkeypatch.setattr(Mesh, "_init_blob_storage", lambda self, settings: None)
+    monkeypatch.setattr(Mesh, "_init_nexus", lambda self: None)
+    monkeypatch.setattr(Mesh, "_init_athena", lambda self, settings: None)
+    config = {"p2p_enabled": False, "distributed_poll_interval": 0.01}
+    worker_mesh = Mesh(config=config)
+    worker_mesh.add(ResearchPeer(llm, agent_id="researcher-1"))
+    worker_mesh.add(AnalysisPeer(agent_id="analyst-1"))
+    submitter_mesh = Mesh(config=config)
+    submitter_mesh.add(SubmitterPeer, agent_id="submitter-1")
+
+    await worker_mesh.start()
+    await submitter_mesh.start()
+    try:
+        result = await submitter_mesh.execute_goal(
+            "Find evidence and analyse it",
+            workflow_id="wf-cross-node",
+            timeout=2,
+        )
+    finally:
+        await submitter_mesh.stop()
+        await worker_mesh.stop()
+
+    assert result["status"] == "completed"
+    assert store.get_workflow_planning_status("wf-cross-node")["status"] == "published"
+
+
+@pytest.mark.asyncio
+async def test_independent_mesh_steps_run_concurrently_on_separate_peers(monkeypatch):
+    steps = [
+        {"step_id": "left", "capability": "left_work", "effect": "read", "task": "Do left", "success_criterion": "Left done", "expected_findings": [], "depends_on": [], "covers": ["o1"]},
+        {"step_id": "right", "capability": "right_work", "effect": "read", "task": "Do right", "success_criterion": "Right done", "expected_findings": [], "depends_on": [], "covers": ["o2"]},
+    ]
+    llm = MockLLMClient(responses=[
+        {"content": json.dumps({"obligations": [
+            {"id": "o1", "description": "Do left", "source_quote": "Do left"},
+            {"id": "o2", "description": "Do right", "source_quote": "do right"},
+        ]})},
+        {"content": json.dumps({"steps": steps})},
+        {"content": json.dumps({"complete": True, "missing": []})},
+    ])
+    store = MockRedisContextStore()
+    monkeypatch.setattr(Mesh, "_init_redis", lambda self, settings: store)
+    monkeypatch.setattr(Mesh, "_init_blob_storage", lambda self, settings: None)
+    monkeypatch.setattr(Mesh, "_init_nexus", lambda self: None)
+    monkeypatch.setattr(Mesh, "_init_athena", lambda self, settings: None)
+    mesh = Mesh(config={"p2p_enabled": False, "distributed_poll_interval": 0.01})
+    planner = mesh.add(ResearchPeer(llm, agent_id="planner-peer"))
+    left = mesh.add(SlowPeer("left_peer", "left_work", "left-1"))
+    right = mesh.add(SlowPeer("right_peer", "right_work", "right-1"))
+
+    await mesh.start()
+    started = time.perf_counter()
+    try:
+        result = await mesh.execute_goal(
+            "Do left and do right",
+            workflow_id="wf-parallel-peers",
+            timeout=2,
+        )
+    finally:
+        await mesh.stop()
+
+    assert result["status"] == "completed"
+    assert left.started is not None and right.started is not None
+    assert abs(left.started - right.started) < 0.05
+    assert time.perf_counter() - started < 0.3
+    assert planner.received == []
+
+
+@pytest.mark.asyncio
+async def test_hold_blocks_multi_system_effects_but_final_response_still_runs(monkeypatch):
+    store = MockRedisContextStore()
+    monkeypatch.setattr(Mesh, "_init_redis", lambda self, settings: store)
+    monkeypatch.setattr(Mesh, "_init_blob_storage", lambda self, settings: None)
+    monkeypatch.setattr(Mesh, "_init_nexus", lambda self: None)
+    monkeypatch.setattr(Mesh, "_init_athena", lambda self, settings: None)
+    mesh = Mesh(config={"p2p_enabled": False, "distributed_poll_interval": 0.01})
+    mesh.add(HoldingPeer, agent_id="verifier")
+    mesh.add(CollateralPeer, agent_id="collateral")
+    writer = mesh.add(WritePeer, agent_id="writer")
+    notifier = mesh.add(NotifyPeer, agent_id="notifier")
+    responder = mesh.add(ResponsePeer, agent_id="responder")
+
+    await mesh.start()
+    store.publish_workflow(
+        "wf-hold-gate",
+        goal="Verify identity before writing",
+        obligations=[],
+        steps=[
+            {
+                "id": "verify", "capability": "verification", "effect": "read",
+                "systems": ["hubspot"], "task": "Verify identity", "depends_on": [],
+            },
+            {
+                "id": "collateral", "capability": "sales_collateral",
+                "effect": "read", "systems": ["google_drive"],
+                "task": "Find collateral", "depends_on": [],
+            },
+            {
+                "id": "write", "capability": "external_write", "effect": "write",
+                "systems": ["hubspot"], "task": "Perform write",
+                "depends_on": ["verify"],
+            },
+            {
+                "id": "notify", "capability": "team_notification", "effect": "notify",
+                "systems": ["slack"], "task": "Notify the team",
+                "depends_on": ["verify", "write"],
+            },
+            {
+                "id": "respond", "capability": "final_response",
+                "effect": "final_response", "task": "Explain outcome",
+                "depends_on": ["verify", "write", "notify"],
+            },
+        ],
+    )
+    try:
+        result = await mesh.execute_goal(
+            "Verify identity before writing", workflow_id="wf-hold-gate", timeout=1,
+        )
+    finally:
+        await mesh.stop()
+
+    assert result["status"] == "completed"
+    assert result["result_summary"] == (
+        "Identity was not verified, so no external write was performed."
+    )
+    assert store.get_step_status("wf-hold-gate", "write") == "blocked"
+    assert store.get_step_status("wf-hold-gate", "notify") == "blocked"
+    assert writer.received == []
+    assert notifier.received == []
+    assert len(responder.received) == 1
+    final_context = responder.received[0]["context"]
+    assert final_context["previous_step_results"]["collateral"] == {
+        "document_id": "deck-1", "status": "existing",
+    }
+    assert final_context["workflow_step_states"]["collateral"] == "completed"
+    assert final_context["workflow_step_states"]["write"] == "blocked"
+    assert final_context["workflow_evidence"]["artifacts"]["collateral"] == {
+        "document_id": "deck-1", "status": "existing",
+    }
+    assert final_context["workflow_evidence"]["states"]["write"] == "blocked"
+    assert responder.received[0]["context"]["previous_step_interpretations"]["verify"][
+        "decision"
+    ] == "hold"
+    persisted = store.get_workflow_definition("wf-hold-gate")
+    assert [
+        (step["capability"], step["effect"], step.get("systems", []))
+        for step in persisted["steps"]
+    ] == [
+        ("verification", "read", ["hubspot"]),
+        ("sales_collateral", "read", ["google_drive"]),
+        ("external_write", "write", ["hubspot"]),
+        ("team_notification", "notify", ["slack"]),
+        ("final_response", "final_response", []),
+    ]
+    assert all("agent" not in step and "atom" not in step for step in persisted["steps"])
+
+
+@pytest.mark.asyncio
+async def test_reasoning_recipient_authorizes_unrelated_partial_dependency(monkeypatch):
+    store = MockRedisContextStore()
+    monkeypatch.setattr(Mesh, "_init_redis", lambda self, settings: store)
+    monkeypatch.setattr(Mesh, "_init_blob_storage", lambda self, settings: None)
+    monkeypatch.setattr(Mesh, "_init_nexus", lambda self: None)
+    monkeypatch.setattr(Mesh, "_init_athena", lambda self, settings: None)
+    llm = MockLLMClient(responses=[{
+        "content": json.dumps({
+            "decision": "allow",
+            "reason": "Duplicate cleanup is unrelated to calendar scheduling.",
+        }),
+    }])
+    mesh = Mesh(config={"p2p_enabled": False, "distributed_poll_interval": 0.01})
+    mesh.add(PartialContactPeer, agent_id="partial-contact")
+    writer = mesh.add(EdgeAwareWritePeer(llm), agent_id="edge-writer")
+
+    await mesh.start()
+    store.publish_workflow(
+        "wf-edge-aware",
+        goal="Schedule from a verified contact",
+        obligations=[],
+        steps=[
+            {
+                "id": "verify", "capability": "partial_contact", "effect": "read",
+                "task": "Verify contact", "depends_on": [],
+            },
+            {
+                "id": "write", "capability": "edge_aware_write", "effect": "write",
+                "task": "Schedule using the verified contact", "depends_on": ["verify"],
+            },
+        ],
+    )
+    try:
+        result = await mesh.execute_goal(
+            "Schedule from a verified contact",
+            workflow_id="wf-edge-aware",
+            timeout=1,
+        )
+    finally:
+        await mesh.stop()
+
+    assert result["status"] == "completed"
+    assert len(writer.received) == 1
+
+
+@pytest.mark.asyncio
+async def test_reasoning_recipient_must_work_a_relevant_dependency_gap(monkeypatch):
+    store = MockRedisContextStore()
+    monkeypatch.setattr(Mesh, "_init_redis", lambda self, settings: store)
+    monkeypatch.setattr(Mesh, "_init_blob_storage", lambda self, settings: None)
+    monkeypatch.setattr(Mesh, "_init_nexus", lambda self: None)
+    monkeypatch.setattr(Mesh, "_init_athena", lambda self, settings: None)
+    llm = MockLLMClient(responses=[{
+        "content": json.dumps({
+            "decision": "block",
+            "reason": "A required detail is unresolved; attempt resolution.",
+        }),
+    }])
+    mesh = Mesh(config={"p2p_enabled": False, "distributed_poll_interval": 0.01})
+    mesh.add(PartialContactPeer, agent_id="partial-contact")
+    writer = mesh.add(EdgeAwareWritePeer(llm), agent_id="edge-writer")
+    await mesh.start()
+    store.publish_workflow(
+        "wf-edge-gap",
+        goal="Resolve then act",
+        obligations=[],
+        steps=[
+            {
+                "id": "verify", "capability": "partial_contact", "effect": "read",
+                "task": "Verify contact", "depends_on": [],
+            },
+            {
+                "id": "write", "capability": "edge_aware_write", "effect": "write",
+                "task": "Resolve remaining detail and act", "depends_on": ["verify"],
+            },
+        ],
+    )
+    try:
+        result = await mesh.execute_goal(
+            "Resolve then act", workflow_id="wf-edge-gap", timeout=1
+        )
+    finally:
+        await mesh.stop()
+
+    assert result["status"] == "completed"
+    assert len(writer.received) == 1
+    assert writer.received[0]["context"]["dependency_authorization"] == {
+        "decision": "block",
+        "reason": "A required detail is unresolved; attempt resolution.",
+    }
+
+
+@pytest.mark.asyncio
+async def test_capability_need_is_claimed_fulfilled_and_returned_to_requester(monkeypatch):
+    store = MockRedisContextStore()
+    monkeypatch.setattr(Mesh, "_init_redis", lambda self, settings: store)
+    monkeypatch.setattr(Mesh, "_init_blob_storage", lambda self, settings: None)
+    monkeypatch.setattr(Mesh, "_init_nexus", lambda self: None)
+    monkeypatch.setattr(Mesh, "_init_athena", lambda self, settings: None)
+    mesh = Mesh(config={"p2p_enabled": False, "distributed_poll_interval": 0.01})
+    requester = mesh.add(NeedRequesterPeer, agent_id="requester-1")
+    resolver = mesh.add(NeedResolverPeer, agent_id="resolver-1")
+
+    await mesh.start()
+    try:
+        response = await asyncio.wait_for(
+            requester.peers.as_tool().execute(
+                "ask_capability",
+                {
+                    "capability": "contact_verification",
+                    "question": "Resolve Ephy Kizito's contact path.",
+                    "timeout": 2,
+                },
+                context={
+                    "workflow_id": "wf-capability-need",
+                    "objective": "Prepare the customer meeting",
+                    "peer_requester_step_id": "schedule",
+                },
+            ),
+            timeout=3,
+        )
+    finally:
+        await mesh.stop()
+
+    assert "ephy@example.com" in response
+    assert len(resolver.received) == 1
+    resolver_context = resolver.received[0]["context"]
+    assert resolver_context["capability"] == "contact_verification"
+    assert resolver_context["effect"] == "read"
+    assert resolver_context["systems"] == ["gmail", "hubspot"]
+    events = [item["event"] for item in store.get_ledger_tail("wf-capability-need")]
+    assert events == [
+        "capability_need_published",
+        "capability_need_claimed",
+        "capability_need_fulfilled",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_cancelling_execute_goal_tombstones_shared_workflow(monkeypatch):
+    store = MockRedisContextStore()
+    monkeypatch.setattr(Mesh, "_init_redis", lambda self, settings: store)
+    monkeypatch.setattr(Mesh, "_init_blob_storage", lambda self, settings: None)
+    monkeypatch.setattr(Mesh, "_init_nexus", lambda self: None)
+    monkeypatch.setattr(Mesh, "_init_athena", lambda self, settings: None)
+    mesh = Mesh(config={"p2p_enabled": False, "distributed_poll_interval": 0.01})
+    mesh.add(SubmitterPeer, agent_id="submitter")
+
+    await mesh.start()
+    store.publish_workflow(
+        "wf-cancel-goal",
+        goal="Wait for unavailable work",
+        obligations=[],
+        steps=[{
+            "id": "unavailable", "capability": "missing", "effect": "write",
+            "task": "Never claimed", "depends_on": [],
+        }],
+    )
+    task = asyncio.create_task(mesh.execute_goal(
+        "Wait for unavailable work", workflow_id="wf-cancel-goal", timeout=5,
+    ))
+    await asyncio.sleep(0.03)
+    task.cancel()
+    try:
+        with pytest.raises(asyncio.CancelledError):
+            await task
+    finally:
+        await mesh.stop()
+
+    assert store.is_workflow_cancelled("wf-cancel-goal") is True
+    assert store.get_step_status("wf-cancel-goal", "unavailable") == "cancelled"
+    assert "wf-cancel-goal" not in store.get_active_workflows()

--- a/tests/test_mesh_planning.py
+++ b/tests/test_mesh_planning.py
@@ -1,0 +1,333 @@
+import json
+
+import pytest
+
+from jarviscore.planning.mesh_planner import MeshPlanError, MeshPlanner
+from jarviscore.testing import MockLLMClient
+
+
+def responses(*, obligations=None, steps=None, audit=None):
+    obligations = obligations or [{
+            "id": "o1",
+            "description": "Find evidence",
+            "source_quote": "Find evidence",
+        }]
+    steps = steps or [{
+            "step_id": "research",
+            "capability": "research",
+        "effect": "read",
+            "systems": [],
+            "task": "Find evidence and cite it",
+            "success_criterion": "At least one source is cited",
+            "expected_findings": ["evidence"],
+            "depends_on": [],
+            "covers": ["o1"],
+        }]
+    return [
+        {"content": json.dumps({"obligations": obligations})},
+        {"content": json.dumps({"steps": steps})},
+        {"content": json.dumps(audit or {"complete": True, "missing": []})},
+    ]
+
+
+@pytest.mark.asyncio
+async def test_mesh_planner_builds_capability_dag_with_complete_obligation_coverage():
+    llm = MockLLMClient(responses=responses())
+    planner = MeshPlanner(llm, capabilities={"research": "Research evidence"})
+
+    plan = await planner.plan("Find evidence")
+
+    assert plan.goal == "Find evidence"
+    assert plan.steps[0].capability == "research"
+    assert plan.steps[0].effect == "read"
+    assert plan.steps[0].covers == ["o1"]
+    assert "agent" not in plan.steps[0].to_dict()
+    obligation_prompt = llm.calls[0]["messages"][0]["content"]
+    dag_prompt = llm.calls[1]["messages"][0]["content"]
+    audit_prompt = llm.calls[2]["messages"][0]["content"]
+    assert "LIVE CAPABILITY CATALOG" not in obligation_prompt
+    assert "research" in dag_prompt
+    assert "agent ID" in dag_prompt
+    assert "inspect-or-create" in dag_prompt
+    assert "one provider-owned outcome" in dag_prompt
+    assert "information required to execute each effectful outcome" in dag_prompt
+    assert "naming an entity does not supply its provider identifiers" in dag_prompt
+    assert "source goal or an ancestor step" in audit_prompt
+    assert all("json" in prompt for prompt in (obligation_prompt, dag_prompt, audit_prompt))
+
+
+@pytest.mark.asyncio
+async def test_mesh_planner_adds_configured_user_response_as_the_terminal_step():
+    llm = MockLLMClient(responses=responses())
+    planner = MeshPlanner(
+        llm,
+        capabilities={
+            "research": "Research evidence",
+            "action_briefing": "Produce the user-facing decision",
+        },
+        response_capability="action_briefing",
+    )
+
+    plan = await planner.plan("Find evidence")
+
+    assert [step.step_id for step in plan.steps] == ["research", "final_response"]
+    response_step = plan.steps[-1]
+    assert response_step.capability == "action_briefing"
+    assert response_step.depends_on == ["research"]
+    assert response_step.covers == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("steps", "error"),
+    [
+        ([{
+            "step_id": "research", "capability": "unknown", "effect": "read",
+            "task": "Find evidence",
+            "success_criterion": "Found", "expected_findings": [], "depends_on": [],
+            "covers": ["o1"],
+        }], "unknown capability"),
+        ([{
+            "step_id": "research", "capability": "research", "effect": "read",
+            "task": "Find evidence",
+            "success_criterion": "Found", "expected_findings": [], "depends_on": [],
+            "covers": [],
+        }], "uncovered obligation"),
+        ([
+            {"step_id": "a", "capability": "research", "effect": "read", "task": "A", "success_criterion": "A", "expected_findings": [], "depends_on": ["b"], "covers": ["o1"]},
+            {"step_id": "b", "capability": "research", "effect": "read", "task": "B", "success_criterion": "B", "expected_findings": [], "depends_on": ["a"], "covers": []},
+        ], "cycle"),
+    ],
+)
+async def test_mesh_planner_rejects_unexecutable_or_lossy_dags(steps, error):
+    llm = MockLLMClient(responses=responses(steps=steps))
+    planner = MeshPlanner(llm, capabilities={"research": "Research evidence"})
+
+    with pytest.raises(MeshPlanError, match=error):
+        await planner.plan("Find evidence")
+
+
+@pytest.mark.asyncio
+async def test_mesh_planner_requires_each_obligation_quote_to_exist_in_source_goal():
+    llm = MockLLMClient(responses=responses(obligations=[{
+        "id": "o1", "description": "Invented requirement", "source_quote": "send an email",
+    }]))
+    planner = MeshPlanner(llm, capabilities={"research": "Research evidence"})
+
+    with pytest.raises(MeshPlanError, match="source_quote"):
+        await planner.plan("Find evidence")
+
+
+@pytest.mark.asyncio
+async def test_mesh_planner_repairs_invalid_obligation_quotes_before_dag_compilation():
+    invalid = {
+        "content": json.dumps({"obligations": [{
+            "id": "o1", "description": "Find evidence",
+            "source_quote": "Find the evidence",
+        }]})
+    }
+    repaired = {
+        "content": json.dumps({"obligations": [{
+            "id": "o1", "description": "Find evidence",
+            "source_quote": "Find evidence",
+        }]})
+    }
+    valid = responses()
+    llm = MockLLMClient(responses=[invalid, repaired, valid[1], valid[2]])
+    planner = MeshPlanner(llm, capabilities={"research": "Research evidence"})
+
+    plan = await planner.plan("Find evidence")
+
+    assert plan.obligations[0].source_quote == "Find evidence"
+    repair_prompt = llm.calls[1]["messages"][0]["content"]
+    assert "Find the evidence" in repair_prompt
+    assert "not present in the source goal" in repair_prompt
+    assert "Do not add, remove, merge or split obligations" in repair_prompt
+
+
+@pytest.mark.asyncio
+async def test_mesh_planner_rejects_a_dag_when_independent_audit_finds_an_omission():
+    llm = MockLLMClient(responses=responses(audit={
+        "complete": False,
+        "missing": [{"description": "Preserve approval boundary", "source_quote": "Find evidence"}],
+    }))
+    planner = MeshPlanner(llm, capabilities={"research": "Research evidence"})
+
+    with pytest.raises(MeshPlanError, match="coverage audit"):
+        await planner.plan("Find evidence")
+
+
+@pytest.mark.asyncio
+async def test_mesh_planner_repairs_one_failed_coverage_audit_before_publication():
+    initial_steps = responses()[1]
+    audit_failure = {
+        "content": json.dumps({
+            "complete": False,
+            "missing": [{
+                "description": "The evidence path is incomplete",
+                "source_quote": "Find evidence",
+            }],
+        }),
+    }
+    repaired_steps = responses(steps=[{
+        "step_id": "research",
+        "capability": "research",
+        "effect": "read",
+        "systems": [],
+        "task": "Find and cite the requested evidence",
+        "success_criterion": "The requested evidence is cited",
+        "expected_findings": ["cited evidence"],
+        "depends_on": [],
+        "covers": ["o1"],
+    }])[1]
+    llm = MockLLMClient(responses=[
+        responses()[0], initial_steps, audit_failure, repaired_steps,
+        {"content": json.dumps({"complete": True, "missing": []})},
+    ])
+    planner = MeshPlanner(llm, capabilities={"research": "Research evidence"})
+
+    plan = await planner.plan("Find evidence")
+
+    assert plan.steps[0].task == "Find and cite the requested evidence"
+    assert len(llm.calls) == 5
+    repair_prompt = llm.calls[3]["messages"][0]["content"]
+    assert "The evidence path is incomplete" in repair_prompt
+    assert "Find evidence" in repair_prompt
+
+
+@pytest.mark.asyncio
+async def test_mesh_planner_can_converge_on_second_bounded_audit_repair():
+    valid = responses()
+    missing = {
+        "content": json.dumps({
+            "complete": False,
+            "missing": [{
+                "description": "Provider identifier is unresolved",
+                "source_quote": "Find evidence",
+            }],
+        }),
+    }
+    repaired_once = responses(steps=[{
+        "step_id": "research", "capability": "research", "effect": "read",
+        "systems": [], "task": "Find evidence", "success_criterion": "Found",
+        "expected_findings": ["evidence"], "depends_on": [], "covers": ["o1"],
+    }])[1]
+    repaired_twice = responses(steps=[{
+        "step_id": "research", "capability": "research", "effect": "read",
+        "systems": [], "task": "Resolve and return the source identifier",
+        "success_criterion": "Concrete source identifier returned",
+        "expected_findings": ["source identifier"], "depends_on": [], "covers": ["o1"],
+    }])[1]
+    llm = MockLLMClient(responses=[
+        valid[0], valid[1], missing, repaired_once, missing, repaired_twice,
+        {"content": json.dumps({"complete": True, "missing": []})},
+    ])
+    planner = MeshPlanner(llm, capabilities={"research": "Research evidence"})
+
+    plan = await planner.plan("Find evidence")
+
+    assert plan.steps[0].task == "Resolve and return the source identifier"
+    assert len(llm.calls) == 7
+
+
+@pytest.mark.asyncio
+async def test_mesh_planner_treats_one_expected_finding_as_one_finding():
+    llm = MockLLMClient(responses=responses(steps=[{
+        "step_id": "research",
+        "capability": "research",
+        "effect": "read",
+        "systems": [],
+        "task": "Find evidence",
+        "success_criterion": "Evidence found",
+        "expected_findings": "one evidence summary",
+        "depends_on": [],
+        "covers": ["o1"],
+    }]))
+    planner = MeshPlanner(llm, capabilities={"research": "Research evidence"})
+
+    plan = await planner.plan("Find evidence")
+
+    assert plan.steps[0].expected_findings == ["one evidence summary"]
+
+
+@pytest.mark.asyncio
+async def test_mesh_planner_requires_an_explicit_valid_effect_for_every_step():
+    missing_effect = responses(steps=[{
+        "step_id": "research", "capability": "research", "task": "Find evidence",
+        "success_criterion": "Found", "expected_findings": [], "depends_on": [],
+        "covers": ["o1"],
+    }])
+    planner = MeshPlanner(
+        MockLLMClient(responses=missing_effect),
+        capabilities={"research": "Research evidence"},
+    )
+    with pytest.raises(MeshPlanError, match="valid effect"):
+        await planner.plan("Find evidence")
+
+
+@pytest.mark.asyncio
+async def test_mesh_planner_rejects_effect_outside_capability_authority():
+    planner = MeshPlanner(
+        MockLLMClient(responses=responses(steps=[{
+            "step_id": "research", "capability": "research", "effect": "write",
+            "systems": ["public_web"],
+            "task": "Create a record", "success_criterion": "Record created",
+            "expected_findings": [], "depends_on": [], "covers": ["o1"],
+        }])),
+        capabilities={
+            "research": {
+                "description": "Read evidence",
+                "effects": ["read"],
+                "systems": ["public_web"],
+            },
+        },
+    )
+
+    with pytest.raises(MeshPlanError, match="does not authorize effect 'write'"):
+        await planner.plan("Find evidence")
+
+
+@pytest.mark.asyncio
+async def test_mesh_planner_rejects_system_outside_capability_authority():
+    planner = MeshPlanner(
+        MockLLMClient(responses=responses(steps=[{
+            "step_id": "research", "capability": "research", "effect": "read",
+            "systems": ["slack"], "task": "Read Slack", "success_criterion": "Read",
+            "expected_findings": [], "depends_on": [], "covers": ["o1"],
+        }])),
+        capabilities={
+            "research": {
+                "description": "Read public evidence",
+                "effects": ["read"],
+                "systems": ["public_web"],
+            },
+        },
+    )
+
+    with pytest.raises(MeshPlanError, match="does not authorize systems.*slack"):
+        await planner.plan("Find evidence")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("systems", [[], ["hubspot", "slack"]])
+async def test_mesh_planner_requires_one_provider_for_mutating_outcomes(systems):
+    planner = MeshPlanner(
+        MockLLMClient(responses=responses(steps=[{
+            "step_id": "manage_deal", "capability": "deal_management",
+            "effect": "write", "systems": systems,
+            "task": "Establish the lead's deal and current stage",
+            "success_criterion": "A verified deal and stage exist",
+            "expected_findings": ["deal identity", "deal stage"],
+            "depends_on": [], "covers": ["o1"],
+        }])),
+        capabilities={
+            "deal_management": {
+                "description": "Establish CRM deal state",
+                "effects": ["read", "write"],
+                "systems": ["hubspot", "slack"],
+            },
+        },
+    )
+
+    with pytest.raises(MeshPlanError, match="exactly one system"):
+        await planner.plan("Find evidence")

--- a/tests/test_mesh_planning.py
+++ b/tests/test_mesh_planning.py
@@ -2,7 +2,13 @@ import json
 
 import pytest
 
-from jarviscore.planning.mesh_planner import MeshPlanError, MeshPlanner
+from jarviscore.planning.mesh_planner import (
+    GoalObligation,
+    MeshPlan,
+    MeshPlanError,
+    MeshPlannedStep,
+    MeshPlanner,
+)
 from jarviscore.testing import MockLLMClient
 
 
@@ -52,8 +58,60 @@ async def test_mesh_planner_builds_capability_dag_with_complete_obligation_cover
     assert "one provider-owned outcome" in dag_prompt
     assert "information required to execute each effectful outcome" in dag_prompt
     assert "naming an entity does not supply its provider identifiers" in dag_prompt
+    assert "provider-readback evidence of usable content" in dag_prompt
+    assert "umbrella obligation" in obligation_prompt
     assert "source goal or an ancestor step" in audit_prompt
+    assert "independently verifiable success criterion" in audit_prompt
+    assert "Resource existence, title, identifier, link or MIME type" in audit_prompt
     assert all("json" in prompt for prompt in (obligation_prompt, dag_prompt, audit_prompt))
+
+
+@pytest.mark.asyncio
+async def test_mesh_planner_audit_removes_redundant_umbrella_obligation():
+    goal = "Execute the launch playbook: find the account and draft the email."
+    initial_obligations = [
+        {
+            "id": "umbrella", "description": "Execute the launch playbook",
+            "source_quote": "Execute the launch playbook",
+        },
+        {
+            "id": "find", "description": "Find the account",
+            "source_quote": "find the account",
+        },
+        {
+            "id": "draft", "description": "Draft the email",
+            "source_quote": "draft the email",
+        },
+    ]
+    initial_step = {
+        "step_id": "work", "capability": "work", "effect": "read", "systems": [],
+        "task": "Execute the playbook", "success_criterion": "Everything completed",
+        "expected_findings": [], "depends_on": [],
+        "covers": ["umbrella", "find", "draft"],
+    }
+    corrected_obligations = initial_obligations[1:]
+    corrected_step = {
+        **initial_step,
+        "task": "Find the account and draft the email",
+        "covers": ["find", "draft"],
+    }
+    llm = MockLLMClient(responses=[
+        {"content": json.dumps({"obligations": initial_obligations})},
+        {"content": json.dumps({"steps": [initial_step]})},
+        {"content": json.dumps({
+            "complete": False,
+            "missing": ["The umbrella duplicates the concrete outcomes."],
+            "obligations": corrected_obligations,
+        })},
+        {"content": json.dumps({"steps": [corrected_step]})},
+        {"content": json.dumps({"complete": True, "missing": []})},
+    ])
+    planner = MeshPlanner(llm, capabilities={"work": "Perform launch work"})
+
+    plan = await planner.plan(goal)
+
+    assert [item.id for item in plan.obligations] == ["find", "draft"]
+    assert plan.steps[0].covers == ["find", "draft"]
 
 
 @pytest.mark.asyncio
@@ -231,6 +289,262 @@ async def test_mesh_planner_can_converge_on_second_bounded_audit_repair():
 
 
 @pytest.mark.asyncio
+async def test_mesh_amendment_repairs_reused_completed_ids_to_a_delta():
+    obligations = [{
+        "id": "o1", "description": "Verify evidence", "source_quote": "Verify evidence",
+    }]
+    completed_response = {
+        "id": "final_response", "capability": "briefing", "effect": "final_response",
+        "systems": [], "task": "Report the first outcome", "success_criterion": "Reported",
+        "expected_findings": [], "depends_on": ["verify"], "covers": [],
+        "status": "completed", "output": {"result_summary": "First response"},
+        "claim_id": "responder:claim", "completed_by": "responder",
+    }
+    verify = {
+        "id": "verify", "capability": "verification", "effect": "read",
+        "systems": [], "task": "Verify evidence", "success_criterion": "Verified",
+        "expected_findings": [], "depends_on": [], "covers": ["o1"],
+        "status": "completed", "output": {"interpretation": {"decision": "hold"}},
+    }
+    rejected = [
+        {key: value for key, value in verify.items() if key not in {"status", "output"}},
+        {
+            **{key: value for key, value in completed_response.items()
+               if key not in {"status", "output", "claim_id", "completed_by"}},
+            "depends_on": ["verify", "verify_content"],
+        },
+        {
+            "id": "verify_content", "capability": "verification", "effect": "read",
+            "systems": [], "task": "Verify content", "success_criterion": "Verified",
+            "expected_findings": [], "depends_on": ["verify"], "covers": ["o1"],
+        },
+    ]
+    repaired = [rejected[-1]]
+    llm = MockLLMClient(responses=[
+        {"content": json.dumps({"steps": rejected})},
+        {"content": json.dumps({"steps": repaired})},
+        {"content": json.dumps({"complete": True, "missing": []})},
+    ])
+    planner = MeshPlanner(
+        llm,
+        capabilities={
+            "verification": {"description": "Verify", "effects": ["read"], "systems": []},
+            "briefing": {
+                "description": "Report", "effects": ["final_response"], "systems": [],
+            },
+        },
+        response_capability="briefing",
+    )
+
+    plan = await planner.amend(
+        "Verify evidence", obligations=obligations,
+        current_steps=[verify, completed_response], reason="Content remains unverified",
+        revision=1,
+    )
+
+    assert [step.step_id for step in plan.steps] == [
+        "verify_content", "final_response_2",
+    ]
+    assert "CURRENT STEP DEFINITIONS" in llm.calls[1]["messages"][0]["content"]
+    assert "already exists" in llm.calls[1]["messages"][0]["content"]
+    assert "claim_id" not in llm.calls[1]["messages"][0]["content"]
+
+
+@pytest.mark.asyncio
+async def test_mesh_amendment_repairs_unknown_capability_before_audit():
+    obligations = [{
+        "id": "o1", "description": "Verify evidence", "source_quote": "Verify evidence",
+    }]
+    valid_step = {
+        "id": "verify", "capability": "verification", "effect": "read",
+        "systems": [], "task": "Verify evidence", "success_criterion": "Verified",
+        "expected_findings": [], "depends_on": [], "covers": ["o1"],
+    }
+    llm = MockLLMClient(responses=[
+        {"content": json.dumps({"steps": [{
+            **valid_step, "capability": "invented_reconciliation",
+        }]})},
+        {"content": json.dumps({"steps": [valid_step]})},
+        {"content": json.dumps({"complete": True, "missing": []})},
+    ])
+    planner = MeshPlanner(
+        llm,
+        capabilities={
+            "verification": {"description": "Verify", "effects": ["read"], "systems": []},
+        },
+    )
+
+    plan = await planner.amend(
+        "Verify evidence", obligations=obligations, current_steps=[],
+        reason="A new verification path is available", revision=1,
+    )
+
+    assert plan.steps[0].capability == "verification"
+    repair_prompt = llm.calls[1]["messages"][0]["content"]
+    assert "unknown capability" in repair_prompt
+    assert "invented_reconciliation" in repair_prompt
+
+
+def test_amendment_audit_distinguishes_attempt_completion_from_effect_execution():
+    plan = MeshPlan(
+        goal="Draft an invitation",
+        obligations=[GoalObligation("o1", "Draft invitation", "Draft an invitation")],
+        steps=[MeshPlannedStep(
+            step_id="draft_retry", capability="email", effect="write",
+            systems=["gmail"], task="Create the draft", success_criterion="Draft exists",
+            depends_on=["draft_first"], covers=["o1"],
+        )],
+        revision=2,
+    )
+    prompt = MeshPlanner._amendment_audit_prompt(
+        plan,
+        current_steps=[{
+            "id": "draft_first", "capability": "email", "effect": "write",
+            "systems": ["gmail"], "task": "Create the draft",
+            "success_criterion": "Draft exists", "expected_findings": [],
+            "depends_on": [], "covers": ["o1"], "status": "completed",
+            "semantic_decision": "reject",
+            "output": {"output": {"status": "blocked", "execution_state": "not_executed"}},
+        }],
+        reason="The first attempt did not execute",
+    )
+
+    assert '"execution_state": "not_executed"' in prompt
+    assert "attempt ended; it does not prove its provider" in prompt
+    assert "must not repeat an already executed" in prompt
+    assert "may advance only the blocked obligations named" in prompt
+
+
+@pytest.mark.asyncio
+async def test_reconciliation_can_only_settle_an_existing_gap_as_blocked():
+    planner = MeshPlanner(
+        MockLLMClient(responses=[{"content": json.dumps({
+            "decision": "settle_blocked", "reason": "A human-only fact is missing.",
+        })}]),
+        capabilities={"verification": "Verify evidence"},
+    )
+    decision = await planner.reconciliation_decision(
+        "Verify evidence", obligations=[], current_steps=[], revision=1,
+    )
+    assert decision["decision"] == "settle_blocked"
+
+    ambiguous = MeshPlanner(
+        MockLLMClient(responses=[{"content": json.dumps({
+            "decision": "settle", "reason": "Everything is satisfied.",
+        })}]),
+        capabilities={"verification": "Verify evidence"},
+    )
+    with pytest.raises(MeshPlanError, match="settle_blocked"):
+        await ambiguous.reconciliation_decision(
+            "Verify evidence", obligations=[], current_steps=[], revision=1,
+        )
+
+
+@pytest.mark.asyncio
+async def test_mesh_amendment_uses_second_repair_after_invalid_first_repair():
+    obligations = [{
+        "id": "o1", "description": "Verify evidence", "source_quote": "Verify evidence",
+    }]
+    valid_step = {
+        "id": "verify", "capability": "verification", "effect": "read",
+        "systems": [], "task": "Verify evidence", "success_criterion": "Verified",
+        "expected_findings": [], "depends_on": [], "covers": ["o1"],
+    }
+    llm = MockLLMClient(responses=[
+        {"content": json.dumps({"steps": [valid_step]})},
+        {"content": json.dumps({"complete": False, "missing": ["Needs repair"]})},
+        {"content": json.dumps({"steps": [{**valid_step, "effect": "invented"}]})},
+        {"content": json.dumps({"steps": [valid_step]})},
+        {"content": json.dumps({"complete": True, "missing": []})},
+    ])
+    planner = MeshPlanner(
+        llm,
+        capabilities={
+            "verification": {"description": "Verify", "effects": ["read"], "systems": []},
+        },
+    )
+
+    plan = await planner.amend(
+        "Verify evidence", obligations=obligations, current_steps=[],
+        reason="A new verification path is available", revision=1,
+    )
+
+    assert plan.steps[0].effect == "read"
+    assert "Repair draft failed validation" in llm.calls[3]["messages"][0]["content"]
+
+
+@pytest.mark.asyncio
+async def test_mesh_amendment_returns_only_new_work():
+    obligations = [{
+        "id": "o1", "description": "Verify evidence", "source_quote": "Verify evidence",
+    }]
+    completed = {
+        "id": "verify_first", "capability": "verification", "effect": "read",
+        "systems": [], "task": "First verification", "success_criterion": "Attempted",
+        "expected_findings": [], "depends_on": [], "covers": ["o1"],
+        "status": "completed", "output": {"interpretation": {"decision": "hold"}},
+    }
+    remediation = {
+        "id": "verify_again", "capability": "verification", "effect": "read",
+        "systems": [], "task": "Verify with the new capability",
+        "success_criterion": "Verified", "expected_findings": [],
+        "depends_on": ["verify_first"], "covers": ["o1"],
+    }
+    llm = MockLLMClient(responses=[
+        {"content": json.dumps({"steps": [remediation]})},
+        {"content": json.dumps({"complete": True, "missing": []})},
+    ])
+    planner = MeshPlanner(
+        llm,
+        capabilities={
+            "verification": {"description": "Verify", "effects": ["read"], "systems": []},
+        },
+    )
+
+    plan = await planner.amend(
+        "Verify evidence", obligations=obligations, current_steps=[completed],
+        reason="A new verification path is available", revision=1,
+    )
+
+    assert [step.step_id for step in plan.steps] == ["verify_again"]
+
+
+@pytest.mark.asyncio
+async def test_mesh_amendment_cannot_supersede_satisfied_obligations():
+    obligations = [
+        {"id": "satisfied", "description": "Keep verified evidence", "source_quote": "verified evidence"},
+        {"id": "unresolved", "description": "Resolve missing evidence", "source_quote": "missing evidence"},
+    ]
+    overbroad = {
+        "id": "restate", "capability": "verification", "effect": "read",
+        "systems": [], "task": "Restate all evidence", "success_criterion": "Restated",
+        "expected_findings": [], "depends_on": [], "covers": ["satisfied", "unresolved"],
+    }
+    targeted = {
+        **overbroad, "id": "resolve", "task": "Resolve missing evidence",
+        "covers": ["unresolved"],
+    }
+    llm = MockLLMClient(responses=[
+        {"content": json.dumps({"steps": [overbroad]})},
+        {"content": json.dumps({"steps": [targeted]})},
+        {"content": json.dumps({"complete": True, "missing": []})},
+    ])
+    planner = MeshPlanner(llm, capabilities={"verification": "Verify evidence"})
+
+    plan = await planner.amend(
+        "Keep verified evidence and resolve missing evidence",
+        obligations=obligations,
+        target_obligation_ids={"unresolved"},
+        current_steps=[],
+        reason="Missing evidence remains unresolved",
+        revision=1,
+    )
+
+    assert [step.covers for step in plan.steps] == [["unresolved"]]
+    assert "outside the amendment target" in llm.calls[1]["messages"][0]["content"]
+
+
+@pytest.mark.asyncio
 async def test_mesh_planner_treats_one_expected_finding_as_one_finding():
     llm = MockLLMClient(responses=responses(steps=[{
         "step_id": "research",
@@ -248,6 +562,20 @@ async def test_mesh_planner_treats_one_expected_finding_as_one_finding():
     plan = await planner.plan("Find evidence")
 
     assert plan.steps[0].expected_findings == ["one evidence summary"]
+
+
+@pytest.mark.asyncio
+async def test_mesh_planner_accepts_canonical_step_id_from_current_ledger():
+    llm = MockLLMClient(responses=responses(steps=[{
+        "id": "research", "capability": "research", "effect": "read",
+        "systems": [], "task": "Find evidence", "success_criterion": "Found",
+        "expected_findings": [], "depends_on": [], "covers": ["o1"],
+    }]))
+    planner = MeshPlanner(llm, capabilities={"research": "Research evidence"})
+
+    plan = await planner.plan("Find evidence")
+
+    assert plan.steps[0].step_id == "research"
 
 
 @pytest.mark.asyncio

--- a/tests/test_migrated_atoms.py
+++ b/tests/test_migrated_atoms.py
@@ -5,6 +5,39 @@ import pytest
 from jarviscore.execution.atom_contract import invocation, read_contract
 
 ATOM = "jarviscore/integrations/atoms/hubspot/hubspot_list_contacts.py"
+DRIVE_FOLDER_ATOM = (
+    "jarviscore/integrations/atoms/google_drive/google_drive_create_folder.py"
+)
+DRIVE_SEARCH_ATOM = (
+    "jarviscore/integrations/atoms/google_drive/google_drive_search_files.py"
+)
+HUBSPOT_SEARCH_ATOM = (
+    "jarviscore/integrations/atoms/hubspot/hubspot_search_contacts.py"
+)
+CALENDAR_CREATE_ATOM = (
+    "jarviscore/integrations/atoms/google_calendar/google_calendar_create_event.py"
+)
+CALENDAR_LIST_ATOM = (
+    "jarviscore/integrations/atoms/google_calendar/google_calendar_list_events.py"
+)
+DRIVE_EXPORT_ATOM = (
+    "jarviscore/integrations/atoms/google_drive/google_drive_export_file.py"
+)
+HUBSPOT_CONTACT_DEALS_ATOM = (
+    "jarviscore/integrations/atoms/hubspot/hubspot_list_contact_deals.py"
+)
+HUBSPOT_SEARCH_DEALS_ATOM = (
+    "jarviscore/integrations/atoms/hubspot/hubspot_search_deals.py"
+)
+HUBSPOT_ASSOCIATE_DEAL_ATOM = (
+    "jarviscore/integrations/atoms/hubspot/hubspot_associate_deal_contact.py"
+)
+HUBSPOT_CREATE_DEAL_ATOM = (
+    "jarviscore/integrations/atoms/hubspot/hubspot_create_deal.py"
+)
+DRIVE_APPEND_DOCUMENT_ATOM = (
+    "jarviscore/integrations/atoms/google_drive/google_drive_append_document_text.py"
+)
 
 
 @pytest.fixture
@@ -62,3 +95,379 @@ class TestMigratedAtomIsCallable:
         result = await namespace["main"]()
 
         assert result == {"success": False, "error": "unauthorised"}
+
+
+class TestDriveFolderAtom:
+
+    def test_direct_token_retrieval_is_not_a_valid_atom(self):
+        source = """
+async def google_drive_create_folder(folder_name: str) -> dict:
+    token = _get_nexus_token(None)
+    return await nexus_call('POST', 'https://example.test', headers={'Authorization': token})
+"""
+        result = read_contract(
+            source, system="google_drive", expected_name="google_drive_create_folder"
+        )
+
+        assert result.ok is False
+        assert "must not retrieve provider tokens" in result.report()
+
+    async def test_it_uses_nexus_managed_google_drive_authority(self):
+        with open(DRIVE_FOLDER_ATOM, encoding="utf-8") as handle:
+            source = handle.read()
+        atom = read_contract(
+            source, system="google_drive", expected_name="google_drive_create_folder"
+        ).atom
+        calls = []
+
+        async def nexus_call(method, url, **kwargs):
+            calls.append((method, url, kwargs))
+            return {
+                "ok": True,
+                "status_code": 200,
+                "json": {"id": "folder-1", "name": "Acme Corp"},
+                "body": "",
+                "headers": {},
+            }
+
+        namespace = {"nexus_call": nexus_call}
+        exec(
+            f"{source}\n\n{invocation(atom, {'folder_name': 'Acme Corp'})}",
+            namespace,
+        )
+        result = await namespace["main"]()
+
+        assert result["success"] is True
+        assert calls[0][2]["provider"] == "google_drive"
+        assert "Authorization" not in calls[0][2].get("headers", {})
+        assert "_get_nexus_token" not in source
+
+
+class TestProviderSearchAtoms:
+
+    @pytest.mark.parametrize(
+        ("path", "system", "name", "params", "expected_url"),
+        [
+            (
+                DRIVE_SEARCH_ATOM,
+                "google_drive",
+                "google_drive_search_files",
+                {"query": "name = 'Acme Corp'"},
+                "https://www.googleapis.com/drive/v3/files",
+            ),
+            (
+                HUBSPOT_SEARCH_ATOM,
+                "hubspot",
+                "hubspot_search_contacts",
+                {"query": "Ephy Kizito"},
+                "https://api.hubapi.com/crm/v3/objects/contacts/search",
+            ),
+        ],
+    )
+    async def test_search_uses_nexus_managed_provider_authority(
+        self, path, system, name, params, expected_url
+    ):
+        with open(path, encoding="utf-8") as handle:
+            source = handle.read()
+        atom = read_contract(source, system=system, expected_name=name).atom
+        calls = []
+
+        async def nexus_call(method, url, **kwargs):
+            calls.append((method, url, kwargs))
+            return {
+                "ok": True,
+                "status_code": 200,
+                "json": {"files": [], "results": [], "total": 0},
+                "body": "",
+                "headers": {},
+            }
+
+        namespace = {"nexus_call": nexus_call}
+        exec(f"{source}\n\n{invocation(atom, params)}", namespace)
+        result = await namespace["main"]()
+
+        assert result["success"] is True
+        method, url, kwargs = calls[0]
+        assert url == expected_url
+        assert kwargs["provider"] == system
+        assert "Authorization" not in kwargs.get("headers", {})
+        assert method in {"GET", "POST"}
+
+
+class TestCalendarCreateAtom:
+
+    async def test_it_returns_submitted_facts_when_provider_omits_them(self):
+        with open(CALENDAR_CREATE_ATOM, encoding="utf-8") as handle:
+            source = handle.read()
+        atom = read_contract(
+            source,
+            system="google_calendar",
+            expected_name="google_calendar_create_event",
+        ).atom
+
+        async def nexus_call(method, url, **kwargs):
+            return {
+                "ok": True,
+                "status_code": 200,
+                "json": {"id": "event-1"},
+                "body": "",
+                "headers": {},
+            }
+
+        params = {
+            "summary": "Discovery Call",
+            "start_datetime": "2026-09-11T17:00:00+03:00",
+            "end_datetime": "2026-09-11T17:30:00+03:00",
+            "attendees": ["ephy@example.com"],
+        }
+        namespace = {"nexus_call": nexus_call}
+        exec(f"{source}\n\n{invocation(atom, params)}", namespace)
+        result = await namespace["main"]()
+
+        assert result["event_id"] == "event-1"
+        assert result["html_link"] is None
+        assert result["starts_at"] == params["start_datetime"]
+        assert result["ends_at"] == params["end_datetime"]
+        assert result["attendees"] == ["ephy@example.com"]
+
+
+class TestProviderIdentityAndContentAtoms:
+
+    async def test_calendar_list_preserves_identity_and_status_fields(self):
+        with open(CALENDAR_LIST_ATOM, encoding="utf-8") as handle:
+            source = handle.read()
+        atom = read_contract(
+            source,
+            system="google_calendar",
+            expected_name="google_calendar_list_events",
+        ).atom
+
+        async def nexus_call(method, url, **kwargs):
+            return {
+                "ok": True,
+                "json": {"items": [{
+                    "id": "event-1",
+                    "summary": "Discovery Call",
+                    "start": {"dateTime": "2026-09-11T17:00:00+03:00"},
+                    "end": {"dateTime": "2026-09-11T17:30:00+03:00"},
+                    "attendees": [{
+                        "email": "ephy@example.com",
+                        "responseStatus": "needsAction",
+                    }],
+                    "organizer": {"email": "owner@example.com", "self": True},
+                    "status": "confirmed",
+                    "htmlLink": "https://calendar.test/event-1",
+                }]},
+                "body": "",
+            }
+
+        namespace = {"nexus_call": nexus_call}
+        exec(f"{source}\n\n{invocation(atom, {})}", namespace)
+        result = await namespace["main"]()
+
+        event = result["events"][0]
+        assert event["attendees"][0]["email"] == "ephy@example.com"
+        assert event["organizer"]["self"] is True
+        assert event["status"] == "confirmed"
+        assert event["htmlLink"] == "https://calendar.test/event-1"
+
+    async def test_drive_export_uses_workspace_export_endpoint(self):
+        with open(DRIVE_EXPORT_ATOM, encoding="utf-8") as handle:
+            source = handle.read()
+        atom = read_contract(
+            source,
+            system="google_drive",
+            expected_name="google_drive_export_file",
+        ).atom
+        calls = []
+
+        async def nexus_call(method, url, **kwargs):
+            calls.append((method, url, kwargs))
+            return {"ok": True, "content": b"Introduction\nProblem\nSolution"}
+
+        namespace = {"nexus_call": nexus_call}
+        exec(
+            f"{source}\n\n{invocation(atom, {'file_id': 'doc-1'})}",
+            namespace,
+        )
+        result = await namespace["main"]()
+
+        assert result["content"].startswith("Introduction")
+        assert calls[0][1].endswith("/files/doc-1/export")
+        assert calls[0][2]["params"] == {"mimeType": "text/plain"}
+        assert calls[0][2]["provider"] == "google_drive"
+
+    async def test_drive_export_preserves_binary_content_as_base64(self):
+        with open(DRIVE_EXPORT_ATOM, encoding="utf-8") as handle:
+            source = handle.read()
+        atom = read_contract(
+            source,
+            system="google_drive",
+            expected_name="google_drive_export_file",
+        ).atom
+
+        async def nexus_call(method, url, **kwargs):
+            return {"ok": True, "content": b"%PDF-\xff"}
+
+        namespace = {"nexus_call": nexus_call}
+        exec(
+            f"{source}\n\n{invocation(atom, {'file_id': 'doc-1', 'mime_type': 'application/pdf'})}",
+            namespace,
+        )
+        result = await namespace["main"]()
+
+        assert result["content"] is None
+        assert result["content_base64"] == "JVBERi3/"
+        assert result["encoding"] == "base64"
+
+    async def test_hubspot_contact_deals_reads_association_records(self):
+        with open(HUBSPOT_CONTACT_DEALS_ATOM, encoding="utf-8") as handle:
+            source = handle.read()
+        atom = read_contract(
+            source,
+            system="hubspot",
+            expected_name="hubspot_list_contact_deals",
+        ).atom
+        calls = []
+
+        async def nexus_call(method, url, **kwargs):
+            calls.append((method, url, kwargs))
+            return {
+                "ok": True,
+                "json": {"results": [{"toObjectId": 520580273359}]},
+                "body": "",
+            }
+
+        namespace = {"nexus_call": nexus_call}
+        exec(
+            f"{source}\n\n{invocation(atom, {'contact_id': '865110084794'})}",
+            namespace,
+        )
+        result = await namespace["main"]()
+
+        assert result["deals"] == [{"toObjectId": 520580273359}]
+        assert calls[0][1].endswith(
+            "/contacts/865110084794/associations/deals"
+        )
+        assert calls[0][2]["provider"] == "hubspot"
+
+    async def test_hubspot_search_deals_uses_provider_search(self):
+        with open(HUBSPOT_SEARCH_DEALS_ATOM, encoding="utf-8") as handle:
+            source = handle.read()
+        atom = read_contract(
+            source, system="hubspot", expected_name="hubspot_search_deals"
+        ).atom
+        calls = []
+
+        async def nexus_call(method, url, **kwargs):
+            calls.append((method, url, kwargs))
+            return {
+                "ok": True,
+                "json": {"results": [{"id": "deal-1"}], "total": 1},
+                "body": "",
+            }
+
+        namespace = {"nexus_call": nexus_call}
+        exec(
+            f"{source}\n\n{invocation(atom, {'query': 'Acme Corp'})}",
+            namespace,
+        )
+        result = await namespace["main"]()
+
+        assert result["deals"] == [{"id": "deal-1"}]
+        assert calls[0][0] == "POST"
+        assert calls[0][1].endswith("/crm/v3/objects/deals/search")
+
+    async def test_hubspot_association_is_verified_by_readback(self):
+        with open(HUBSPOT_ASSOCIATE_DEAL_ATOM, encoding="utf-8") as handle:
+            source = handle.read()
+        atom = read_contract(
+            source,
+            system="hubspot",
+            expected_name="hubspot_associate_deal_contact",
+        ).atom
+        calls = []
+
+        async def nexus_call(method, url, **kwargs):
+            calls.append((method, url, kwargs))
+            if method == "PUT":
+                return {"ok": True, "json": {}, "body": ""}
+            return {
+                "ok": True,
+                "json": {"results": [{"toObjectId": "deal-1"}]},
+                "body": "",
+            }
+
+        namespace = {"nexus_call": nexus_call}
+        exec(
+            f"{source}\n\n{invocation(atom, {'deal_id': 'deal-1', 'contact_id': 'contact-1'})}",
+            namespace,
+        )
+        result = await namespace["main"]()
+
+        assert result["association_verified"] is True
+        assert [call[0] for call in calls] == ["PUT", "GET"]
+
+    async def test_hubspot_create_can_associate_and_verify_the_contact(self):
+        with open(HUBSPOT_CREATE_DEAL_ATOM, encoding="utf-8") as handle:
+            source = handle.read()
+        atom = read_contract(
+            source, system="hubspot", expected_name="hubspot_create_deal"
+        ).atom
+        calls = []
+
+        async def nexus_call(method, url, **kwargs):
+            calls.append((method, url, kwargs))
+            if method == "POST":
+                return {"ok": True, "json": {"id": "deal-1"}, "body": ""}
+            if method == "PUT":
+                return {"ok": True, "json": {}, "body": ""}
+            return {
+                "ok": True,
+                "json": {"results": [{"toObjectId": "deal-1"}]},
+                "body": "",
+            }
+
+        namespace = {"nexus_call": nexus_call}
+        exec(
+            f"{source}\n\n{invocation(atom, {'deal_name': 'Acme opportunity', 'stage': 'qualified', 'contact_id': 'contact-1'})}",
+            namespace,
+        )
+        result = await namespace["main"]()
+
+        assert result["id"] == "deal-1"
+        assert result["contact_id"] == "contact-1"
+        assert result["association_verified"] is True
+        assert [call[0] for call in calls] == ["POST", "PUT", "GET"]
+
+    async def test_google_docs_append_uses_the_current_document_end(self):
+        with open(DRIVE_APPEND_DOCUMENT_ATOM, encoding="utf-8") as handle:
+            source = handle.read()
+        atom = read_contract(
+            source,
+            system="google_drive",
+            expected_name="google_drive_append_document_text",
+        ).atom
+        calls = []
+
+        async def nexus_call(method, url, **kwargs):
+            calls.append((method, url, kwargs))
+            if method == "GET":
+                return {
+                    "ok": True,
+                    "json": {"body": {"content": [{"endIndex": 2}]}},
+                    "body": "",
+                }
+            return {"ok": True, "json": {}, "body": ""}
+
+        namespace = {"nexus_call": nexus_call}
+        exec(
+            f"{source}\n\n{invocation(atom, {'document_id': 'doc-1', 'content': 'Introduction'})}",
+            namespace,
+        )
+        result = await namespace["main"]()
+
+        assert result["inserted_characters"] == len("Introduction")
+        request = calls[1][2]["json"]["requests"][0]["insertText"]
+        assert request["location"]["index"] == 1
+        assert request["text"] == "Introduction"

--- a/tests/test_migrated_atoms.py
+++ b/tests/test_migrated_atoms.py
@@ -23,6 +23,9 @@ CALENDAR_LIST_ATOM = (
 DRIVE_EXPORT_ATOM = (
     "jarviscore/integrations/atoms/google_drive/google_drive_export_file.py"
 )
+DRIVE_GET_DOCUMENT_ATOM = (
+    "jarviscore/integrations/atoms/google_drive/google_drive_get_document.py"
+)
 HUBSPOT_CONTACT_DEALS_ATOM = (
     "jarviscore/integrations/atoms/hubspot/hubspot_list_contact_deals.py"
 )
@@ -319,6 +322,57 @@ class TestProviderIdentityAndContentAtoms:
         assert result["content"] is None
         assert result["content_base64"] == "JVBERi3/"
         assert result["encoding"] == "base64"
+
+    async def test_drive_get_document_reads_structural_text(self):
+        with open(DRIVE_GET_DOCUMENT_ATOM, encoding="utf-8") as handle:
+            source = handle.read()
+        atom = read_contract(
+            source,
+            system="google_drive",
+            expected_name="google_drive_get_document",
+        ).atom
+        calls = []
+
+        async def nexus_call(method, url, **kwargs):
+            calls.append((method, url, kwargs))
+            return {
+                "ok": True,
+                "json": {
+                    "title": "Acme Pitch",
+                    "body": {"content": [
+                        {"paragraph": {"elements": [
+                            {"textRun": {"content": "Introduction\n"}},
+                            {"textRun": {"content": "Problem\n"}},
+                        ]}},
+                        {"sectionBreak": {}},
+                        {"paragraph": {"elements": [
+                            {"textRun": {"content": "Solution\n"}},
+                        ]}},
+                    ]},
+                },
+                "body": "",
+            }
+
+        namespace = {"nexus_call": nexus_call}
+        exec(
+            f"{source}\n\n{invocation(atom, {'document_id': 'doc-1'})}",
+            namespace,
+        )
+        result = await namespace["main"]()
+
+        assert result == {
+            "success": True,
+            "document_id": "doc-1",
+            "title": "Acme Pitch",
+            "text": "Introduction\nProblem\nSolution\n",
+            "paragraph_count": 2,
+            "content_length": 29,
+            "error": None,
+        }
+        assert calls == [(
+            "GET", "https://docs.googleapis.com/v1/documents/doc-1",
+            {"provider": "google_drive"},
+        )]
 
     async def test_hubspot_contact_deals_reads_association_records(self):
         with open(HUBSPOT_CONTACT_DEALS_ATOM, encoding="utf-8") as handle:

--- a/tests/test_p2p_integration.py
+++ b/tests/test_p2p_integration.py
@@ -5,9 +5,10 @@ Tests SWIM protocol, keepalive, broadcaster, and P2P coordinator.
 """
 import pytest
 import asyncio
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 from jarviscore import Mesh
+from jarviscore.p2p.peer_client import PeerClient
 from jarviscore.p2p.peer_tool import PeerTool
 from jarviscore.profiles import AutoAgent, CustomAgent
 
@@ -427,6 +428,28 @@ class TestP2PIntegrationWithAgents:
         assert result["semantic_error"] == "INVALID_PEER_TOOL_ARGUMENTS"
         assert result["peer_request_attempted"] is False
         peers.request.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_peer_request_timeout_is_distinct_from_missing_identity(self):
+        class SlowPeer:
+            agent_id = "slow-peer"
+            role = "slow_peer"
+
+        client = PeerClient.__new__(PeerClient)
+        client._agent_id = "requester"
+        client._agent_role = "requester"
+        client._node_id = "node-1"
+        client._pending_requests = {}
+        client._logger = MagicMock()
+        client._resolve_target = MagicMock(return_value=SlowPeer())
+        client._send_message = AsyncMock(return_value=True)
+
+        result = await client.request(
+            "slow_peer", {"query": "Review evidence"}, timeout=0.001
+        )
+
+        assert result["semantic_error"] == "PEER_RESPONSE_TIMEOUT"
+        assert result["peer_request_attempted"] is True
 
     @pytest.mark.asyncio
     async def test_capability_request_rejects_an_active_ancestor(self, monkeypatch):

--- a/tests/test_p2p_integration.py
+++ b/tests/test_p2p_integration.py
@@ -5,7 +5,10 @@ Tests SWIM protocol, keepalive, broadcaster, and P2P coordinator.
 """
 import pytest
 import asyncio
+from unittest.mock import MagicMock
+
 from jarviscore import Mesh
+from jarviscore.p2p.peer_tool import PeerTool
 from jarviscore.profiles import AutoAgent, CustomAgent
 
 
@@ -282,6 +285,261 @@ class TestP2PIntegrationWithAgents:
             if "swim" in str(e).lower():
                 pytest.skip("SWIM library not available")
             raise
+
+    @pytest.mark.asyncio
+    async def test_autoagents_answer_peer_requests_without_custom_listener_wiring(self, monkeypatch):
+        class Requester(AutoAgent):
+            role = "requester"
+            capabilities = ["coordination"]
+            system_prompt = "Coordinate work."
+
+            async def setup(self):
+                pass
+
+            async def execute_task(self, task):
+                return {"status": "success", "output": task["task"]}
+
+        class Analyst(AutoAgent):
+            role = "analyst"
+            capabilities = ["analysis"]
+            system_prompt = "Analyse evidence."
+
+            async def setup(self):
+                pass
+
+            async def execute_task(self, task):
+                return {"status": "success", "output": f"analysed: {task['task']}"}
+
+        monkeypatch.setattr(Mesh, "_init_redis", lambda self, settings: None)
+        monkeypatch.setattr(Mesh, "_init_blob_storage", lambda self, settings: None)
+        monkeypatch.setattr(Mesh, "_init_nexus", lambda self: None)
+        monkeypatch.setattr(Mesh, "_init_athena", lambda self, settings: None)
+        mesh = Mesh()
+        requester = mesh.add(Requester)
+        mesh.add(Analyst)
+
+        await mesh.start()
+        try:
+            response = await requester.peers.as_tool().execute(
+                "ask_peer", {"role": "analyst", "question": "Review Acme"}
+            )
+            assert "analysed: Review Acme" in response
+        finally:
+            await mesh.stop()
+
+    @pytest.mark.asyncio
+    async def test_autoagents_request_help_by_capability_with_recipient_authority(
+        self, monkeypatch
+    ):
+        received = []
+
+        class Requester(AutoAgent):
+            role = "requester"
+            capabilities = ["coordination"]
+            system_prompt = "Coordinate work."
+
+            async def setup(self):
+                pass
+
+        class ContactVerifier(AutoAgent):
+            role = "contact_verifier"
+            capabilities = ["contact_verification"]
+            capability_descriptions = {
+                "contact_verification": "Resolve contact identity from connected sources.",
+            }
+            capability_contracts = {
+                "contact_verification": {
+                    "effects": ["read"], "systems": ["gmail", "hubspot"],
+                },
+            }
+            system_prompt = "Verify contacts."
+
+            async def setup(self):
+                pass
+
+            async def execute_task(self, task):
+                received.append(task)
+                return {"status": "success", "output": {"email": "ephy@example.com"}}
+
+        monkeypatch.setattr(Mesh, "_init_redis", lambda self, settings: None)
+        monkeypatch.setattr(Mesh, "_init_blob_storage", lambda self, settings: None)
+        monkeypatch.setattr(Mesh, "_init_nexus", lambda self: None)
+        monkeypatch.setattr(Mesh, "_init_athena", lambda self, settings: None)
+        mesh = Mesh(config={"p2p_enabled": False})
+        requester = mesh.add(Requester, agent_id="requester-1")
+        mesh.add(ContactVerifier, agent_id="verifier-1")
+
+        await mesh.start()
+        try:
+            ask_schema = next(
+                item
+                for item in requester.peers.as_tool().schema
+                if item["name"] == "ask_capability"
+            )
+            assert "Resolve contact identity" in ask_schema["description"]
+            response = await requester.peers.as_tool().execute(
+                "ask_capability",
+                {
+                    "capability": "contact_verification",
+                    "question": "Find a verified contact path for Ephy Kizito.",
+                },
+                context={
+                    "workflow_id": "wf-1", "objective": "Prepare the customer meeting",
+                    "system": "google_calendar", "effect": "write",
+                    "_nexus_connection_id": "caller-secret",
+                },
+            )
+        finally:
+            await mesh.stop()
+
+        assert "ephy@example.com" in response
+        context = received[0]["context"]
+        assert context["workflow_id"] == "wf-1"
+        assert context["objective"] == "Prepare the customer meeting"
+        assert context["capability"] == "contact_verification"
+        assert context["effect"] == "read"
+        assert context["systems"] == ["gmail", "hubspot"]
+        assert "system" not in context
+        assert "_nexus_connection_id" not in context
+
+    @pytest.mark.asyncio
+    async def test_peer_tool_schema_error_is_typed_and_never_dispatched(self):
+        peers = MagicMock()
+        peers.my_id = "requester-1"
+        peers.my_role = "requester"
+        peers.list_roles.return_value = ["analyst"]
+        peers.list_peers.return_value = [{
+            "role": "analyst",
+            "capabilities": ["analysis"],
+        }]
+        tool = PeerTool(peers)
+
+        result = await tool.execute_result(
+            "ask_peer",
+            {
+                "peer": "analyst",
+                "task": "Review Acme",
+                "context": "Known facts",
+            },
+        )
+
+        assert result["status"] == "error"
+        assert result["semantic_error"] == "INVALID_PEER_TOOL_ARGUMENTS"
+        assert result["peer_request_attempted"] is False
+        peers.request.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_capability_request_rejects_an_active_ancestor(self, monkeypatch):
+        class Requester(AutoAgent):
+            role = "requester"
+            capabilities = ["coordination"]
+            system_prompt = "Coordinate work."
+
+            async def setup(self):
+                pass
+
+        class Reconciler(AutoAgent):
+            role = "reconciler"
+            capabilities = ["crm_reconciliation"]
+            system_prompt = "Reconcile CRM evidence."
+
+            async def setup(self):
+                pass
+
+        monkeypatch.setattr(Mesh, "_init_redis", lambda self, settings: None)
+        monkeypatch.setattr(Mesh, "_init_blob_storage", lambda self, settings: None)
+        monkeypatch.setattr(Mesh, "_init_nexus", lambda self: None)
+        monkeypatch.setattr(Mesh, "_init_athena", lambda self, settings: None)
+        mesh = Mesh(config={"p2p_enabled": False})
+        requester = mesh.add(Requester, agent_id="requester-1")
+        mesh.add(Reconciler, agent_id="reconciler-1")
+
+        await mesh.start()
+        try:
+            response = await requester.peers.as_tool().execute(
+                "ask_capability",
+                {
+                    "capability": "crm_reconciliation",
+                    "question": "Inspect the associated CRM records.",
+                },
+                context={"peer_request_lineage": ["reconciler-1"]},
+            )
+        finally:
+            await mesh.stop()
+
+        assert "no non-cyclic peer" in response
+
+    @pytest.mark.asyncio
+    async def test_autoagent_notifications_enter_its_durable_mailbox(self, monkeypatch):
+        class Peer(AutoAgent):
+            role = "peer"
+            capabilities = ["work"]
+            system_prompt = "Do peer work."
+
+            async def setup(self):
+                pass
+
+            async def execute_task(self, task):
+                return {"status": "success", "output": "done"}
+
+        monkeypatch.setattr(Mesh, "_init_redis", lambda self, settings: None)
+        monkeypatch.setattr(Mesh, "_init_blob_storage", lambda self, settings: None)
+        monkeypatch.setattr(Mesh, "_init_nexus", lambda self: None)
+        monkeypatch.setattr(Mesh, "_init_athena", lambda self, settings: None)
+        mesh = Mesh()
+        sender = mesh.add(Peer, agent_id="sender")
+        receiver = mesh.add(Peer, agent_id="receiver")
+
+        await mesh.start()
+        try:
+            await sender.peers.notify(
+                "receiver", {"event": "evidence_ready", "step_id": "research"},
+                context={"workflow_id": "wf-1"},
+            )
+            messages = receiver.mailbox.peek()
+            assert messages[0]["sender"] == "sender"
+            assert messages[0]["message"]["event"] == "evidence_ready"
+            assert messages[0]["workflow_id"] == "wf-1"
+        finally:
+            await mesh.stop()
+
+    @pytest.mark.asyncio
+    async def test_autoagent_preserves_application_peer_request_handler(self, monkeypatch):
+        class Peer(AutoAgent):
+            role = "peer"
+            capabilities = ["work"]
+            system_prompt = "Do peer work."
+
+            async def setup(self):
+                pass
+
+            async def execute_task(self, task):
+                raise AssertionError("custom peer handler must run first")
+
+        class Specialist(Peer):
+            role = "specialist"
+            capabilities = ["specialized"]
+
+            async def on_peer_request(self, message):
+                return {"status": "success", "output": message.data["artifact"]}
+
+        monkeypatch.setattr(Mesh, "_init_redis", lambda self, settings: None)
+        monkeypatch.setattr(Mesh, "_init_blob_storage", lambda self, settings: None)
+        monkeypatch.setattr(Mesh, "_init_nexus", lambda self: None)
+        monkeypatch.setattr(Mesh, "_init_athena", lambda self, settings: None)
+        mesh = Mesh(config={"p2p_enabled": False})
+        sender = mesh.add(Peer, agent_id="sender")
+        mesh.add(Specialist, agent_id="specialist-1")
+
+        await mesh.start()
+        try:
+            response = await sender.peers.request(
+                "specialist", {"artifact": {"id": "typed-1"}}, timeout=1
+            )
+        finally:
+            await mesh.stop()
+
+        assert response["output"] == {"id": "typed-1"}
 
     @pytest.mark.asyncio
     async def test_customagent_with_p2p(self):

--- a/tests/test_planning.py
+++ b/tests/test_planning.py
@@ -203,7 +203,31 @@ class TestStepEvaluation:
         assert StepEvaluation(verdict="fail", confidence=0.2, evaluator_note="").needs_replan
 
     def test_needs_hitl(self):
-        assert StepEvaluation(verdict="hitl", confidence=0.5, evaluator_note="").needs_hitl
+        assert StepEvaluation(
+            verdict="hitl",
+            confidence=0.5,
+            evaluator_note="",
+            hitl_category="critical_action",
+        ).needs_hitl
+
+    def test_data_hitl_requires_exhausted_human_exclusive_evidence(self):
+        lazy = StepEvaluation(
+            verdict="hitl",
+            confidence=0.5,
+            evaluator_note="unsure",
+            hitl_category="data_required",
+        )
+        admissible = StepEvaluation(
+            verdict="hitl",
+            confidence=0.5,
+            evaluator_note="Only the human can choose a new time constraint.",
+            hitl_category="data_required",
+            autonomous_paths_exhausted=True,
+            human_exclusive=True,
+        )
+        assert lazy.needs_hitl is False
+        assert lazy.needs_replan is True
+        assert admissible.needs_hitl is True
 
     def test_not_needs_replan_for_pass(self):
         assert not StepEvaluation(verdict="pass", confidence=0.9, evaluator_note="").needs_replan
@@ -550,6 +574,64 @@ class TestStepEvaluator:
         result = ev._parse_evaluation(raw, _make_step())
         assert result.additional_findings == {}
 
+    def test_parse_evaluation_carries_goal_convergence_decision(self):
+        ev = self._evaluator()
+        raw = json.dumps({
+            "verdict": "pass",
+            "confidence": 0.95,
+            "evaluator_note": "The existing artifact satisfies the observation.",
+            "additional_findings": {"artifact_status": "existing"},
+            "goal_decision": "complete",
+            "goal_note": "The conditional creation branch is obsolete.",
+        })
+
+        result = ev._parse_evaluation(raw, _make_step())
+
+        assert result.goal_decision == "complete"
+        assert "conditional creation branch" in result.goal_note
+
+    def test_parse_evaluation_accepts_null_string_hitl_category(self):
+        ev = self._evaluator()
+        raw = json.dumps({
+            "verdict": "pass",
+            "confidence": 0.9,
+            "evaluator_note": "No human input is needed.",
+            "additional_findings": {},
+            "goal_decision": "continue",
+            "goal_note": "Continue autonomously.",
+            "hitl_category": "null",
+            "autonomous_paths_exhausted": False,
+            "human_exclusive": False,
+        })
+
+        result = ev._parse_evaluation(raw, _make_step())
+
+        assert result.hitl_category is None
+
+    def test_goal_replan_decision_uses_existing_replan_path(self):
+        evaluation = StepEvaluation(
+            verdict="pass",
+            confidence=0.9,
+            evaluator_note="Step passed.",
+            goal_decision="replan",
+            goal_note="New evidence invalidated the remaining plan.",
+        )
+
+        assert evaluation.needs_replan is True
+
+    def test_evaluator_prompt_exposes_remaining_steps_and_conditional_rule(self):
+        ev = self._evaluator()
+        prompt = ev._build_prompt(
+            _make_step(),
+            _make_output(),
+            GoalExecution(goal="Create only if absent", agent_id="a"),
+            remaining_steps=[_make_step("create", task="Create the artifact")],
+        )
+
+        assert "Remaining planned steps" in prompt
+        assert "create: Create the artifact" in prompt
+        assert "conditional branch is false" in prompt
+
 
 # ── Scratchpad scope changes ──────────────────────────────────────────────────
 
@@ -682,7 +764,14 @@ class TestGoalSnapshotRoundTrip:
         ge.record_completed(
             ge.plan[0],
             _make_output(summary="found the auth method"),
-            _make_evaluation(verdict="pass"),
+            StepEvaluation(
+                verdict="pass",
+                confidence=0.9,
+                evaluator_note="Looks good",
+                additional_findings={"discovered_key": "discovered_value"},
+                goal_decision="replan",
+                goal_note="New evidence changed the remaining work.",
+            ),
             elapsed_ms=120.0,
         )
         return ge
@@ -715,6 +804,8 @@ class TestGoalSnapshotRoundTrip:
         cs = restored.completed[0]
         assert cs.step.step_id == "step_01"
         assert cs.evaluation.verdict == "pass"
+        assert cs.evaluation.goal_decision == "replan"
+        assert "changed the remaining work" in cs.evaluation.goal_note
         assert cs.to_summary()["summary"] == "found the auth method"
 
     def test_resumed_context_chains_into_next_step(self):
@@ -926,6 +1017,54 @@ class TestReplanTailAndBudget:
 
 class TestDependencyParallelExecution:
     """Plans that declare depends_on opt into concurrent co-ready steps."""
+
+    @pytest.mark.asyncio
+    async def test_goal_convergence_stops_obsolete_remaining_steps(self):
+        from unittest.mock import AsyncMock, patch
+        from jarviscore.profiles.autoagent import AutoAgent
+
+        class _GoalAgent(AutoAgent):
+            role = "goal-convergence"
+            capabilities = ["x"]
+            system_prompt = "test"
+
+        agent = _GoalAgent()
+        agent.llm = object()
+        executed = []
+
+        class _Kernel:
+            blob_storage = None
+            auth_manager = None
+
+            async def execute(self, task, **kwargs):
+                executed.append(kwargs["context"]["step_id"])
+                return _make_output(payload={"status": "existing"})
+
+        agent._kernel = _Kernel()
+        plan = [
+            PlannedStep("inspect", "Inspect artifact", "Existence resolved"),
+            PlannedStep("create", "Create artifact if absent", "Artifact created"),
+        ]
+        converged = StepEvaluation(
+            verdict="pass",
+            confidence=0.98,
+            evaluator_note="The existing artifact satisfies the goal.",
+            goal_decision="complete",
+            goal_note="The conditional creation branch is obsolete.",
+        )
+
+        with patch(
+            "jarviscore.planning.planner.Planner.plan",
+            new=AsyncMock(return_value=plan),
+        ), patch(
+            "jarviscore.planning.evaluator.StepEvaluator.evaluate",
+            new=AsyncMock(return_value=converged),
+        ):
+            execution = await agent.execute_goal("Create the artifact only if absent")
+
+        assert execution.status == "complete"
+        assert executed == ["inspect"]
+        assert [item.step.step_id for item in execution.completed] == ["inspect"]
 
     @pytest.mark.asyncio
     async def test_co_ready_steps_overlap_and_dependents_wait(self, monkeypatch):
@@ -1243,7 +1382,12 @@ class TestHITLConsentGate:
             new=AsyncMock(return_value=plan),
         ), patch(
             "jarviscore.planning.evaluator.StepEvaluator.evaluate",
-            new=AsyncMock(return_value=_make_evaluation(verdict="hitl")),
+            new=AsyncMock(return_value=StepEvaluation(
+                verdict="hitl",
+                confidence=0.9,
+                evaluator_note="The consequential action needs approval.",
+                hitl_category="critical_action",
+            )),
         ):
             execution = await agent.execute_goal("attended goal")
 

--- a/tests/test_process_isolation.py
+++ b/tests/test_process_isolation.py
@@ -1,8 +1,11 @@
 import os
+from typing import ClassVar
 
 import pytest
 
+from jarviscore import Mesh
 from jarviscore.execution.coder_sandbox import create_coder_sandbox
+from jarviscore.profiles.autoagent import AutoAgent, _AutoAgentMeshProxy
 
 
 class RecordingProxy:
@@ -15,6 +18,18 @@ class RecordingProxy:
 
     def connection_handle(self, provider):
         return f"connection:{provider}"
+
+
+class RecordingMeshProxy:
+    def __init__(self):
+        self.calls = []
+
+    async def delegate(self, to, task, context=None, capability=None, timeout=None):
+        self.calls.append((to, task, context, capability, timeout))
+        return {"status": "success", "output": {"review": "complete"}}
+
+    def list_peers(self):
+        return [{"role": "analyst", "capabilities": ["analysis"]}]
 
 
 @pytest.mark.asyncio
@@ -53,7 +68,25 @@ async def test_allowlisted_commands_remain_available_in_the_scrubbed_child():
 
 
 @pytest.mark.asyncio
-async def test_provider_access_crosses_the_parent_rpc_only():
+async def test_provider_read_access_crosses_the_parent_rpc_only():
+    proxy = RecordingProxy()
+    sandbox = create_coder_sandbox(timeout=10, nexus_call_proxy=proxy)
+
+    result = await sandbox.execute(
+        "async def main():\n"
+        "    return await nexus_call('GET', 'https://example.invalid/items')\n",
+        context={"_nexus_connection_id": "demo", "_nexus_provider": "demo"},
+    )
+
+    assert result["status"] == "success"
+    assert result["data"]["status_code"] == 200
+    assert proxy.calls == [
+        ("demo", "GET", "https://example.invalid/items", {})
+    ]
+
+
+@pytest.mark.asyncio
+async def test_generated_code_cannot_mutate_provider_through_raw_nexus_call():
     proxy = RecordingProxy()
     sandbox = create_coder_sandbox(timeout=10, nexus_call_proxy=proxy)
 
@@ -63,11 +96,9 @@ async def test_provider_access_crosses_the_parent_rpc_only():
         context={"_nexus_connection_id": "demo", "_nexus_provider": "demo"},
     )
 
-    assert result["status"] == "success"
-    assert result["data"]["status_code"] == 200
-    assert proxy.calls == [
-        ("demo", "POST", "https://example.invalid/items", {"json": {"x": 1}})
-    ]
+    assert result["status"] == "failure"
+    assert "registered atom" in result["error"]
+    assert proxy.calls == []
 
 
 @pytest.mark.asyncio
@@ -86,3 +117,79 @@ async def test_one_child_routes_multiple_providers_through_parent_handles():
     assert [call[0] for call in proxy.calls] == [
         "connection:gmail", "connection:google_calendar",
     ]
+
+
+@pytest.mark.asyncio
+async def test_generated_code_delegates_through_a_restricted_parent_mesh_facade():
+    proxy = RecordingMeshProxy()
+    sandbox = create_coder_sandbox(timeout=10, mesh_proxy=proxy)
+
+    result = await sandbox.execute(
+        "async def main():\n"
+        "    peers = await mesh.list_peers()\n"
+        "    delegated = await mesh.delegate(\n"
+        "        to='analyst', task='Review Acme',\n"
+        "        context={'workflow_id': 'wf-1'}, capability='analysis', timeout=30,\n"
+        "    )\n"
+        "    return {\n"
+        "        'peers': peers, 'delegated': delegated,\n"
+        "        'has_stop': hasattr(mesh, 'stop'),\n"
+        "        'has_add': hasattr(mesh, 'add'),\n"
+        "    }\n"
+    )
+
+    assert result["status"] == "success"
+    assert result["data"]["delegated"]["output"]["review"] == "complete"
+    assert result["data"]["peers"][0]["role"] == "analyst"
+    assert result["data"]["has_stop"] is False
+    assert result["data"]["has_add"] is False
+    assert proxy.calls == [
+        ("analyst", "Review Acme", {"workflow_id": "wf-1"}, "analysis", 30),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_generated_code_delegates_to_a_live_autoagent_peer(monkeypatch):
+    class Peer(AutoAgent):
+        role = "peer"
+        capabilities: ClassVar[list[str]] = ["coordination"]
+        system_prompt = "Coordinate."
+
+        async def setup(self):
+            pass
+
+        async def execute_task(self, task):
+            return {"status": "success", "output": task["task"]}
+
+    class Analyst(Peer):
+        role = "analyst"
+        capabilities: ClassVar[list[str]] = ["analysis"]
+
+        async def execute_task(self, task):
+            return {"status": "success", "output": f"analysed: {task['task']}"}
+
+    monkeypatch.setattr(Mesh, "_init_redis", lambda self, settings: None)
+    monkeypatch.setattr(Mesh, "_init_blob_storage", lambda self, settings: None)
+    monkeypatch.setattr(Mesh, "_init_nexus", lambda self: None)
+    monkeypatch.setattr(Mesh, "_init_athena", lambda self, settings: None)
+    mesh = Mesh(config={"p2p_enabled": False})
+    requester = mesh.add(Peer, agent_id="requester")
+    mesh.add(Analyst, agent_id="analyst-1")
+
+    await mesh.start()
+    try:
+        sandbox = create_coder_sandbox(
+            timeout=10,
+            mesh_proxy=_AutoAgentMeshProxy(requester),
+        )
+        result = await sandbox.execute(
+            "async def main():\n"
+            "    return await mesh.delegate(\n"
+            "        to='any', capability='analysis', task='Review Acme'\n"
+            "    )\n"
+        )
+    finally:
+        await mesh.stop()
+
+    assert result["status"] == "success"
+    assert result["data"]["output"] == "analysed: Review Acme"

--- a/tests/test_redis_store.py
+++ b/tests/test_redis_store.py
@@ -81,6 +81,90 @@ class TestStepOutputs:
         result = store.get_step_output("wf-1", "step-1")
         assert result["context_vars"]["endpoint"] == "https://api.example.com"
 
+
+class TestWorkflowTokenBudget:
+
+    def test_reservations_are_atomic_and_settle_exact_usage(self, store):
+        store.register_workflow_goal(
+            "wf-budget",
+            "Do bounded work",
+            budget={"max_tokens": 100},
+        )
+
+        assert store.reserve_workflow_tokens("wf-budget", "epoch-1", "call-1", 60)
+        assert not store.reserve_workflow_tokens("wf-budget", "epoch-1", "call-2", 50)
+        assert store.settle_workflow_tokens("wf-budget", "epoch-1", "call-1", 40, 0.25)
+        assert store.reserve_workflow_tokens("wf-budget", "epoch-1", "call-2", 50)
+
+        usage = store.get_workflow_budget_usage("wf-budget", "epoch-1")
+        assert usage == {
+            "max_tokens_per_epoch": 100,
+            "used_tokens": 40,
+            "cost_usd": 0.25,
+            "call_count": 1,
+            "epoch_count": 1,
+            "epoch_id": "epoch-1",
+            "epoch_used_tokens": 40,
+            "epoch_reserved_tokens": 50,
+        }
+
+    def test_failed_dispatch_releases_its_reservation(self, store):
+        store.register_workflow_goal(
+            "wf-release",
+            "Do bounded work",
+            budget={"max_tokens": 100},
+        )
+        assert store.reserve_workflow_tokens("wf-release", "epoch-1", "call-1", 80)
+        assert store.release_workflow_token_reservation("wf-release", "epoch-1", "call-1")
+        assert store.reserve_workflow_tokens("wf-release", "epoch-1", "call-2", 100)
+
+    def test_new_execution_epoch_renews_capacity_without_resetting_totals(self, store):
+        store.register_workflow_goal(
+            "wf-long",
+            "Continue across durable progress",
+            budget={"max_tokens": 100},
+        )
+        assert store.reserve_workflow_tokens("wf-long", "step:a", "call-1", 100)
+        assert store.settle_workflow_tokens("wf-long", "step:a", "call-1", 90, 0.2)
+        assert not store.reserve_workflow_tokens("wf-long", "step:a", "call-2", 20)
+        assert store.reserve_workflow_tokens("wf-long", "step:b", "call-3", 100)
+        assert store.settle_workflow_tokens("wf-long", "step:b", "call-3", 80, 0.3)
+
+        usage = store.get_workflow_budget_usage("wf-long")
+        assert usage["used_tokens"] == 170
+        assert usage["cost_usd"] == 0.5
+        assert usage["epoch_count"] == 2
+
+    def test_pre_upgrade_workflow_lazily_gets_a_budget_account(self, store):
+        store.register_workflow_goal(
+            "wf-upgrade",
+            "Resume old work",
+            budget={"max_tokens": 75},
+        )
+        store._redis.delete("workflow_budget:wf-upgrade")
+
+        assert store.reserve_workflow_tokens(
+            "wf-upgrade", "resume:1", "resume-call", 50
+        )
+        usage = store.get_workflow_budget_usage("wf-upgrade", "resume:1")
+        assert usage["max_tokens_per_epoch"] == 75
+        assert usage["epoch_reserved_tokens"] == 50
+
+    def test_legacy_lifetime_hash_migrates_to_epoch_limit(self, store):
+        store.register_workflow_goal(
+            "wf-legacy-hash",
+            "Resume legacy accounting",
+            budget={"max_tokens": 75},
+        )
+        key = "workflow_budget:wf-legacy-hash"
+        store._redis.hset(key, "max_tokens", 75)
+        store._redis.hdel(key, "max_tokens_per_epoch")
+
+        assert store.reserve_workflow_tokens(
+            "wf-legacy-hash", "resume:2", "call-1", 50
+        )
+        assert store._redis.hget(key, "max_tokens_per_epoch") == "75"
+
     def test_isolation_between_workflows(self, store):
         """Different workflows don't see each other's outputs."""
         store.save_step_output("wf-1", "step-1", output="workflow 1")
@@ -314,6 +398,154 @@ class TestWorkflowDAG:
         """Querying status of a non-existent step returns None."""
         assert dag.get_step_status("wf-dag", "ghost") is None
 
+    def test_publish_workflow_preserves_goal_obligations_and_complete_steps(self, store):
+        steps = [{
+            "id": "research",
+            "capability": "account_research",
+            "task": "Research Acme",
+            "success_criterion": "Evidence is cited",
+            "expected_findings": ["account_evidence"],
+            "covers": ["obligation-1"],
+            "depends_on": [],
+        }]
+        obligations = [{
+            "id": "obligation-1",
+            "description": "Research Acme without inventing evidence",
+            "source_quote": "Research Acme",
+        }]
+
+        store.publish_workflow(
+            "wf-lossless",
+            goal="Research Acme without inventing evidence",
+            obligations=obligations,
+            steps=steps,
+        )
+
+        workflow = store.get_workflow_definition("wf-lossless")
+        assert workflow["goal"] == "Research Acme without inventing evidence"
+        assert workflow["obligations"] == obligations
+        assert workflow["steps"][0] == {**steps[0], "status": "pending"}
+        assert "wf-lossless" in store.get_active_workflows()
+
+    def test_dependency_outputs_are_read_from_the_shared_ledger(self, store):
+        store.publish_workflow(
+            "wf-context",
+            goal="Research then analyse",
+            obligations=[],
+            steps=[
+                {"id": "research", "capability": "research", "task": "Research", "depends_on": []},
+                {"id": "analyse", "capability": "analysis", "task": "Analyse", "depends_on": ["research"]},
+            ],
+        )
+        store.save_step_output("wf-context", "research", output={"evidence": ["source-1"]})
+        store.update_step_status("wf-context", "research", "completed")
+
+        assert store.get_dependency_outputs("wf-context", "analyse") == {
+            "research": {"evidence": ["source-1"]},
+        }
+
+    def test_dependency_interpretations_are_preserved_separately_from_artifacts(self, store):
+        store.publish_workflow(
+            "wf-interpretation",
+            goal="Qualify an account",
+            obligations=[],
+            steps=[
+                {"id": "research", "capability": "research", "task": "Research", "depends_on": []},
+                {"id": "analyse", "capability": "analysis", "task": "Analyse", "depends_on": ["research"]},
+            ],
+        )
+        assert store.claim_step("wf-interpretation", "research", "peer:claim", 30)
+        assert store.finish_claimed_step(
+            "wf-interpretation",
+            "research",
+            "peer:claim",
+            {
+                "status": "success",
+                "output": {"status": "research_incomplete", "account": "Acme"},
+                "interpretation": {
+                    "verdict": "partial",
+                    "meaning": "Fit is plausible but the buyer is unresolved.",
+                    "decision": "hold",
+                    "unmet_requirements": ["Verified buyer"],
+                },
+            },
+        )
+
+        assert store.get_dependency_outputs("wf-interpretation", "analyse") == {
+            "research": {"status": "research_incomplete", "account": "Acme"},
+        }
+        assert store.get_dependency_interpretations("wf-interpretation", "analyse") == {
+            "research": {
+                "verdict": "partial",
+                "meaning": "Fit is plausible but the buyer is unresolved.",
+                "decision": "hold",
+                "unmet_requirements": ["Verified buyer"],
+            },
+        }
+
+    def test_dag_amendment_preserves_completed_steps_and_source_goal(self, store):
+        obligations = [
+            {"id": "o1", "description": "Research", "source_quote": "Research"},
+            {"id": "o2", "description": "Analyse", "source_quote": "analyse"},
+        ]
+        store.publish_workflow(
+            "wf-amend",
+            goal="Research and analyse",
+            obligations=obligations,
+            steps=[
+                {"id": "research", "capability": "research", "task": "Research", "depends_on": [], "covers": ["o1"]},
+                {"id": "analyse", "capability": "analysis", "task": "Analyse", "depends_on": ["research"], "covers": ["o2"]},
+            ],
+        )
+        assert store.claim_step("wf-amend", "research", "researcher:claim", 30)
+        assert store.finish_claimed_step(
+            "wf-amend", "research", "researcher:claim",
+            {"status": "success", "output": {"evidence": ["source-1"]}},
+        )
+
+        store.amend_workflow(
+            "wf-amend",
+            expected_revision=1,
+            obligations=obligations,
+            steps=[
+                {"id": "research", "capability": "research", "task": "Research", "depends_on": [], "covers": ["o1"]},
+                {"id": "analyse_v2", "capability": "analysis", "task": "Analyse using another method", "depends_on": ["research"], "covers": ["o2"]},
+            ],
+            reason="Original analysis path failed",
+        )
+
+        definition = store.get_workflow_definition("wf-amend")
+        assert definition["goal"] == "Research and analyse"
+        assert definition["revision"] == 2
+        assert store.get_step_status("wf-amend", "research") == "completed"
+        assert store.get_step_output("wf-amend", "research")["output"]["output"] == {"evidence": ["source-1"]}
+        assert store.get_step_status("wf-amend", "analyse") is None
+        assert store.get_step_status("wf-amend", "analyse_v2") == "pending"
+        assert store.get_ledger_tail("wf-amend")[-1]["event"] == "dag_amended"
+
+        with pytest.raises(ValueError, match="revision changed"):
+            store.amend_workflow(
+                "wf-amend",
+                expected_revision=1,
+                obligations=obligations,
+                steps=definition["steps"],
+                reason="Stale planner",
+            )
+
+        changed_completed_step = [
+            {**step, "task": "Rewrite completed research"}
+            if step["id"] == "research" else step
+            for step in definition["steps"]
+        ]
+        with pytest.raises(ValueError, match="cannot change completed step"):
+            store.amend_workflow(
+                "wf-amend",
+                expected_revision=2,
+                obligations=obligations,
+                steps=changed_completed_step,
+                reason="Invalid rewrite",
+            )
+
 
 class TestAtomicStepClaiming:
     """
@@ -338,6 +570,297 @@ class TestAtomicStepClaiming:
 
         assert store.claim_step("wf-race", "step-1", "agent-a") is True
         assert store.claim_step("wf-race", "step-1", "agent-b") is False
+
+    def test_only_current_claimant_can_renew_or_commit(self, store):
+        store.init_workflow_graph(
+            "wf-fenced",
+            [{"id": "step-1", "capability": "analysis", "task": "work", "depends_on": []}],
+        )
+        claim_id = "agent-a:claim-a"
+        assert store.claim_step("wf-fenced", "step-1", claim_id, lease_seconds=30)
+        assert store.get_step_definition("wf-fenced", "step-1")["claimed_by"] == "agent-a"
+
+        assert store.renew_step_claim("wf-fenced", "step-1", "agent-b:claim-b", 30) is False
+        assert store.finish_claimed_step(
+            "wf-fenced", "step-1", "agent-b:claim-b", {"status": "success", "output": "stale"}
+        ) is False
+        assert store.get_step_output("wf-fenced", "step-1") is None
+
+        assert store.renew_step_claim("wf-fenced", "step-1", claim_id, 30) is True
+        assert store.get_step_definition("wf-fenced", "step-1")["claimed_by"] == "agent-a"
+        assert store.finish_claimed_step(
+            "wf-fenced", "step-1", claim_id, {"status": "success", "output": "fresh"}
+        ) is True
+        assert store.get_step_status("wf-fenced", "step-1") == "completed"
+        assert store.get_step_output("wf-fenced", "step-1")["output"]["output"] == "fresh"
+
+    def test_expired_claim_is_recovered_for_another_peer(self, store):
+        store.init_workflow_graph(
+            "wf-recover-claim",
+            [{"id": "step-1", "capability": "analysis", "task": "work", "depends_on": []}],
+        )
+        assert store.claim_step("wf-recover-claim", "step-1", "claim-a", lease_seconds=30)
+        store._store._redis.delete("step_lock:wf-recover-claim:step-1")
+
+        assert store.recover_expired_step_claim("wf-recover-claim", "step-1") is True
+        assert store.get_step_status("wf-recover-claim", "step-1") == "pending"
+        assert store.claim_step("wf-recover-claim", "step-1", "claim-b", lease_seconds=30)
+
+    def test_epoch_exhaustion_requeues_same_peer_without_terminal_output(self, store):
+        store.init_workflow_graph(
+            "wf-epoch-rollover",
+            [{"id": "step-1", "capability": "analysis", "task": "work", "depends_on": []}],
+        )
+        claim_id = "agent-a:epoch-1"
+        assert store.claim_step(
+            "wf-epoch-rollover", "step-1", claim_id, lease_seconds=30
+        )
+
+        assert store.continue_claimed_step(
+            "wf-epoch-rollover",
+            "step-1",
+            claim_id,
+            resume_agent_id="agent-a",
+        )
+
+        step = store.get_step_definition("wf-epoch-rollover", "step-1")
+        assert step["status"] == "pending"
+        assert step["resume_agent_id"] == "agent-a"
+        assert step["resume_context"] == {
+            "_resume": True,
+            "_new_execution_epoch": True,
+        }
+        assert step["execution_epochs"] == 2
+        assert store.get_step_output("wf-epoch-rollover", "step-1") is None
+        assert not store.continue_claimed_step(
+            "wf-epoch-rollover",
+            "step-1",
+            claim_id,
+            resume_agent_id="agent-a",
+        )
+
+    def test_partial_semantics_are_preserved_for_recipient_authorization(self, store):
+        store.publish_workflow(
+            "wf-semantic-gate",
+            goal="Verify then act",
+            obligations=[],
+            steps=[
+                {
+                    "id": "verify", "capability": "verification", "effect": "read",
+                    "task": "Verify", "depends_on": [],
+                },
+                {
+                    "id": "write", "capability": "writer", "effect": "write",
+                    "task": "Write", "depends_on": ["verify"],
+                },
+                {
+                    "id": "respond", "capability": "response", "effect": "final_response",
+                    "task": "Respond", "depends_on": ["verify"],
+                },
+            ],
+        )
+        assert store.claim_step("wf-semantic-gate", "verify", "peer:verify", 30)
+        assert store.finish_claimed_step(
+            "wf-semantic-gate",
+            "verify",
+            "peer:verify",
+            {
+                "status": "success",
+                "output": {"verified": False},
+                "interpretation": {
+                    "verdict": "partial",
+                    "decision": "hold",
+                    "meaning": "Verification is incomplete.",
+                    "satisfied_requirements": [],
+                    "unmet_requirements": ["Verified identity"],
+                    "evidence_refs": [],
+                },
+            },
+        )
+
+        verify = store.get_step_definition("wf-semantic-gate", "verify")
+        assert verify["semantic_outcome"] == "partial"
+        assert verify["semantic_decision"] == "hold"
+        assert store.get_dependency_blockers("wf-semantic-gate", "write") == {}
+        assert store.claim_step("wf-semantic-gate", "write", "peer:write", 30) is True
+        assert store.get_dependency_blockers("wf-semantic-gate", "respond") == {}
+        assert store.claim_step("wf-semantic-gate", "respond", "peer:respond", 30) is True
+
+    def test_recipient_terminal_block_is_not_requeued(self, store):
+        store.publish_workflow(
+            "wf-recipient-block",
+            goal="Do safe work",
+            obligations=[],
+            steps=[{
+                "id": "write", "capability": "writer", "effect": "write",
+                "task": "Write safely", "depends_on": [],
+            }],
+        )
+        assert store.claim_step(
+            "wf-recipient-block", "write", "peer:write", 30
+        )
+        assert store.finish_claimed_step(
+            "wf-recipient-block",
+            "write",
+            "peer:write",
+            {"status": "blocked", "error": "Relevant evidence is missing"},
+        )
+
+        assert store.requeue_blocked_step(
+            "wf-recipient-block", "write"
+        ) is False
+        assert store.get_step_status("wf-recipient-block", "write") == "blocked"
+
+    def test_cancelled_workflow_cannot_be_claimed_renewed_committed_or_recovered(self, store):
+        store.publish_workflow(
+            "wf-cancelled",
+            goal="Do work",
+            obligations=[],
+            steps=[
+                {"id": "active", "capability": "work", "effect": "write", "task": "Work", "depends_on": []},
+                {"id": "later", "capability": "work", "effect": "write", "task": "Later", "depends_on": ["active"]},
+            ],
+        )
+        assert store.claim_step("wf-cancelled", "active", "peer:claim", 30)
+
+        assert store.cancel_workflow("wf-cancelled", reason="User cancelled") is True
+        assert store.is_workflow_cancelled("wf-cancelled") is True
+        assert "wf-cancelled" not in store.get_active_workflows()
+        assert store.get_step_status("wf-cancelled", "active") == "cancelled"
+        assert store.get_step_status("wf-cancelled", "later") == "cancelled"
+        assert store.renew_step_claim("wf-cancelled", "active", "peer:claim", 30) is False
+        assert store.finish_claimed_step(
+            "wf-cancelled", "active", "peer:claim", {"status": "success"}
+        ) is False
+        assert store.recover_expired_step_claim("wf-cancelled", "active") is False
+        assert store.claim_step("wf-cancelled", "later", "peer:new", 30) is False
+        assert store.get_ledger_tail("wf-cancelled")[-1]["event"] == "workflow_cancelled"
+
+
+# ======================================================================
+# Capability Needs (Adaptive Peer Collaboration)
+# ======================================================================
+
+class TestCapabilityNeeds:
+
+    def test_need_is_claimed_once_by_matching_capability_and_fulfilled(self, store):
+        need_id = store.publish_capability_need(
+            "wf-needs",
+            requester_agent_id="calendar-1",
+            requester_step_id="schedule",
+            capability="contact_verification",
+            question="Resolve the lead contact path.",
+            context={"objective": "Prepare the meeting"},
+        )
+
+        assert store.claim_capability_need(
+            "wf-needs", need_id, "pipeline-1:claim", {"contact_verification"}, 30
+        )
+        assert not store.claim_capability_need(
+            "wf-needs", need_id, "other:claim", {"contact_verification"}, 30
+        )
+        assert store.fulfill_capability_need(
+            "wf-needs", need_id, "pipeline-1:claim",
+            {"status": "success", "output": {"email": "ephy@example.com"}},
+        )
+
+        need = store.get_capability_need("wf-needs", need_id)
+        assert need["status"] == "fulfilled"
+        assert need["fulfilled_by"] == "pipeline-1"
+        assert need["result"]["output"]["email"] == "ephy@example.com"
+
+    def test_expired_need_claim_can_be_recovered(self, store):
+        need_id = store.publish_capability_need(
+            "wf-needs-recover",
+            requester_agent_id="requester",
+            requester_step_id="step",
+            capability="research",
+            question="Find evidence.",
+        )
+        assert store.claim_capability_need(
+            "wf-needs-recover", need_id, "peer-a:claim", {"research"}, 30
+        )
+        store._store._redis.delete(
+            f"capability_need_lock:wf-needs-recover:{need_id}"
+        )
+
+        assert store.recover_expired_capability_need(
+            "wf-needs-recover", need_id
+        )
+        assert store.claim_capability_need(
+            "wf-needs-recover", need_id, "peer-b:claim", {"research"}, 30
+        )
+
+    def test_active_need_claim_can_be_renewed_with_fencing(self, store):
+        need_id = store.publish_capability_need(
+            "wf-needs-renew",
+            requester_agent_id="requester",
+            requester_step_id="step",
+            capability="research",
+            question="Find evidence.",
+        )
+        assert store.claim_capability_need(
+            "wf-needs-renew", need_id, "peer-a:claim", {"research"}, 30
+        )
+        before = store.get_capability_need("wf-needs-renew", need_id)
+
+        assert store.renew_capability_need_claim(
+            "wf-needs-renew", need_id, "peer-a:claim", 60
+        )
+        after = store.get_capability_need("wf-needs-renew", need_id)
+        assert after["claim_expires_at"] > before["claim_expires_at"]
+        assert not store.renew_capability_need_claim(
+            "wf-needs-renew", need_id, "peer-b:stale", 60
+        )
+
+        store.cancel_workflow("wf-needs-renew", reason="cancelled")
+        assert not store.renew_capability_need_claim(
+            "wf-needs-renew", need_id, "peer-a:claim", 60
+        )
+
+    def test_failed_peer_result_is_a_failed_mandate(self, store):
+        need_id = store.publish_capability_need(
+            "wf-needs-failed",
+            requester_agent_id="requester",
+            requester_step_id="step",
+            capability="research",
+            question="Find evidence.",
+        )
+        assert store.claim_capability_need(
+            "wf-needs-failed", need_id, "peer-a:claim", {"research"}, 30
+        )
+
+        assert store.fulfill_capability_need(
+            "wf-needs-failed",
+            need_id,
+            "peer-a:claim",
+            {"status": "failure", "error": "Provider unavailable"},
+        )
+        need = store.get_capability_need("wf-needs-failed", need_id)
+        assert need["status"] == "failed"
+        assert need["error"] == "Provider unavailable"
+
+    def test_requester_can_fail_and_unclaim_a_timed_out_mandate(self, store):
+        need_id = store.publish_capability_need(
+            "wf-needs-timeout",
+            requester_agent_id="requester",
+            requester_step_id="step",
+            capability="research",
+            question="Find evidence.",
+        )
+        assert store.claim_capability_need(
+            "wf-needs-timeout", need_id, "peer-a:claim", {"research"}, 30
+        )
+
+        assert store.fail_capability_need(
+            "wf-needs-timeout", need_id, "requester", "Timed out"
+        )
+        need = store.get_capability_need("wf-needs-timeout", need_id)
+        assert need["status"] == "failed"
+        assert need["error"] == "Timed out"
+        assert not store.fulfill_capability_need(
+            "wf-needs-timeout", need_id, "peer-a:claim", {"status": "success"}
+        )
 
 
 # ======================================================================

--- a/tests/test_redis_store.py
+++ b/tests/test_redis_store.py
@@ -346,6 +346,20 @@ class TestMailbox:
 # ======================================================================
 
 class TestWorkflowDAG:
+
+    def test_existing_goal_binding_ignores_mapping_insertion_order(self, store):
+        first_context = {"workflow_id": "thread", "run_id": "run-1"}
+        reordered_context = {"run_id": "run-1", "workflow_id": "thread"}
+
+        assert store.register_workflow_goal(
+            "wf-existing", "Do the work", first_context,
+        )
+        assert not store.register_workflow_goal(
+            "wf-existing", "Do the work", reordered_context,
+        )
+        assert [
+            event["event"] for event in store.get_ledger_full("wf-existing")
+        ].count("goal_registered") == 1
     """
     In v0.3.2: workflow engine executes steps sequentially with
     in-memory dependency polling.
@@ -424,7 +438,9 @@ class TestWorkflowDAG:
         workflow = store.get_workflow_definition("wf-lossless")
         assert workflow["goal"] == "Research Acme without inventing evidence"
         assert workflow["obligations"] == obligations
-        assert workflow["steps"][0] == {**steps[0], "status": "pending"}
+        assert workflow["steps"][0] == {
+            **steps[0], "status": "pending", "plan_revision": 1,
+        }
         assert "wf-lossless" in store.get_active_workflows()
 
     def test_dependency_outputs_are_read_from_the_shared_ledger(self, store):
@@ -502,24 +518,31 @@ class TestWorkflowDAG:
             "wf-amend", "research", "researcher:claim",
             {"status": "success", "output": {"evidence": ["source-1"]}},
         )
+        completed = store.get_step_definition("wf-amend", "research")
+        assert completed["completed_by"] == "researcher"
 
         store.amend_workflow(
             "wf-amend",
             expected_revision=1,
             obligations=obligations,
-            steps=[
-                {"id": "research", "capability": "research", "task": "Research", "depends_on": [], "covers": ["o1"]},
-                {"id": "analyse_v2", "capability": "analysis", "task": "Analyse using another method", "depends_on": ["research"], "covers": ["o2"]},
-            ],
+            steps=[{
+                "id": "analyse_v2", "capability": "analysis",
+                "task": "Analyse using another method",
+                "depends_on": ["research"], "covers": ["o2"],
+            }],
             reason="Original analysis path failed",
         )
 
         definition = store.get_workflow_definition("wf-amend")
         assert definition["goal"] == "Research and analyse"
         assert definition["revision"] == 2
+        assert [step["id"] for step in definition["steps"]] == [
+            "research", "analyse", "analyse_v2",
+        ]
         assert store.get_step_status("wf-amend", "research") == "completed"
         assert store.get_step_output("wf-amend", "research")["output"]["output"] == {"evidence": ["source-1"]}
-        assert store.get_step_status("wf-amend", "analyse") is None
+        assert store.get_step_status("wf-amend", "analyse") == "superseded"
+        assert store.claim_step("wf-amend", "analyse", "stale:claim", 30) is False
         assert store.get_step_status("wf-amend", "analyse_v2") == "pending"
         assert store.get_ledger_tail("wf-amend")[-1]["event"] == "dag_amended"
 
@@ -528,22 +551,137 @@ class TestWorkflowDAG:
                 "wf-amend",
                 expected_revision=1,
                 obligations=obligations,
-                steps=definition["steps"],
+                steps=[{
+                    "id": "late", "capability": "analysis", "task": "Late",
+                    "depends_on": ["research"], "covers": ["o2"],
+                }],
                 reason="Stale planner",
             )
 
-        changed_completed_step = [
-            {**step, "task": "Rewrite completed research"}
-            if step["id"] == "research" else step
-            for step in definition["steps"]
-        ]
-        with pytest.raises(ValueError, match="cannot change completed step"):
+        with pytest.raises(ValueError, match="already exists"):
             store.amend_workflow(
                 "wf-amend",
                 expected_revision=2,
                 obligations=obligations,
-                steps=changed_completed_step,
+                steps=[{
+                    "id": "research", "capability": "research",
+                    "task": "Rewrite completed research", "depends_on": [],
+                    "covers": ["o1"],
+                }],
                 reason="Invalid rewrite",
+            )
+
+        assert store.claim_step("wf-amend", "analyse_v2", "analyst:claim", 30)
+        assert store.finish_claimed_step(
+            "wf-amend", "analyse_v2", "analyst:claim",
+            {"status": "success", "output": {"analysis": "complete"}},
+        )
+        terminal_definition = store.get_workflow_definition("wf-amend")
+        with pytest.raises(ValueError, match="at least one new step"):
+            store.amend_workflow(
+                "wf-amend",
+                expected_revision=2,
+                obligations=obligations,
+                steps=[],
+                reason="No new work",
+            )
+
+    def test_reconciliation_lease_and_settlement_are_revision_scoped(self, store):
+        assert store.claim_workflow_reconciliation("wf-r", 1, "node-a", 30)
+        assert not store.claim_workflow_reconciliation("wf-r", 1, "node-b", 30)
+        assert not store.release_workflow_reconciliation("wf-r", 1, "node-b")
+        assert store.release_workflow_reconciliation("wf-r", 1, "node-a")
+        assert store.claim_workflow_reconciliation("wf-r", 2, "node-b", 30)
+
+        settlement = {
+            "event": "semantic_reconciliation_settled",
+            "obligation_status": "blocked",
+            "reason": "No available capability can obtain the missing fact.",
+        }
+        assert store.save_workflow_reconciliation_settlement("wf-r", 1, settlement)
+        assert not store.save_workflow_reconciliation_settlement("wf-r", 1, settlement)
+        assert store.get_workflow_reconciliation_settlement("wf-r", 1) == {
+            **settlement, "revision": 1,
+        }
+        events = [
+            event for event in store.get_ledger_full("wf-r")
+            if event.get("event") == "semantic_reconciliation_settled"
+        ]
+        assert len(events) == 1
+
+    def test_obligation_projection_tracks_current_revision_and_supersession(self, store):
+        obligations = [{
+            "id": "o1", "description": "Verify stage", "source_quote": "Verify stage",
+        }]
+        first = {
+            "id": "verify_first", "capability": "verification", "effect": "read",
+            "task": "Verify stage", "depends_on": [], "covers": ["o1"],
+        }
+        store.publish_workflow(
+            "wf-projection", goal="Verify stage", obligations=obligations, steps=[first],
+        )
+        assert store.get_obligation_projection("wf-projection")["o1"]["state"] == "pending"
+        assert store.claim_step("wf-projection", "verify_first", "peer:first", 30)
+        assert store.finish_claimed_step(
+            "wf-projection", "verify_first", "peer:first", {
+                "status": "success", "output": {"stage": None},
+                "interpretation": {
+                    "verdict": "unsatisfied", "decision": "reject",
+                    "satisfied_requirements": [], "unmet_requirements": ["o1"],
+                },
+            },
+        )
+        assert store.get_obligation_projection("wf-projection")["o1"]["state"] == "unresolved"
+
+        store.amend_workflow(
+            "wf-projection", expected_revision=1, obligations=obligations,
+            steps=[{
+                "id": "verify_retry", "capability": "verification", "effect": "read",
+                "task": "Verify stage from fresh evidence", "depends_on": ["verify_first"],
+                "covers": ["o1"],
+            }],
+            reason="Fresh evidence is available",
+        )
+        pending = store.get_obligation_projection("wf-projection")["o1"]
+        assert pending["state"] == "pending"
+        assert pending["current_step_ids"] == ["verify_retry"]
+        assert pending["superseded_step_ids"] == ["verify_first"]
+
+        assert store.claim_step("wf-projection", "verify_retry", "peer:retry", 30)
+        assert store.finish_claimed_step(
+            "wf-projection", "verify_retry", "peer:retry", {
+                "status": "success", "output": {"stage": "appointmentscheduled"},
+                "interpretation": {
+                    "verdict": "satisfied", "decision": "proceed",
+                    "satisfied_requirements": ["o1"], "unmet_requirements": [],
+                },
+            },
+        )
+        current = store.get_obligation_projection("wf-projection")["o1"]
+        assert current["state"] == "satisfied"
+        assert current["revision"] == 2
+        assert current["attempt_states"] == {"verify_retry": "satisfied"}
+
+    def test_cancelled_workflow_rejects_an_inflight_amendment(self, store):
+        obligations = [{"id": "o1", "description": "Work", "source_quote": "Work"}]
+        steps = [{
+            "id": "work", "capability": "research", "task": "Work",
+            "depends_on": [], "covers": ["o1"],
+        }]
+        store.publish_workflow(
+            "wf-cancel-amend", goal="Work", obligations=obligations, steps=steps,
+        )
+        assert store.cancel_workflow("wf-cancel-amend", reason="User cancelled")
+
+        with pytest.raises(ValueError, match="cancelled workflow"):
+            store.amend_workflow(
+                "wf-cancel-amend", expected_revision=1,
+                obligations=obligations,
+                steps=[*steps, {
+                    "id": "retry", "capability": "research", "task": "Retry",
+                    "depends_on": [], "covers": ["o1"],
+                }],
+                reason="Late planner response",
             )
 
 


### PR DESCRIPTION
## Summary

- add no-master, capability-addressed Mesh planning and independent peer claims
- add canonical durable workflow, evidence, mandate, and obligation envelopes
- separate immutable execution attempts from current source-obligation truth
- add append-only revision deltas with selective supersession and reconciliation leases
- expose independent execution, obligation, and final-response status
- add bounded execution epochs, cumulative workflow budgets, typed HITL, cancellation fencing, and pre-effect review
- add provider-native Google Docs readback plus the Drive, Calendar, HubSpot, Gmail, and Slack primitives used by the live GTM proof
- prepare the backward-compatible `1.11.0` SemVer minor release

## Architecture

There is no master agent router. Planning publishes capability-addressed work, peers claim ready steps independently, and Redis arbitrates leases and effects.

Attempts remain immutable. A durable obligation projection identifies the authoritative current attempt for each source obligation. Reconciliation appends only new work for unresolved obligation IDs; satisfied obligations and completed effects are preserved. Historical final responses cannot override the current revision response.

The framework remains domain-neutral: GTM defines what its typed evidence means, while JarvisCore reduces obligation IDs, ownership, revisions, and terminal state.

## Live acceptance

Exact Desk-visible Ephy/Acme Tier-1 workflow: `e5c9182612d34535851834da00a9b452`.

- initial obligation audit published 10 independently verifiable obligations and removed the redundant playbook umbrella
- revision 2 contained only one direct HubSpot read for the unresolved stage obligation plus a fresh final response
- nine satisfied obligations remained satisfied across revision publication
- HubSpot stage resolved to `appointmentscheduled`
- pitch deck verification, conflict-free Calendar scheduling, Gmail draft creation, and Slack notification completed
- final durable framework state: execution `completed`, obligations `10/10 satisfied`, response `completed`
- persisted result projects successfully through the companion GTM/Desk adapter with valid email and document artifacts

## Validation

- affected framework gates: `133 passed`
- Mesh/planner/storage regression gate after final response projection fix: `115 passed`
- full framework baseline: `2099 passed, 42 skipped, 1 xfailed`; 10 unrelated environment-sensitive failures were confined to profile-path and no-op Prometheus tests
- package build: wheel and sdist built successfully as `1.11.0`
- companion GTM: `114 passed`
- companion Desk: `100 passed`
- companion frontend: lint and build passed on Node `20.20.2`; Playwright `46 passed`

## Release

SemVer: `1.11.0` (minor). This adds public Mesh workflow and reconciliation behavior without a breaking API change.

After merge and green CI, create tag `v1.11.0` and run the existing publish workflow according to `.github/PUBLISHING.md`.

## Companion PR

- Prescott-Data/jarviscore-agents#1
